### PR TITLE
#619 if re-rendering after a save, we need to destroy the existing state form controller and re-create it

### DIFF
--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -309,6 +309,10 @@ class window.ACASFormStateTableController extends Backbone.View
 		@thingRef.get('lsStates').getStatesByTypeAndKind @tableDef.stateType, @tableDef.stateKind
 
 	setupFormForNewState: (state) ->
+		if @stateTableFormControllersCollection[rowNumber]?
+			@stateTableFormControllersCollection[rowNumber].remove()
+			@stateTableFormControllersCollection[rowNumber].unbind()
+			
 		fDiv = @formWrapper.clone()
 		@$('.bv_formWrapper').append fDiv
 		rowNumber = @getRowNumberForState(state)


### PR DESCRIPTION
This fixes the duplicate rendering after an update of a thing