### PR TITLE
752 acas thing browser class

### DIFF
--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -239,12 +239,14 @@ class ACASThingBrowserController extends Backbone.View
 			$(".bv_thingTableController").html @thingSummaryTable.render().el
 
 	selectedThingUpdated: (thing) =>
+		@$('.bv_thingControllerWrapper').append("<div class='bv_thingController'></div>")
 		@trigger "selectedThingUpdated"
 		@thingController = new @controllerClass
+			el: @$('.bv_thingController')
 			model: thing
 			readOnly: true
 
-		@$('.bv_thingController').html @thingController.render().el
+		@thingController.render()
 		@$(".bv_thingController").removeClass("hide")
 		@$(".bv_thingControllerContainer").removeClass("hide")
 

--- a/modules/Components/src/client/ACASThingBrowserView.html
+++ b/modules/Components/src/client/ACASThingBrowserView.html
@@ -85,7 +85,7 @@
         </div>
         <hr style="margin-top:40px;"/>
         <div class="row-fluid">
-            <div class="bv_thingController hide"></div>
+            <div class="bv_thingControllerWrapper"></div>
         </div>
     </div>
 


### PR DESCRIPTION
This fixes a few issues with ACASThingBrowser:

- TinyMCE wasn't rendering when ThingController was instatiated so Clob values were not shown
- Adds the ability to search by recorded date with searches like
  - "2021" all recorded date within year 2021
  - "2021-04 all recorded date within April 2021
  - "2021-04-02 all recorded date on April 2nd 2021
- Adds the ability to search by recordedBy
- Refactors ACASThingBrowser to not require a separate query config
  - To update to this branch, classes that extend this class need to
    - Rename "toDisplay" option to "configs"
    - Remove "query" option
  - To display a thing attribute without making it searchable you can add `false` to the `isSearchable` key of the config you are adding (default is to always search by all display values.