### PR TITLE
ACAS-133: Add simple textarea clobValue FormField

### DIFF
--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -663,6 +663,48 @@ class ACASFormLSHTMLClobValueFieldController extends ACASFormAbstractFieldContro
 		else
 			@disableEditor = false
 
+
+class ACASFormLSClobValueFieldController extends ACASFormAbstractFieldController
+	###
+		Launching controller must:
+		- Initialize the model with an LSValue
+    Do whatever else is required or optional in ACASFormAbstractFieldController
+	###
+
+	template: _.template($("#ACASFormLSClobValueFieldView").html())
+
+	applyOptions: ->
+		super()
+		if @options.rows?
+			@rows = @options.rows
+			@$('textarea').attr 'rows', @rows
+
+	handleInputChanged: =>
+		@clearError()
+		@userInputEvent = true
+		value = UtilityFunctions::getTrimmedInput(@$('textarea'))
+		if value == ""
+			@setEmptyValue()
+		else
+			@getModel().set
+				value: value
+				ignored: false
+		super()
+
+	setEmptyValue: ->
+		@getModel().set
+			value: null
+			ignored: true
+
+	setInputValue: (inputValue) ->
+		@$('textarea').val inputValue
+
+
+	renderModelContent: =>
+		@$('textarea').val @getModel().get('textarea')
+		super()
+
+
 class ACASFormLSStringValueFieldController extends ACASFormAbstractFieldController
 	###
 		Launching controller must:

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -25,6 +25,7 @@ class ACASFormAbstractFieldController extends Backbone.View
 
 	events: ->
 		"keyup input": "handleInputChanged"
+		"keyup textarea": "handleInputChanged"
 		"mouseover .label-tooltip": "handleToolTipMouseover"
 		"mouseoff .label-tooltip": "handleToolTipMouseoff"
 
@@ -701,7 +702,7 @@ class ACASFormLSClobValueFieldController extends ACASFormAbstractFieldController
 
 
 	renderModelContent: =>
-		@$('textarea').val @getModel().get('textarea')
+		@$('textarea').val @getModel().get('value')
 		super()
 
 

--- a/modules/Components/src/client/ACASFormFieldsView.html
+++ b/modules/Components/src/client/ACASFormFieldsView.html
@@ -59,6 +59,14 @@
     </div>
 </script>
 
+<script type="text/template" id="ACASFormLSClobValueFieldView" xmlns="http://www.w3.org/1999/html">
+    <label class="control-label"><span class ="label-text">launching controller must provide or set label</span><i class="icon-info-sign label-tooltip hide" data-toggle="tooltip" style="margin-left:4px;"></i></label>
+    <div class="controls">
+        <textarea class=""></textarea>
+        <span class="help-inline hide"></span>
+    </div>
+</script>
+
 <script type="text/template" id="ACASFormLSFileValueFieldView" xmlns="http://www.w3.org/1999/html">
     <label class="control-label"><span class ="label-text">launching controller must provide or set label</span><i class="icon-info-sign label-tooltip hide" data-toggle="tooltip" style="margin-left:4px;"></i></label>
     <div class="controls">

--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -832,6 +832,9 @@ class ACASFormStateTableFormController extends Backbone.View
 						newField = new ACASFormMultiCodeValueCheckboxController opts
 					else
 						newField = new ACASFormLSCodeValueFieldController opts
+				when 'clobValue'
+					opts.rows = field.fieldSettings?.rows
+					newField = new ACASFormLSClobValueFieldController opts
 				when 'htmlClobValue'
 					opts.rows = field.fieldSettings?.rows
 					newField = new ACASFormLSHTMLClobValueFieldController opts

--- a/modules/Components/src/client/AbstractFormController.coffee
+++ b/modules/Components/src/client/AbstractFormController.coffee
@@ -170,6 +170,9 @@ class AbstractThingFormController extends AbstractFormController
 						newField = new ACASFormMultiCodeValueCheckboxController opts
 					else
 						newField = new ACASFormLSCodeValueFieldController opts
+				when 'clobValue'
+					opts.rows = field.fieldSettings?.rows
+					newField = new ACASFormLSClobValueFieldController opts
 				when 'htmlClobValue'
 					opts.rows = field.fieldSettings?.rows
 					newField = new ACASFormLSHTMLClobValueFieldController opts


### PR DESCRIPTION
HTMLClobValue was causing problems because it includes HTML in the saved value, and we were trying to use it to store command-line arguments which should be plaintext.
Implemented an "ACASFormLsClobValueController" tied to type `clobValue` (as opposed to `htmlClobValue`) which creates a simple `textarea` which is resizable.