### PR TITLE
Bugfix/cmpdreg bulk loader freezes on route errors

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -161,7 +161,15 @@ class window.DetectSdfPropertiesController extends Backbone.View
 			dataType: 'json'
 
 	handlePropertiesDetected: (response) ->
-		if response is "Error" || response.errors? && response.errors.length > 0
+		hasError = false
+		if response is "Error"
+			hasError = true
+		if response.errors? && response.errors.length > 0
+			for err in response.errors
+				if err.level = 'error'
+					hasError = true
+					break
+		if hasError
 			@handleReadError(response)
 		else
 			@trigger 'propsDetected', response

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -161,17 +161,22 @@ class window.DetectSdfPropertiesController extends Backbone.View
 			dataType: 'json'
 
 	handlePropertiesDetected: (response) ->
-		if response is "Error"
+		if response is "Error" || response.errors? && response.errors.length > 0
 			@handleReadError(response)
 		else
 			@trigger 'propsDetected', response
 
 	handleReadError: (err) ->
 		@$('.bv_detectedSdfPropertiesList').addClass 'readError'
-		@$('.bv_detectedSdfPropertiesList').html "An error occurred reading the SD file. Please retry upload or contact an administrator."
+		if err? && typeof(err) == 'object' && err.errors? && err.errors.length > 0
+			errorList = []
+			for error in err.errors
+				errorList.push(error.message)
+			err = errorList.join("\n")
+		@$('.bv_detectedSdfPropertiesList').html "An error occurred reading the SD file. Please retry upload or contact an administrator.\n\n#{err}"
 
 	handleFileRemoved: =>
-		@disableInputs()
+		@disableInputs()	
 		@$('.bv_detectedSdfPropertiesList').html ""
 		@fileName = null
 		@numRecords = 100

--- a/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
+++ b/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
@@ -176,14 +176,17 @@ exports.registerCmpds = (req, resp) ->
 					json: true
 				, (error, response, json) =>
 					console.log json
-					if !error && response.statusCode == 200
+					if !error && response.statusCode == 200 && json.reportFiles?
 						createSummaryZip fileName, json
 					else
 						console.log 'got ajax error trying to register compounds'
 						console.log error
 						console.log json
 						console.log response
-						resp.end JSON.stringify "Error"
+						if json.summary?
+							resp.json [json]
+						else
+							resp.end JSON.stringify "Error"
 				)
 
 	moveSdfFile = (req, resp, callback) ->


### PR DESCRIPTION
Here is an example of when and error occurs on reading the sdf:

<img width="942" alt="screen shot 2018-08-01 at 11 35 45 am" src="https://user-images.githubusercontent.com/868119/43532429-0f47e60e-9580-11e8-8aea-4843423e4481.png">

Here is an example of when bulk loader attempts to load a file that is malformated far down the file where the readSDF route did not read the broken piece so the error wasn't caught until registration:
<img width="909" alt="image" src="https://user-images.githubusercontent.com/868119/43534458-6728d31a-9585-11e8-9f8d-5317829e9173.png">

Previously the second error would have frozen the UI.  The first error would have just reported that no properties were detected but would not display a reason for the error or prevent the user from attempting to load the file.
