### PR TITLE
bugfix/render-empty-clobValue-form-field: Render empty clobValue form…

### DIFF
--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -469,7 +469,8 @@ class window.ACASFormLSHTMLClobValueFieldController extends ACASFormAbstractFiel
 
 	renderModelContent: =>
 		if @editor?
-			@editor.setContent @getModel().get('value')
+			if @getModel().get('value')?
+				@editor.setContent @getModel().get('value')
 		else
 			@contentToLoad = @getModel().get('value')
 		super()


### PR DESCRIPTION
… field when calling renderModelContent (Issue #479)