### PR TITLE
remove problematic logging line

### DIFF
--- a/modules/ServerAPI/src/server/routes/ThingServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ThingServiceRoutes.coffee
@@ -1077,7 +1077,6 @@ exports.bulkPostThings = (req, resp) ->
 
 exports.bulkPostThingsInternal = (thingArray, callback) ->
 	console.log "bulkPostThings"
-	console.log JSON.stringify thingArray
 	baseurl = config.all.client.service.persistence.fullpath+"lsthings/jsonArray"
 	request(
 		method: 'POST'


### PR DESCRIPTION
This is the minimal change, but it seems like this perhaps should be expanded out a bit.
- Similar logging lines are in `bulkPutThingsInternal`
- It would be more desirable to log out the `thingArray` only if the save fails, but I wasn't sure if the logging line I removed could be safely placed down around line 1090 below `console.log "got error bulk posting things"`

I wasn't set up well to test the error cases, so opted to keep this initial PR very small, but open to suggestions to widen it a bit.