### PR TITLE
fixes #501: Validate Dose, Response values as numeric

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3620,7 +3620,13 @@ getSubjectAndTreatmentData <- function (precise, genericDataFileDataFrame, calcu
       }
       
       yColumn <- getResultKindWithoutExtras(subjectData[2, 3]) # usually "Response"
-      
+
+      if(any(is.na(suppressWarnings(as.numeric(subjectData[3:nrow(subjectData), 3]))))) {
+        addError(paste0("Some y values in the 'Raw Results' section are missing numeric values.  Please check the 'Raw Results' section."), errorEnv)
+      }
+      if(any(is.na(suppressWarnings(as.numeric(subjectData[3:nrow(subjectData), 2]))))) {
+        addError(paste0("Some x values in the 'Raw Results' section are missing numeric values.  Please check the 'Raw Results' section."), errorEnv)
+      }
       subjectData[1, 1:4] <- c("Datatype", "Number", "Number", "Text")
       
       subjectData[2, 1] <- "link"


### PR DESCRIPTION
The change is to validate all Dose, Reponse (x, y) values being uploaded as numeric.  The following errors will be displayed to the user if the file being uploaded has empty, non-numeric, or formula errors  in place of numeric values.

For x values:
```
Some x values in the 'Raw Results' section are missing numeric values. Please check the 'Raw Results' section.
```
For y values:
```
Some y values in the 'Raw Results' section are missing numeric values. Please check the 'Raw Results' section.
```

Previous to this bug fix, and even after this bug fix user would see warnings for formula errors:
```
The system has encountered an internal warning, give this message to your system administrator: Error detected in cell B24 - Division by 0
```

