### PR TITLE
Fixing acas thing browser rendering

### DIFF
--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -163,7 +163,7 @@ class ACASThingBrowserCellController extends Backbone.View
 	render: =>
 		$(@el).empty()
 
-		value = @model.escape(@configs.key)
+		value = @model.get(@configs.key)
 		if value instanceof Value
 			content = value.escape("value")
 			if value.get("lsType") == "dateValue"  && !@configs.formatter?


### PR DESCRIPTION
Found the issue. I was mistakingly escape the entire value instead of just the things.