### PR TITLE
fixes #826 Use model.escape and _.escape to protect against XSS

### DIFF
--- a/modules/CmpdRegAdmin/src/client/AbstractCmpdRegAdmin.coffee
+++ b/modules/CmpdRegAdmin/src/client/AbstractCmpdRegAdmin.coffee
@@ -74,7 +74,7 @@ class AbstractCmpdRegAdminController extends AbstractFormController
 	render: =>
 		unless @model?
 			@model = new window[@modelClass]()
-		code = @model.get('code')
+		code = @model.escape('code')
 		@$('.bv_cmpdRegAdminCode').val(code)
 		@$('.bv_cmpdRegAdminCode').html(code)
 		if @showIgnore

--- a/modules/CmpdRegAdmin/src/client/AbstractCmpdRegAdminBrowser.coffee
+++ b/modules/CmpdRegAdmin/src/client/AbstractCmpdRegAdminBrowser.coffee
@@ -226,12 +226,12 @@ class AbstractCmpdRegAdminBrowserController extends Backbone.View
 				@$(".bv_moreSpecificCmpdRegAdminSearchNeeded").removeClass "hide"
 			else
 				@$(".bv_searchingCmpdRegAdminsMessage").removeClass "hide"
-				@$(".bv_cmpdRegAdminSearchTerm").html cmpdRegAdminSearchTerm
+				@$(".bv_cmpdRegAdminSearchTerm").html _.escape(cmpdRegAdminSearchTerm)
 				@$(".bv_moreSpecificCmpdRegAdminSearchNeeded").addClass "hide"
 				@searchController.doSearch cmpdRegAdminSearchTerm
 		
 	handleDeleteCmpdRegAdminClicked: =>
-		@$(".bv_cmpdRegAdminCodeName").html @cmpdRegAdminController.model.get("code")
+		@$(".bv_cmpdRegAdminCodeName").html @cmpdRegAdminController.model.escape("code")
 		@$(".bv_deleteButtons").removeClass "hide"
 		@$(".bv_okayButton").addClass "hide"
 		@$(".bv_errorDeletingCmpdRegAdminMessage").addClass "hide"

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -200,7 +200,7 @@ class DetectSdfPropertiesController extends Backbone.View
 				props += newLine + prop.get('name')
 		if props == ""
 			props = "No SDF Properties Detected"
-		@$('.bv_detectedSdfPropertiesList').html props
+		@$('.bv_detectedSdfPropertiesList').html _.escape(props)
 
 	disableInputs: ->
 		@$('.bv_readMore').attr 'disabled', 'disabled'
@@ -243,7 +243,7 @@ class AssignedPropertyController extends AbstractFormController
 	render: =>
 		$(@el).empty()
 		$(@el).html @template(@model.attributes)
-		@$('.bv_sdfProperty').html(@model.get('sdfProperty'))
+		@$('.bv_sdfProperty').html(@model.escape('sdfProperty'))
 		@setupDbPropertiesSelect()
 		@$('.bv_defaultVal').val @model.get('defaultVal')
 		if @model.get('dbProperty') is "none"
@@ -527,7 +527,7 @@ class AssignSdfPropertiesController extends Backbone.View
 	handleNameTemplateChanged: ->
 		tempName = UtilityFunctions::getTrimmedInput @$('.bv_templateName')
 		if @templateList.findWhere({name: tempName})? #and tempName.toLowerCase() != "none"
-			@$('.bv_overwriteMessage').html tempName+" already exists. Overwrite?"
+			@$('.bv_overwriteMessage').html _.escape(tempName)+" already exists. Overwrite?"
 			@$('.bv_overwriteWarning').show()
 			@$('input[name="bv_overwrite"][value="no"]').prop('checked',true)
 			@$('.bv_overwrite').change()
