### PR TITLE
Fix updates of saved values in StateTableForm

### DIFF
--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -676,6 +676,14 @@ class window.ACASFormStateTableFormController extends Backbone.View
 			newKey = keyBase + value.cid
 			value.set key: newKey
 			@thingRef.set newKey, value
+			# Deep copy the field modelDefaults and change the key to the newKey
+			newField = $.extend( true, {}, field)
+			newField.modelDefaults.key = newKey
+			# Save the modelDefaults to the Thing's defaultValues with the new key
+			# This allows @createNewValue to find the correct modelDefaults when creating a new value should this value be edited
+			@thingRef.lsProperties.defaultValues.push newField.modelDefaults
+			# Add a new listener to value changes to create a new value in the proper state
+			@listenTo value, 'createNewValue', @createNewValue
 
 			opts =
 				modelKey: newKey
@@ -749,3 +757,22 @@ class window.ACASFormStateTableFormController extends Backbone.View
 			return rowValues[0].get('numericValue')
 		else
 			return null
+		
+	createNewValue: (vKind, newVal, key) =>
+		state = @getStateForRow()
+		# Get the modelDefaults for this key that was populated above during setupForm
+		valInfo = _.where(@thingRef.lsProperties.defaultValues, {key: key})[0]
+		@thingRef.unset(key)
+		newValue = state.createValueByTypeAndKind valInfo['type'], valInfo['kind']
+		newValue.set valInfo['type'], newVal
+		newValue.set
+			unitKind: valInfo['unitKind']
+			unitType: valInfo['unitType']
+			codeKind: valInfo['codeKind']
+			codeType: valInfo['codeType']
+			codeOrigin: valInfo['codeOrigin']
+			value: newVal
+		# Replace the Thing's reference to the old ignored value with a reference to the newValue
+		@thingRef.set key, newValue
+		# Add a listener in case this new value is changed again
+		@listenTo newValue, 'createNewValue', @createNewValue


### PR DESCRIPTION
Added a proper listener to `createNewValue` in the right state when StateTableForm values get updated.
In the normal case in Thing.coffee, the `Thing` adds listeners to `createNewValue` for each value in the defaultValues list. The `setValueType` method on the `Value` class from Label.coffee handles detecting changes and ignoring the old value, but then triggers `createNewValue` for another controller to listen for.
Since the values in our StateTableForm are initialized via a slightly different method, they need a separate listener to listen for 'createNewValue'.

Tested that this works for editing saved values, changing filled-in values back to null, and can properly handle multiple changes to the field before a save.