### PR TITLE
bugfix/prot-and-expt-browsers-view-deleted-entities: Protocol and exp…

### DIFF
--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -332,8 +332,8 @@ class window.ExperimentSummaryTableController extends Backbone.View
 					rolesToTest.push role
 			if rolesToTest.length is 0
 				return false
-			unless UtilityFunctions::testUserHasRole window.AppLaunchParams.loginUser, rolesToTest
-				return false
+			if UtilityFunctions::testUserHasRole window.AppLaunchParams.loginUser, rolesToTest
+				return true
 		return false
 
 class window.ExperimentBrowserController extends Backbone.View

--- a/modules/ProtocolBrowser/src/client/ProtocolBrowser.coffee
+++ b/modules/ProtocolBrowser/src/client/ProtocolBrowser.coffee
@@ -164,8 +164,8 @@ class window.ProtocolSummaryTableController extends Backbone.View
 					rolesToTest.push role
 			if rolesToTest.length is 0
 				return false
-			unless UtilityFunctions::testUserHasRole window.AppLaunchParams.loginUser, rolesToTest
-				return false
+			if UtilityFunctions::testUserHasRole window.AppLaunchParams.loginUser, rolesToTest
+				return true
 		return false
 
 class window.ProtocolBrowserController extends Backbone.View


### PR DESCRIPTION
…eriment browsers should allow user to view deleted entities if user has role specified in config client.entity.viewDeletedRoles, Fixes issue #372