### PR TITLE
Revert "Bump csv-parse from 1.3.3 to 4.6.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cookie-parser": "^1.4.3",
     "connect-flash": "~0.1.0",
     "cron": "1.3.0",
-    "csv-parse": "^4.6.5",
+    "csv-parse": "^1.1.1",
     "each": "0.6.1",
     "exports-loader": "0.6.4",
     "express": "3.0.2",


### PR DESCRIPTION
Reverts mcneilco/acas#599

This merge requests breaks ACAS, I'll revisit it later but reverting for now.