@@ -555,7 +555,7 @@ class AssignSdfPropertiesController extends Backbone.View
 		if @assignedPropertiesList.findWhere({dbProperty: 'salt equivalents'})?
 			unless (@assignedPropertiesList.findWhere({dbProperty: 'salt id'})? or @assignedPropertiesList.findWhere({dbProperty: 'salt type'})?)
 				unassignedDbProps += newLine + 'salt id/type (required for salt equivalents)'
-		@$('.bv_unassignedProperties').html unassignedDbProps
+		@$('.bv_unassignedProperties').html _.escape(unassignedDbProps)
 		@isValid()
 
 	isValid: =>
@@ -1095,8 +1095,8 @@ class CmpdRegBulkLoaderAppController extends Backbone.View
 		else
 			@$('.bv_headerName').html "BULK COMPOUND REGISTRATION"
 
-		@$('.bv_loginUserFirstName').html window.AppLaunchParams.loginUser.firstName
-		@$('.bv_loginUserLastName').html window.AppLaunchParams.loginUser.lastName
+		@$('.bv_loginUserFirstName').html _.escape(window.AppLaunchParams.loginUser.firstName)
+		@$('.bv_loginUserLastName').html _.escape(window.AppLaunchParams.loginUser.lastName)
 		if UtilityFunctions::testUserHasRole window.AppLaunchParams.loginUser, [window.conf.roles.cmpdreg.adminRole]
 			@$('.bv_adminDropdownWrapper').show()
 		else

--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdmin.coffee
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdmin.coffee
@@ -81,7 +81,7 @@ class AbstractCodeTablesAdminController extends AbstractFormController
 	render: =>
 		unless @model?
 			@model = new window[@modelClass]()
-		code = @model.get('code')
+		code = @model.escape('code')
 		@$('.bv_codeTablesAdminCode').val(code)
 		@$('.bv_codeTablesAdminCode').html(code)
 		if @showIgnore

--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowser.coffee
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowser.coffee
@@ -229,12 +229,12 @@ class AbstractCodeTablesAdminBrowserController extends Backbone.View
 				@$(".bv_moreSpecificCodeTablesAdminSearchNeeded").removeClass "hide"
 			else
 				@$(".bv_searchingCodeTablesAdminsMessage").removeClass "hide"
-				@$(".bv_codeTablesAdminSearchTerm").html codeTablesAdminSearchTerm
+				@$(".bv_codeTablesAdminSearchTerm").html _.escape(codeTablesAdminSearchTerm)
 				@$(".bv_moreSpecificCodeTablesAdminSearchNeeded").addClass "hide"
 				@searchController.doSearch codeTablesAdminSearchTerm
 		
 	handleDeleteCodeTablesAdminClicked: =>
-		@$(".bv_codeTablesAdminCodeName").html @codeTablesAdminController.model.get("code")
+		@$(".bv_codeTablesAdminCodeName").html @codeTablesAdminController.model.escape("code")
 		@$(".bv_deleteButtons").removeClass "hide"
 		@$(".bv_okayButton").addClass "hide"
 		@$(".bv_errorDeletingCodeTablesAdminMessage").addClass "hide"

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -288,7 +288,7 @@ class ACASFormLSNumericValueFieldController extends ACASFormAbstractFieldControl
 	render: =>
 		super()
 		if @getModel()? and @getModel().has('unitKind')
-			@$('.bv_units').html @getModel().get('unitKind')
+			@$('.bv_units').html @getModel().escape('unitKind')
 		@
 
 	handleInputChanged: =>
@@ -328,7 +328,7 @@ class ACASFormLSNumericValueFieldController extends ACASFormAbstractFieldControl
 				@$('.bv_number').val @getModel().get('value')
 
 		if @getModel().has 'unitKind'
-			@$('.bv_units').html @getModel().get('unitKind')
+			@$('.bv_units').html @getModel().escape('unitKind')
 		super()
 
 class ACASFormLSCodeValueFieldController extends ACASFormAbstractFieldController
