### PR TITLE
Changed PreferredEntityCodeService.getSpecificEntityType to be more f…

### DIFF
--- a/modules/ServerAPI/src/server/routes/PreferredEntityCodeService.coffee
+++ b/modules/ServerAPI/src/server/routes/PreferredEntityCodeService.coffee
@@ -49,6 +49,8 @@ exports.getSpecificEntityTypeRoute = (req, resp) ->
 
 exports.getSpecificEntityType = (displayName, callback) ->
 	entityType = _.findWhere configuredEntityTypes.entityTypes, {displayName:displayName}
+	if !entityType?
+		entityType = _.findWhere configuredEntityTypes.entityTypes, {code:displayName}
 	entityType ?= {}
 	if callback?
 		callback entityType


### PR DESCRIPTION
…orgiving and lookup by code if the lookup by displayName fails.

Fixed reporting of invalid entityType to list available configured entityTypes. Fixes #350
Switched getPreferredId2 call to use displayName instead of code. Added function to dealias entity displayName or code into code. Switched entity type not matching that required by the protocol to be an error, not a warning. Fixed reporting of entity ype mismatch to use displayNames, not codes. Fixes #368