### PR TITLE
#423: Protocols created via SEL should have scientist set

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -1716,6 +1716,17 @@ createNewProtocol <- function(metaData, lsTransaction, recordedBy) {
   if (is.null(protocolStatus) || protocolStatus == "") {
     protocolStatus <- "created"
   }
+
+  protocolValues[[length(protocolValues)+1]] <- createStateValue(
+    recordedBy = recordedBy,
+    lsType = "codeValue",
+    lsKind = "scientist",
+    codeValue = metaData$Scientist,
+    codeType = "assay",
+    codeKind = "scientist",
+    codeOrigin = racas::applicationSettings$client.scientistCodeOrigin,
+    lsTransaction= lsTransaction)
+
   protocolValues[[length(protocolValues)+1]] <- createStateValue(
     recordedBy = recordedBy,
     lsType = "codeValue",


### PR DESCRIPTION
Currently protocols created through SEL do not have a scientist value. It should be set to be the same as the scientist for the experiment created through SEL