@@ -479,7 +479,7 @@ class ACASFormLSCodeValueFieldController extends ACASFormAbstractFieldController
 		if @options.showDescription? and @options.showDescription
 			@clearDescription()
 			if @pickListController.getSelectedModel()?
-				desc = @pickListController.getSelectedModel().get('description')
+				desc = @pickListController.getSelectedModel().escape('description')
 				if desc?
 					@setDescription(desc)
 	
@@ -854,12 +854,12 @@ class ACASFormLSFileValueFieldController extends ACASFormAbstractFieldController
 		super()
 
 	setupFileController: ->
-		fileValue = @getModel().get('value')
+		fileValue = @getModel().escape('value')
 		if @isEmpty()
 			@createNewFileChooser()
 			@$('.bv_deleteSavedFile').hide()
 		else
-			displayText = @getModel().get('comments')
+			displayText = @getModel().escape('comments')
 			if !displayText?
 				displayText = fileValue
 			if @displayInline
@@ -931,12 +931,12 @@ class ACASFormLSBlobValueFieldController extends ACASFormLSFileValueFieldControl
 		), '')
 
 	setupFileController: ->
-		fileValue = @getModel().get('value')
+		fileValue = @getModel().escape('value')
 		if @isEmpty()
 			@createNewFileChooser()
 			@$('.bv_deleteSavedFile').hide()
 		else
-			displayText = @getModel().get('comments')
+			displayText = @getModel().escape('comments')
 			if !displayText?
 				displayText = "InternalErrorUnknownFileName"
 			id = @getModel().get('id')

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -479,13 +479,13 @@ class ACASFormLSCodeValueFieldController extends ACASFormAbstractFieldController
 		if @options.showDescription? and @options.showDescription
 			@clearDescription()
 			if @pickListController.getSelectedModel()?
-				desc = @pickListController.getSelectedModel().escape('description')
+				desc = @pickListController.getSelectedModel().get('description')
 				if desc?
 					@setDescription(desc)
 	
 	setDescription: (message) ->
 		@$('.desc-inline').removeClass 'hide'
-		@$('.desc-inline').html message
+		@$('.desc-inline').html _.escape message
 
 	clearDescription: ->
 		@$('.desc-inline').addClass 'hide'

--- a/modules/Components/src/client/ACASFormStateDisplayUpdate.coffee
+++ b/modules/Components/src/client/ACASFormStateDisplayUpdate.coffee
@@ -35,7 +35,7 @@ class ACASFormStateDisplayUpdateCellController extends Backbone.View
 			content = "NA"
 		else
 			val = @collection.findWhere ignored: false
-			content = val.escape(val.get('lsType'))
+			content = val.get(val.get('lsType'))
 			if @options.cellDef.displayOverride?
 				content = @options.cellDef.displayOverride content
 			if val.get('lsType') == 'dateValue'
@@ -43,7 +43,7 @@ class ACASFormStateDisplayUpdateCellController extends Backbone.View
 			else if val.get('lsType') == 'codeValue'
 				content = UtilityFunctions::getNameForCode val, content, @options.pickLists
 
-		$(@el).html content
+		$(@el).html _.escape content
 		$(@el).addClass if @collection.length > 1 then "valueWasEdited" else ""
 		if @options.cellDef.editable? and !@options.cellDef.editable
 			$(@el).addClass 'valueNotEditable'

--- a/modules/Components/src/client/ACASFormStateDisplayUpdate.coffee
+++ b/modules/Components/src/client/ACASFormStateDisplayUpdate.coffee
@@ -35,7 +35,7 @@ class ACASFormStateDisplayUpdateCellController extends Backbone.View
 			content = "NA"
 		else
 			val = @collection.findWhere ignored: false
-			content = val.get(val.get('lsType'))
+			content = val.escape(val.get('lsType'))
 			if @options.cellDef.displayOverride?
 				content = @options.cellDef.displayOverride content
 			if val.get('lsType') == 'dateValue'
