### PR TITLE
Added uniqueness validation to ACASFormStateTable

### DIFF
--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -164,6 +164,7 @@ class window.ACASFormStateTableController extends Backbone.View
 			minSpareRows: 1,
 			allowInsertRow: true
 			contextMenu: true
+			comments: true
 			startRows: 1,
 			className: "htCenter",
 			colHeaders: _.pluck @colHeaders, 'displayName'

--- a/modules/ServerAPI/src/client/ExampleThing.coffee
+++ b/modules/ServerAPI/src/client/ExampleThing.coffee
@@ -13,6 +13,20 @@ ExampleThingConf =
 				formLabel: "*Name"
 				placeholder: "name"
 				fieldWrapper: "bv_thingName"
+		,
+			key: 'alias_'
+			multiple: true
+			modelDefaults:
+				type: 'name'
+				kind: 'alias'
+				preferred: false
+			fieldSettings:
+				fieldType: 'label'
+				required: false
+				inputClass: ""
+				formLabel: "Alias"
+				placeholder: "alias"
+				fieldWrapper: "bv_aliasWrapper"
 		]
 		values: [
 			key: 'scientist'
@@ -91,6 +105,7 @@ ExampleThingConf =
 					fieldType: 'stringValue'
 					formLabel: "Media Component"
 					required: true
+					unique: true
 					width: 215
 			,
 				modelDefaults:
@@ -102,6 +117,7 @@ ExampleThingConf =
 				fieldSettings:
 					fieldType: 'numericValue'
 					formLabel: "Volume"
+					format: "0.00"
 					required: false
 			,
 				modelDefaults:

--- a/modules/ServerAPI/src/client/ExampleThing.html
+++ b/modules/ServerAPI/src/client/ExampleThing.html
@@ -9,6 +9,7 @@
             </div>
         </div>
         <div class="bv_thingName"></div>
+        <div class="bv_aliasWrapper"></div>
         <div class="bv_componentPicker"></div>
         <div class="bv_scientist_date"></div>
         <div class="bv_notebook"></div>


### PR DESCRIPTION
Added uniqueness validation to ACASFormStateTable for columns with fieldSettings.unique: true following example from https://github.com/handsontable/handsontable/issues/3102 . Also passed through fieldSettings.format to control numeric formatting.