### PR TITLE
Fixes #397: SEL errors when checking protocol required entity type fo…

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3101,7 +3101,12 @@ getPreviousExperimentCodes <- function(experiment) {
   return(previousExperimentCodes)
 }
 getProtocolRequiredEntityCode <- function(protocol) {
-  metadataState <- getStatesByTypeAndKind(protocol, "metadata_protocol metadata")[[1]]
+  metadataState <- getStatesByTypeAndKind(protocol, "metadata_protocol metadata")
+  if(length(metadataState) > 0) {
+    metadataState <- metadataState[[1]]
+  } else {
+    return(NA)
+  }
   requiredEntities <- getValuesByTypeAndKind(metadataState, "codeValue_required entity type")
   requiredEntityCodes <- lapply(requiredEntities, getElement, "codeValue")
   return(requiredEntityCodes)


### PR DESCRIPTION
…r older protocols that are missing a state

Older protocols don't have a metadata_protocol metadata state and SEL breaks when this happens