### PR TITLE
Add value kind length check as value kinds are limited to 64 characters

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -797,6 +797,12 @@ validateValueKinds <- function(neededValueKinds, neededValueKindTypes, dryRun, r
   require(rjson)
   require(RCurl)
   
+  # Throw errors for value kinds greater than 64 characters
+  valueKindsTooLong <- unique(neededValueKinds)[which(nchar(unique(neededValueKinds)) > 64)]
+  if(length(valueKindsTooLong) > 0) {
+    stopUser(paste0("The value kind(s) are too long: ",sqliz(valueKindsTooLong), ". Value kinds must be 64 characters or less. <br>* Note: Values are typically grouped by assay so the value kind should just be a descriptor of the value (i.e. EC50, Comment, Max).  Units are recorded seperately so are not included in the character limit."))
+  }
+
   # Throw errors for words used with special meanings by the loader
   usedReservedWords <- reserved %in% neededValueKinds
   if (any(usedReservedWords)) {


### PR DESCRIPTION
This fix is for SEL to check the length of the column header to make sure it will fit in the analysis_group_value.ls_kind column