### PR TITLE
fixes #673 setting for allowing no structures compounds to be registered as unique parents

### DIFF
--- a/modules/CmpdReg/src/client/custom/configuration.json
+++ b/modules/CmpdReg/src/client/custom/configuration.json
@@ -75,7 +75,8 @@
 		"standardizeStructure": false,
 		"useExternalStandardizerConfig": false,
 		"standardizerConfigFilePath": "/opt/acas/conf/standardizerConfig.xml",
-		"orderSelectLists": true
+		"orderSelectLists": true,
+		"registerNoStructureCompoundsAsUniqueParents": false
 	},
 	"bulkLoadSettings": {
 		"useProjectRoles": false,


### PR DESCRIPTION
there is an accompanying acas-roo-server commit which often provides most of the implementation