### PR TITLE
Added in optional ?withContainers parameter for getContainerLocationT…

### DIFF
--- a/modules/ServerAPI/src/server/routes/InventoryServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/InventoryServiceRoutes.coffee
@@ -3510,16 +3510,18 @@ exports.getParentVialByDaughterVialBarcodeInternal = (daughterVialBarcode, callb
 				callback null, responseStub
 
 exports.getContainerLocationTree = (req, resp) ->
-	exports.getContainerLocationTreeInternal (err, response) ->
+	exports.getContainerLocationTreeInternal req.query.withContainers, (err, response) ->
 		if err?
 			resp.statusCode = 500
 			resp.json err
 		else
 			resp.json response
 
-exports.getContainerLocationTreeInternal = (callback) ->
+exports.getContainerLocationTreeInternal = (withContainers, callback) ->
 	rootLabel = config.all.client.compoundInventory.rootLocationLabel
 	baseurl = config.all.client.service.persistence.fullpath+"containers/getLocationTreeByRootLabel?rootLabel=#{rootLabel}"
+	if withContainers?
+		baseurl+= "&withContainers=#{withContainers}"
 	request(
 		method: 'GET'
 		url: baseurl


### PR DESCRIPTION
…ree that will include non-location containers in the tree. Without the paremeter, or with the parameter set to false, it the tree will only have locations, and not any containers in those locations.