### PR TITLE
fixes #725 cmpd reg button cutoff

### DIFF
--- a/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
+++ b/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
@@ -61,6 +61,7 @@ div#content .bottomPad {
     left: 0px;
     width: 10px;
     height: 35px;
+    padding-bottom: 35px;
 }
 div#footer {
     clear:both;


### PR DESCRIPTION
This fixes a long issue seen on Safari which made its way to Chrome as chrome changed the way it handles something with our css/html

![Screen Shot 2021-01-07 at 10 44 51 AM](https://user-images.githubusercontent.com/868119/103931598-694f6880-50d5-11eb-90d7-cfc9ca2e615b.png)