@@ -259,7 +259,7 @@ class ACASFormStateDisplayOldValueController extends Backbone.View
 				url: "/api/transaction/"+prevLsTransaction
 				json: true
 				success: (response) =>
-					@$('.bv_reason').html response.comments
+					@$('.bv_reason').html _.escape(response.comments)
 
 		@
 

--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -44,7 +44,7 @@ class ThingSimpleSearchController extends AbstractFormController
 				@$(".bv_moreSpecificThingSearchNeeded").removeClass "hide"
 			else
 				@$(".bv_searchingThingsMessage").removeClass "hide"
-				@$(".bv_exptSearchTerm").html thingSearchTerm
+				@$(".bv_exptSearchTerm").html _.escape(thingSearchTerm)
 				@$(".bv_moreSpecificThingSearchNeeded").addClass "hide"
 				@doSearch thingSearchTerm
 
@@ -163,13 +163,13 @@ class ACASThingBrowserCellController extends Backbone.View
 	render: =>
 		$(@el).empty()
 
-		value = @model.get(@configs.key)
+		value = @model.escape(@configs.key)
 		if value instanceof Value
-			content = value.get("value")
+			content = value.escape("value")
 			if value.get("lsType") == "dateValue"  && !@configs.formatter?
 				content = UtilityFunctions::convertMSToYMDDate(content)
 		else if value instanceof Label
-			content = value.get("labelText")
+			content = value.escape("labelText")
 		else
 			content = value
 		

--- a/modules/Components/src/client/RealtimeDeviceConnectionController.coffee
+++ b/modules/Components/src/client/RealtimeDeviceConnectionController.coffee
@@ -189,7 +189,7 @@ class RealtimeDeviceConnectionController extends Backbone.View
 	displayInUseMessage: =>
 		@resetStatusMessages()
 		@displayStatusMessage(".bv_deviceServerInUseButIdle")
-		@$(".bv_deviceUsedBy").html @userNameOfConnectedUser
+		@$(".bv_deviceUsedBy").html _.escape(@userNameOfConnectedUser)
 
 	handleDeviceSelectChange: =>
 		@disableElement(".bv_deviceSelectContainer")
@@ -221,7 +221,7 @@ class RealtimeDeviceConnectionController extends Backbone.View
 		@$(".bv_disconnectedByAUserMessage").hide()
 
 	displayInUseModal: =>
-		@$(".bv_alreadyConnectedUserName").html @userNameOfConnectedUser
+		@$(".bv_alreadyConnectedUserName").html _.escape(@userNameOfConnectedUser)
 		@$(".bv_deviceInUse").modal "show"
 
 	handleConnectError: =>
@@ -277,7 +277,7 @@ class RealtimeDeviceConnectionController extends Backbone.View
 			@connectToDeviceCallback(msg, null)
 
 	displayDisconnectedModal: (disconnectingUserName) =>
-		@$(".bv_disconnectingUserName").html disconnectingUserName
+		@$(".bv_disconnectingUserName").html _.escape(disconnectingUserName)
 		@$(".bv_disconnectedByAUserMessage").show "slide", {direction: "right"}
 
 	dismissDeviceInUse: =>

--- a/modules/CurveAnalysis/src/client/CurveCurator.coffee
+++ b/modules/CurveAnalysis/src/client/CurveCurator.coffee
@@ -406,7 +406,7 @@ class CurveEditorController extends Backbone.View
 			@stopListening @drpc.model, 'change'
 			@listenTo @drpc.model, 'change', @handlePointsChanged
 
-			@$('.bv_compoundCode').html @model.get('compoundCode')
+			@$('.bv_compoundCode').html @model.escape('compoundCode')
 			@$('.bv_reportedValues').html @model.get('reportedValues')
 			@$('.bv_fitSummary').html @model.get('fitSummary')
 			@$('.bv_parameterStdErrors').html @model.get('parameterStdErrors')
