### PR TITLE
New rows in a state table are not rendering automatically so defaults are not rendered properly and can show as an error when they are not.

### DIFF
--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -486,6 +486,11 @@ class ACASFormStateTableController extends Backbone.View
 									@setCodeForName(value, cellContent)
 					rowNumValue = state.getOrCreateValueByTypeAndKind 'numericValue', @rowNumberKind
 					rowNumValue.set numericValue: changeRow
+
+					# If this state is new, we want to render it again because it could have default
+					# values which need to be displayed in the ui
+					if state.isNew()
+						@renderState state
 			@trigger 'cellChangeComplete', state
 
 


### PR DESCRIPTION
Fixes #774