### PR TITLE
Fix getFromACASServerInternal to return a JSON object, and getFromACA…

### DIFF
--- a/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
+++ b/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
@@ -220,7 +220,7 @@ exports.runRApacheFunctionTest = (request, response)  ->
 exports.getFromACASServer = (baseurl, resp) ->
 	exports.getFromACASServerInternal baseurl, (statusCode, json) ->
 		resp.statusCode = statusCode
-		resp.end JSON.stringify json
+		resp.json json
 
 exports.getFromACASServerInternal = (baseurl, callback) ->
 	request = require 'request'
@@ -230,7 +230,7 @@ exports.getFromACASServerInternal = (baseurl, callback) ->
 		json: true
 	, (error, response, json) =>
 		if !error && response.statusCode == 200
-			callback response.statusCode, JSON.stringify json
+			callback response.statusCode, json
 		else
 			console.log 'got ajax error'
 			console.log error


### PR DESCRIPTION
…SServer to return properly formatted JSON, rather than a string resulting from JSON.stringifying twice.