@@ -672,7 +672,7 @@ class CurveSummaryController extends Backbone.View
 		else
 			@$('.bv_dirty').hide()
 
-		@$('.bv_compoundCode').html @model.get('curveAttributes').compoundCode
+		@$('.bv_compoundCode').html _.escape(@model.get('curveAttributes').compoundCode)
 #		@model.on 'change', @render
 		@
 

--- a/modules/CurveAnalysis/src/client/DoseResponseKiAnalysis.coffee
+++ b/modules/CurveAnalysis/src/client/DoseResponseKiAnalysis.coffee
@@ -93,7 +93,7 @@ class DoseResponseKiAnalysisParametersController extends AbstractFormController
 		@
 
 	updateThresholdDisplay: (val)->
-		@$('.bv_inactiveThresholdDisplay').html val
+		@$('.bv_inactiveThresholdDisplay').html _.escape(val)
 
 	setThresholdModeEnabledState: ->
 		if @model.get 'smartMode'

--- a/modules/DocForBatches/src/client/BatchListValidator.coffee
+++ b/modules/DocForBatches/src/client/BatchListValidator.coffee
@@ -81,7 +81,7 @@ class BatchNameController extends Backbone.View
 
 	render: =>
 		$(@el).html @template()
-		@$(".bv_preferredName").html @model.getDisplayName()
+		@$(".bv_preferredName").html _.escape(@model.getDisplayName())
 		@$(".bv_comment").val @model.get "comment"
 		unless @model.hasValidName()
 			@$('.bv_preferredName').addClass "error"

--- a/modules/DocForBatches/src/client/DocUpload.coffee
+++ b/modules/DocForBatches/src/client/DocUpload.coffee
@@ -56,7 +56,7 @@ class DocUploadController extends AbstractFormController
 			@$('.bv_fileInput').hide()
 			if @model.get('docType') is 'file'
 				$('.bv_currentFileRadio').attr('checked', true)
-				@$('.bv_currentFileName').html(@model.get('currentFileName'))
+				@$('.bv_currentFileName').html(@model.escape('currentFileName'))
 			else
 				@.$('.bv_currentDocContainer').hide()
 				$('.bv_urlRadio').attr('checked', true)

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -185,7 +185,7 @@ class ExperimentSimpleSearchController extends AbstractFormController
 				$(".bv_moreSpecificExperimentSearchNeeded").removeClass "hide"
 			else
 				$(".bv_searchingExperimentsMessage").removeClass "hide"
-				$(".bv_exptSearchTerm").html experimentSearchTerm
+				$(".bv_exptSearchTerm").html _.escape(experimentSearchTerm)
 				$(".bv_moreSpecificExperimentSearchNeeded").addClass "hide"
 				@doSearch experimentSearchTerm
 
@@ -505,15 +505,15 @@ class ExperimentBrowserController extends Backbone.View
 		subclass = @experimentController.model.get('subclass')
 		if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
 			if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].escape('labelText')
 			else if @model.get('lsKind') is "study" and @model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-				code = @model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+				code = @model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].escape('labelText')
 			else
 				code = @experimentController.model.get("codeName")
 		else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].escape('labelText')
 		else
-			code = @experimentController.model.get('codeName')
+			code = @experimentController.model.escape('codeName')
 
 		@$(".bv_experimentCodeName").html code
 		@$(".bv_deleteButtons").removeClass "hide"

--- a/modules/ModuleMenus/src/client/ModuleMenus.coffee
+++ b/modules/ModuleMenus/src/client/ModuleMenus.coffee
@@ -67,15 +67,15 @@ class ModuleMenusController extends Backbone.View
 				@setupFastUserSwitching()
 			else
 				@$('.bv_fastUserSelect').hide()
