### PR TITLE
Bugfix/ls thing service breaks for bad codename

### DIFF
--- a/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
+++ b/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
@@ -220,7 +220,7 @@ exports.runRApacheFunctionTest = (request, response)  ->
 exports.getFromACASServer = (baseurl, resp) ->
 	exports.getFromACASServerInternal baseurl, (statusCode, json) ->
 		resp.statusCode = statusCode
-		resp.end json
+		resp.end JSON.stringify json
 
 exports.getFromACASServerInternal = (baseurl, callback) ->
 	request = require 'request'


### PR DESCRIPTION
Fixed an issue in ServerUtilityFunctions getFromACASServer where the json payload was being returned by the response object without being cast to string first.  