### PR TITLE
fix gulp execute tasks to not kill watch if they error

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -328,6 +328,8 @@ createExecuteTask = (options) =>
     watchOptions = watch?.options ? {}
     gulp.task watchTaskName, ->
       gulp.watch options.src, watchOptions, gulp.series(taskName)
+        .on('error', console.error)
+
       return
     watchTasks.push watchTaskName
   return taskName


### PR DESCRIPTION
currently gulp watch will die if any of the execute scripts throw an error, this fix pipes the error to console.error and continues the process