-				@$('.bv_loginUserFirstName').html window.AppLaunchParams.loginUser.firstName
-				@$('.bv_loginUserLastName').html window.AppLaunchParams.loginUser.lastName
+				@$('.bv_loginUserFirstName').html _.escape(window.AppLaunchParams.loginUser.firstName)
+				@$('.bv_loginUserLastName').html _.escape(window.AppLaunchParams.loginUser.lastName)
 		else
 			@$('.bv_userInfo').hide()
 
 	render: =>
 		if window.AppLaunchParams.deployMode?
 			unless window.AppLaunchParams.deployMode.toUpperCase() =="PROD"
-				@$('.bv_deployMode h1').html(window.AppLaunchParams.deployMode.toUpperCase())
+				@$('.bv_deployMode h1').html(_.escape(window.AppLaunchParams.deployMode.toUpperCase()))
 
 		@
 

--- a/modules/Project/src/client/Project.coffee
+++ b/modules/Project/src/client/Project.coffee
@@ -706,7 +706,7 @@ class ProjectController extends AbstractFormController
 	render: =>
 		unless @model?
 			@model = new Project()
-		codeName = @model.get('codeName')
+		codeName = @model.escape('codeName')
 		@$('.bv_projectCode').val(codeName)
 		@$('.bv_projectCode').html(codeName)
 		if @model.isNew()

--- a/modules/Project/src/client/ProjectBrowser.coffee
+++ b/modules/Project/src/client/ProjectBrowser.coffee
@@ -54,7 +54,7 @@ class ProjectSimpleSearchController extends AbstractFormController
 				$(".bv_moreSpecificProjectSearchNeeded").removeClass "hide"
 			else
 				$(".bv_searchingProjectsMessage").removeClass "hide"
-				$(".bv_exptSearchTerm").html projectSearchTerm
+				$(".bv_exptSearchTerm").html _.escape(projectSearchTerm)
 				$(".bv_moreSpecificProjectSearchNeeded").addClass "hide"
 				@doSearch projectSearchTerm
 
@@ -174,7 +174,7 @@ class ProjectBrowserController extends Backbone.View
 		@searchController.render()
 		@searchController.on "searchReturned", @setupProjectSummaryTable.bind(@)
 		#@searchController.on "resetSearch", @destroyProjectSummaryTable
-		@$('.bv_queryToolDisplayName').html window.conf.service.result.viewer.displayName
+		@$('.bv_queryToolDisplayName').html _.escape(window.conf.service.result.viewer.displayName)
 
 	setupProjectSummaryTable: (projects) =>
 		@destroyProjectSummaryTable()
@@ -219,7 +219,7 @@ class ProjectBrowserController extends Backbone.View
 #				@$('.bv_deleteProject').hide()
 
 	handleDeleteProjectClicked: =>
-		@$(".bv_projectCodeName").html @projectController.model.get("codeName")
+		@$(".bv_projectCodeName").html @projectController.model.escape("codeName")
 		@$(".bv_deleteButtons").removeClass "hide"
 		@$(".bv_okayButton").addClass "hide"
 		@$(".bv_errorDeletingProjectMessage").addClass "hide"

--- a/modules/ProtocolBrowser/src/client/ProtocolBrowser.coffee
+++ b/modules/ProtocolBrowser/src/client/ProtocolBrowser.coffee
@@ -42,7 +42,7 @@ class ProtocolSimpleSearchController extends AbstractFormController
 				$(".bv_moreSpecificProtocolSearchNeeded").removeClass "hide"
 			else
 				$(".bv_searchingProtocolsMessage").removeClass "hide"
-				$(".bv_protSearchTerm").html protocolSearchTerm
+				$(".bv_protSearchTerm").html _.escape(protocolSearchTerm)
 				$(".bv_moreSpecificProtocolSearchNeeded").addClass "hide"
 				@doSearch protocolSearchTerm
 
@@ -335,11 +335,11 @@ class ProtocolBrowserController extends Backbone.View
 		subclass = @protocolController.model.get('subclass')
 		if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
 			if @protocolController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-				code = @protocolController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+				code = @protocolController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].escape('labelText')
 			else
