### PR TITLE
#634 set cells to readonly when disabling all inputs

### DIFF
--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -568,6 +568,10 @@ class window.ACASFormStateTableController extends Backbone.View
 				readOnly: true
 				contextMenu: false
 				comments: false
+				cells: (row, col, prop) =>
+					cellProperties = {readOnly: true}
+					return cellProperties;
+
 #Other options I decided not to use
 #			disableVisualSelection: true
 #			manualColumnResize: false
@@ -583,6 +587,10 @@ class window.ACASFormStateTableController extends Backbone.View
 				readOnly: false
 				contextMenu: contextMenu
 				comments: true
+				cells: (row, col, prop) =>
+					cellProperties = {}
+					return cellProperties;
+
 #Other options I decided not to use
 #			disableVisualSelection: false
 #			manualColumnResize: true


### PR DESCRIPTION
This fix appears to solve both of these issues:
- StateTable should be read-only and styled in grey/read-only mode
- "autocomplete" and date dropdowns should not be editable

I haven't been able to reproduce the update button being available.