### PR TITLE
Fixes #729 When all.client.service.result.viewer.liveDesign.makeRepor…

### DIFF
--- a/modules/ServerAPI/src/server/python/createLiveDesignLiveReportForACAS/create_lr_for_acas.py
+++ b/modules/ServerAPI/src/server/python/createLiveDesignLiveReportForACAS/create_lr_for_acas.py
@@ -71,7 +71,8 @@ def make_acas_live_report(api, compound_ids, assays_to_add, experiment_code, log
     #Make the LR read-only
     if readonly:
         lr.update_policy = LiveReport.NEVER
-        api.update_live_report(lr.id, lr)
+    #Update LR
+    api.update_live_report(lr.id, lr)
     
     
     lr_id = int(lr.id)


### PR DESCRIPTION
…tReadonly is set to true, make sure the report is still updated (added to the auto generated live reports folder)