### PR TITLE
Uncommented options for disabling/enabling comments option as part of…

### DIFF
--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -371,21 +371,21 @@ class window.ACASFormStateTableController extends Backbone.View
 		@hot.updateSettings
 			readOnly: true
 			contextMenu: false
+			comments: false
 #Other options I decided not to use
 #			disableVisualSelection: true
 #			manualColumnResize: false
 #			manualRowResize: false
-#			comments: false
 
 	enableInput: ->
 		@hot.updateSettings
 			readOnly: false
 			contextMenu: true
+			comments: true
 #Other options I decided not to use
 #			disableVisualSelection: false
 #			manualColumnResize: true
 #			manualRowResize: true
-#			comments: true
 
 	validateUniqueness: (changes, source) =>
 		uniqueColumnIndices = @tableDef.values.map (value, idx) ->


### PR DESCRIPTION
… State Table disableInput / enableInput. Fixes console error relating to comments when state table is in readOnly mode.