### PR TITLE
Fix for recently introduced SEL bug when re-loading existing experiment

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -1782,7 +1782,7 @@ getExperimentByNameCheck <- function(experimentName, protocol, configList, dupli
     protocolOfExperiment <- getProtocolByCodeName(experimentList[[1]]$protocol$codeName)
 
     
-    if (is.na(protocol) || protocolOfExperiment$id != protocol$codeName) {
+    if (is.na(protocol) || protocolOfExperiment$codeName != protocol$codeName) {
       if (duplicateNamesAllowed) {
         experiment <- NA
       } else {


### PR DESCRIPTION
Fix for bug introduced in commit 78d4d413462a5c2ce5ceb27bc6410d4f0dc7c4d9 where "id" was being compared to "codeName" to determine whether a protocol matched, rather than comparing "codeName" to "codeName".

Resulting bug was the wrong warning when a user tried to reload an experiment to the same protocol -- warning that the experiment exists on another protocol, rather than just warning that the data will be deleted.