-				code = @protocolController.model.get("codeName")
+				code = @protocolController.model.escape("codeName")
 		else
-			code = @protocolController.model.get('codeName')
+			code = @protocolController.model.escape('codeName')
 		@$(".bv_protocolCodeName").html code
 		@$(".bv_deleteButtons").removeClass "hide"
 		@$(".bv_okayButton").addClass "hide"

--- a/modules/ServerAPI/src/client/AttachFile.coffee
+++ b/modules/ServerAPI/src/client/AttachFile.coffee
@@ -99,16 +99,16 @@ class BasicFileController extends AbstractFormController
 	render: =>
 		$(@el).empty()
 		$(@el).html @template(@model.attributes)
-		fileValue = @model.get('fileValue')
-		urlValue = @model.get('urlValue')
+		fileValue = @model.escape('fileValue')
+		urlValue = @model.excape('urlValue')
 		if ((fileValue is null or fileValue is "" or fileValue is undefined) and (urlValue is null or urlValue is "" or urlValue is undefined))
 			@createNewFileChooser()
 		else
 			if urlValue?
-				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+ @model.get('urlValue')+'">'+@model.get('urlValue')+'</a></div>'
+				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+ urlValue+'">'+urlValue+'</a></div>'
 			else
-				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+window.conf.datafiles.downloadurl.prefix+fileValue+'">'+@model.get('comments')+'</a></div>'
-			@$('.bv_recordedBy').html @model.get("recordedBy")
+				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+window.conf.datafiles.downloadurl.prefix+fileValue+'">'+@model.escape('comments')+'</a></div>'
+			@$('.bv_recordedBy').html @model.escape("recordedBy")
 			@$('.bv_recordedDate').html UtilityFunctions::convertMSToYMDDate @model.get("recordedDate")
 		@
 

--- a/modules/ServerAPI/src/client/AuthorBrowser.coffee
+++ b/modules/ServerAPI/src/client/AuthorBrowser.coffee
@@ -44,7 +44,7 @@ class AuthorSimpleSearchController extends AbstractFormController
 				$(".bv_moreSpecificAuthorSearchNeeded").removeClass "hide"
 			else
 				$(".bv_searchingAuthorsMessage").removeClass "hide"
-				$(".bv_exptSearchTerm").html authorSearchTerm
+				$(".bv_exptSearchTerm").html _.escape(authorSearchTerm)
 				$(".bv_moreSpecificAuthorSearchNeeded").addClass "hide"
 				@doSearch authorSearchTerm
 
@@ -183,7 +183,7 @@ class AuthorBrowserController extends Backbone.View
 				@$('.bv_deleteAuthor').hide()
 
 	handleDeleteAuthorClicked: =>
-		@$(".bv_authorUserName").html @authorController.model.get("userName")
+		@$(".bv_authorUserName").html @authorController.model.escape("userName")
 		@$(".bv_deleteButtons").removeClass "hide"
 		@$(".bv_okayButton").addClass "hide"
 		@$(".bv_errorDeletingAuthorMessage").addClass "hide"

--- a/modules/ServerAPI/src/client/BaseEntity.coffee
+++ b/modules/ServerAPI/src/client/BaseEntity.coffee
@@ -298,15 +298,15 @@ class BaseEntityController extends AbstractThingFormController #TODO: check to s
 			@model = new BaseEntity()
 		subclass = @model.get('subclass')
 		unless @model.get('shortDescription') is " "
-			@$('.bv_shortDescription').html @model.get('shortDescription')
+			@$('.bv_shortDescription').html @model.escape('shortDescription')
 		bestName = @model.get('lsLabels').pickBestName()
 		if bestName?
 			@$('.bv_'+subclass+'Name').val bestName.get('labelText')
