### PR TITLE
fixes #407: Add mechanism for having a configured entity type that is…

### DIFF
--- a/conf/ConfiguredEntityTypes.coffee
+++ b/conf/ConfiguredEntityTypes.coffee
@@ -6,6 +6,7 @@ exports.entityTypes = [
     displayName: 'Corporate Parent ID'
     sourceExternal: true
     parent: true
+    isTestedEntity: false
   ,
     code: 'Corporate Batch ID'
     type: 'compound'
@@ -14,6 +15,7 @@ exports.entityTypes = [
     displayName: 'Corporate Batch ID'
     sourceExternal: true
     parent: false
+    isTestedEntity: true
   ,
     code: 'Protein Parent'
     type: 'parent'
@@ -22,6 +24,7 @@ exports.entityTypes = [
     displayName: 'Protein Parent'
     sourceExternal: false
     parent: true
+    isTestedEntity: false
   ,
     code: 'Protein Batch'
     type: 'batch'
@@ -30,6 +33,7 @@ exports.entityTypes = [
     displayName: 'Protein Batch'
     sourceExternal: false
     parent: false
+    isTestedEntity: false
   ,
     code: 'Gene ID'
     type: 'gene'
@@ -38,6 +42,7 @@ exports.entityTypes = [
     displayName: 'Gene ID'
     sourceExternal: false
     parent: false
+    isTestedEntity: false
   ,
     code: 'Container Plate'
     type: 'container'
@@ -47,6 +52,7 @@ exports.entityTypes = [
     sourceExternal: false
     parent: false
     model: require("../routes/ServerUtilityFunctions.js").ContainerPlate
+    isTestedEntity: false
   ,
     code: 'Container Tube'
     type: 'container'
@@ -56,6 +62,7 @@ exports.entityTypes = [
     sourceExternal: false
     parent: false
     model: require("../routes/ServerUtilityFunctions.js").ContainerTube
+    isTestedEntity: false
   ,
     code: 'Definition Container Plate'
     type: 'definition container'
@@ -65,6 +72,7 @@ exports.entityTypes = [
     sourceExternal: false
     parent: false
     model: require("../routes/ServerUtilityFunctions.js").DefinitionContainerPlate
+    isTestedEntity: false
   ,
     code: 'Definition Container Tube'
     type: 'definition container'
@@ -74,6 +82,7 @@ exports.entityTypes = [
     sourceExternal: false
     parent: false
     model: require("../routes/ServerUtilityFunctions.js").DefinitionContainerTube
+    isTestedEntity: false
   ,
     code: 'Solution Container Tube'
     type: 'container'
@@ -82,6 +91,7 @@ exports.entityTypes = [
     displayName: 'Solution Aliquot'
     sourceExternal: false
     parent: false
+    isTestedEntity: false
   ,
     code: 'Location Container'
     type: 'location'
@@ -91,4 +101,5 @@ exports.entityTypes = [
     sourceExternal: false
     parent: false
     model: require("../routes/ServerUtilityFunctions.js").LocationContainer
+    isTestedEntity: false
 ]

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -471,7 +471,7 @@ validateCalculatedResults <- function(calculatedResults, dryRun, curveNames, tes
   
   require(data.table)
   entityTypeAndKindList <- fromJSON(getURLcheckStatus(paste0(racas::applicationSettings$server.nodeapi.path, 
-                                                             "/api/entitymeta/configuredEntityTypes/"), 
+                                                             "/api/entitymeta/configuredTestedEntityTypes/"), 
                                                              requireJSON = TRUE))
   # Expected column names: 'type', 'kind', 'codeOrigin', 'displayName', 'sourceExternal'
   entityTypeAndKindTable <- as.data.table(do.call(rbind, entityTypeAndKindList))

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -335,7 +335,7 @@ class window.ProtocolBaseController extends BaseEntityController
 		else
 			@$('.bv_requiredEntityTypeLabel').html 'Required Entity Type'
 		@requiredEntityTypeList = new PickListList()
-		@requiredEntityTypeList.url = "/api/entitymeta/configuredEntityTypes/displayName?asCodes=true"
+		@requiredEntityTypeList.url = "/api/entitymeta/configuredTestedEntityTypes/displayName?asCodes=true"
 		@requiredEntityTypeListController = new PickListSelectController
 			el: @$('.bv_requiredEntityType')
 			collection: @requiredEntityTypeList

--- a/modules/ServerAPI/src/server/routes/PreferredEntityCodeService.coffee
+++ b/modules/ServerAPI/src/server/routes/PreferredEntityCodeService.coffee
@@ -1,6 +1,8 @@
 exports.setupAPIRoutes = (app) ->
 	app.get '/api/entitymeta/configuredEntityTypes/:asCodes?', exports.getConfiguredEntityTypesRoute
 	app.get '/api/entitymeta/configuredEntityTypes/displayName/:displayName', exports.getSpecificEntityTypeRoute
+	app.get '/api/entitymeta/configuredTestedEntityTypes/:asCodes?', exports.getConfiguredTestedEntityTypesRoute
+	app.get '/api/entitymeta/configuredTestedEntityTypes/displayName/:displayName', exports.getSpecificTestedEntityTypeRoute
 	app.post '/api/entitymeta/referenceCodes/:csv?', exports.referenceCodesRoute
 	app.post '/api/entitymeta/pickBestLabels/:csv?', exports.pickBestLabelsRoute
 	app.post '/api/entitymeta/searchForEntities', exports.searchForEntitiesRoute
@@ -9,6 +11,8 @@ exports.setupAPIRoutes = (app) ->
 exports.setupRoutes = (app, loginRoutes) ->
 	app.get '/api/entitymeta/configuredEntityTypes/:asCodes?', loginRoutes.ensureAuthenticated, exports.getConfiguredEntityTypesRoute
 	app.get '/api/entitymeta/ConfiguredEntityTypes/displayName/:displayName', loginRoutes.ensureAuthenticated, exports.getSpecificEntityTypeRoute
+	app.get '/api/entitymeta/configuredTestedEntityTypes/:asCodes?', loginRoutes.ensureAuthenticated, exports.getConfiguredTestedEntityTypesRoute
+	app.get '/api/entitymeta/configuredTestedEntityTypes/displayName/:displayName', loginRoutes.ensureAuthenticated, exports.getSpecificTestedEntityTypeRoute
 	app.post '/api/entitymeta/referenceCodes/:csv?', loginRoutes.ensureAuthenticated, exports.referenceCodesRoute
 	app.post '/api/entitymeta/pickBestLabels/:csv?', loginRoutes.ensureAuthenticated, exports.pickBestLabelsRoute
 	app.post '/api/entitymeta/searchForEntities', loginRoutes.ensureAuthenticated ,exports.searchForEntitiesRoute
@@ -56,6 +60,38 @@ exports.getSpecificEntityType = (codeNameOrDisplayName, callback) ->
 		callback entityType
 	else
 		return entityType
+
+exports.getConfiguredTestedEntityTypesRoute = (req, resp) ->
+	if req.params.asCodes?
+		asCodes = true
+	else
+		asCodes = false
+	testedEntityTypes = exports.getConfiguredTestedEntityTypes asCodes
+	resp.json testedEntityTypes
+
+exports.getConfiguredTestedEntityTypes = (asCodes) ->
+	testedEntityTypes = _.where configuredEntityTypes.entityTypes, {isTestedEntity: true}
+	if asCodes
+		codes = for type in testedEntityTypes
+			code: type.code
+			name: type.displayName
+			ignored: false
+		return codes
+	else
+		return testedEntityTypes
+
+exports.getSpecificLoableEntityTypeRoute = (req, resp) ->
+	displayName = req.params.displayName
+	specificTestedEntityType = exports.getSpecificTestedEntityType displayName
+	resp.json specificTestedEntityType
+
+exports.getSpecificTestedEntityType = (codeNameOrDisplayName) ->
+	testedEntityTypes = exports.getConfiguredTestedEntityTypes asCodes = false
+	entityType = _.findWhere testedEntityTypes, {displayName:codeNameOrDisplayName}
+	if !entityType?
+		entityType = _.findWhere testedEntityTypes, {code:codeNameOrDisplayName}
+	entityType ?= {}
+	return entityType
 
 exports.getSpecificEntityTypeByTypeKindAndCodeOrigin = (type, kind, codeOrigin) ->
 	entityType = _.findWhere configuredEntityTypes.entityTypes, {type: type, kind: kind, codeOrigin: codeOrigin}

--- a/modules/ServerAPI/src/server/routes/PreferredEntityCodeService.coffee
+++ b/modules/ServerAPI/src/server/routes/PreferredEntityCodeService.coffee
@@ -80,7 +80,7 @@ exports.getConfiguredTestedEntityTypes = (asCodes) ->
 	else
 		return testedEntityTypes
 
-exports.getSpecificLoableEntityTypeRoute = (req, resp) ->
+exports.getSpecificTestedEntityTypeRoute = (req, resp) ->
 	displayName = req.params.displayName
 	specificTestedEntityType = exports.getSpecificTestedEntityType displayName
 	resp.json specificTestedEntityType


### PR DESCRIPTION
… not loadable as a tested entity

Currently there is no way to add a configured entity type that is not allowed to be loaded as a tested entity. This becomes an issue when you have entity types like "Solution Container Tube" that check projects of their content "Corporate Batch ID" thus requiring a configured entity type for their contents, however we don't want to allow users to load that entity type.