### PR TITLE
Fix issue required to shows base64 images inline

### DIFF
--- a/app_template.coffee
+++ b/app_template.coffee
@@ -96,6 +96,7 @@ startApp = ->
 		helmet(
 			contentSecurityPolicy:
 				directives:
+					imgSrc: ["'self'", "data:"]
 					defaultSrc: ["'self'", "'unsafe-eval'"],
 					scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
 					styleSrc: ["'self'", "'unsafe-inline'"],


### PR DESCRIPTION
Fixes a few places we do this but discovered that Structure Images rendered in base64 in creg were broken without this.