-		@$('.bv_scientist').val(@model.getScientist().get('codeValue'))
-		@$('.bv_'+subclass+'Code').html(@model.get('codeName'))
-		@$('.bv_'+subclass+'Kind').html(@model.get('lsKind')) #should get value from protocol create form
-		@$('.bv_details').val(@model.getDetails().get('clobValue'))
-		@$('.bv_comments').val(@model.getComments().get('clobValue'))
+		@$('.bv_scientist').val(@model.getScientist().escape('codeValue'))
+		@$('.bv_'+subclass+'Code').html(@model.escape('codeName'))
+		@$('.bv_'+subclass+'Kind').html(@model.escape('lsKind')) #should get value from protocol create form
+		@$('.bv_details').val(@model.getDetails().escape('clobValue'))
+		@$('.bv_comments').val(@model.getComments().escape('clobValue'))
 		saveNotebook = true #default
 		if window.conf.entity?.notebook?.save?
 			saveNotebook= window.conf.entity.notebook.save

--- a/modules/ServerAPI/src/client/ExampleThing.coffee
+++ b/modules/ServerAPI/src/client/ExampleThing.coffee
@@ -267,7 +267,7 @@ class ExampleThingController extends AbstractThingFormController
 		@
 
 	renderModelContent: ->
-		codeName = @model.get('codeName')
+		codeName = @model.escape('codeName')
 		@$('.bv_thingCode').val(codeName)
 		@$('.bv_thingCode').html(codeName)
 		if @readOnly is true
@@ -451,7 +451,7 @@ class ExampleTableAuditController extends AbstractThingFormController
 		@
 
 	renderModelContent: ->
-		codeName = @model.get('codeName')
+		codeName = @model.escape('codeName')
 		@$('.bv_thingCode').html(codeName)
 
 	modelSaveCallback: (method, model) =>

--- a/modules/ServerAPI/src/client/Experiment.coffee
+++ b/modules/ServerAPI/src/client/Experiment.coffee
@@ -476,7 +476,7 @@ class ExperimentBaseController extends BaseEntityController
 				@$('.bv_openInQueryToolWrapper').hide()
 			else
 				@$('.bv_openInQueryToolWrapper').show()
-			@$('.bv_queryToolDisplayName').html window.conf.service.result.viewer.displayName
+			@$('.bv_queryToolDisplayName').html _.escape(window.conf.service.result.viewer.displayName)
 			@$('.bv_openInQueryToolLink').attr 'href', "/openExptInQueryTool?experiment="+@model.get('codeName')
 		@
 
@@ -617,7 +617,7 @@ class ExperimentBaseController extends BaseEntityController
 		@$(".bv_deleteWarningMessage").addClass "hide"
 		@$(".bv_deletingStatusIndicator").removeClass "hide"
 		@$(".bv_deleteButtons").addClass "hide"
-		@$(".bv_experimentCodeName").html @model.get('codeName')
+		@$(".bv_experimentCodeName").html @model.escape('codeName')
 		$.ajax(
 			url: "/api/experiments/#{@model.get("id")}",
 			type: 'DELETE',

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -439,7 +439,7 @@ class ProtocolBaseController extends BaseEntityController
 		@$(".bv_deleteWarningMessage").addClass "hide"
 		@$(".bv_deletingStatusIndicator").removeClass "hide"
 		@$(".bv_deleteButtons").addClass "hide"
-		@$(".bv_protocolCodeName").html @model.get('codeName')
+		@$(".bv_protocolCodeName").html @model.escape('codeName')
 		$.ajax(
 			url: "/api/protocols/browser/#{@model.get("id")}",
 			type: 'DELETE',


### PR DESCRIPTION
I found that backbone uses underscore's escape method under the hood:

https://github.com/jashkenas/backbone/blob/153dc41616a1f2663e4a86b705fefd412ecb4a7a/backbone.js#L456

So instead of rolling my own escape, I just used _.escape when we are setting .html without a backbone model