### PR TITLE
Brianbolt/issue881

### DIFF
--- a/conf/acas-base.env
+++ b/conf/acas-base.env
@@ -472,6 +472,9 @@ CLIENT_PROTOCOL_SHOWASSAYTREERULE=false
 # MAPS TO: client.protocol.showCurveDisplayParams
 CLIENT_PROTOCOL_SHOWCURVEDISPLAYPARAMS=true
 
+# MAPS TO: client.protocol.notebook.require
+CLIENT_PROTOCOL_NOTEBOOK_REQUIRE=false
+
 # MAPS TO: client.experiment.uneditableFileTypes
 CLIENT_EXPERIMENT_UNEDITABLEFILETYPES=["source file", "annotation file"]
 
@@ -504,6 +507,9 @@ CLIENT_PROTOCOL_HIDEFIELDS=
 
 # MAPS TO: client.experiment.hideFields
 CLIENT_EXPERIMENT_HIDEFIELDS=
+
+# MAPS TO: client.experiment.notebook.require
+CLIENT_EXPERIMENT_NOTEBOOK_REQUIRE=true
 
 # MAPS TO: client.entity.approvalRole
 CLIENT_ENTITY_APPROVALROLE=

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -431,6 +431,7 @@ client.experiment.lockwhenapproved.filter=${env.CLIENT_EXPERIMENT_LOCKWHENAPPROV
 #Note that notebook page can't be visible if notebook is not visible and page can't be required if notebook is not required
 client.entity.notebook.save=${env.CLIENT_ENTITY_NOTEBOOK_SAVE}
 client.entity.notebook.require=${env.CLIENT_ENTITY_NOTEBOOK_REQUIRE}
+client.entity.notebook.subclassExempt=${env.CLIENT_ENTITY_NOTEBOOKPAGE_REQUIRE}
 client.entity.notebookPage.save=${env.CLIENT_ENTITY_NOTEBOOKPAGE_SAVE}
 client.entity.notebookPage.require=${env.CLIENT_ENTITY_NOTEBOOKPAGE_REQUIRE}
 
@@ -455,7 +456,9 @@ client.entity.viewDeletedRoles=${env.CLIENT_ENTITY_VIEWDELETEDROLES}
 
 client.protocol.showAssayTreeRule=${env.CLIENT_PROTOCOL_SHOWASSAYTREERULE}
 client.protocol.showCurveDisplayParams=${env.CLIENT_PROTOCOL_SHOWCURVEDISPLAYPARAMS}
+client.protocol.notebook.require=${env.CLIENT_PROTOCOL_NOTEBOOK_REQUIRE}
 client.experiment.uneditableFileTypes=${env.CLIENT_EXPERIMENT_UNEDITABLEFILETYPES}
+client.experiment.notebook.require=${env.CLIENT_EXPERIMENT_NOTEBOOK_REQUIRE}
 
 #Controls privileges for who can create/edit and delete authors
 client.author.editingRoles=${env.CLIENT_AUTHOR_EDITINGROLES}

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -431,7 +431,6 @@ client.experiment.lockwhenapproved.filter=${env.CLIENT_EXPERIMENT_LOCKWHENAPPROV
 #Note that notebook page can't be visible if notebook is not visible and page can't be required if notebook is not required
 client.entity.notebook.save=${env.CLIENT_ENTITY_NOTEBOOK_SAVE}
 client.entity.notebook.require=${env.CLIENT_ENTITY_NOTEBOOK_REQUIRE}
-client.entity.notebook.subclassExempt=${env.CLIENT_ENTITY_NOTEBOOKPAGE_REQUIRE}
 client.entity.notebookPage.save=${env.CLIENT_ENTITY_NOTEBOOKPAGE_SAVE}
 client.entity.notebookPage.require=${env.CLIENT_ENTITY_NOTEBOOKPAGE_REQUIRE}
 

--- a/modules/ServerAPI/src/client/BaseEntity.coffee
+++ b/modules/ServerAPI/src/client/BaseEntity.coffee
@@ -153,7 +153,9 @@ class BaseEntity extends Backbone.Model
 				saveNotebook= window.conf.entity.notebook.save
 			requireNotebook = true #default
 			if window.conf.entity?.notebook?.require?
-				requireNotebook= window.conf.entity.notebook.require
+				requireNotebook = window.conf.entity.notebook.require
+				if window.conf[attrs.subclass]?.notebook?.require?
+					requireNotebook = window.conf[attrs.subclass].notebook.require
 			if saveNotebook and requireNotebook
 				notebook = @getNotebook().get('stringValue')
 				if notebook is "" or notebook is undefined or notebook is null


### PR DESCRIPTION
Fixes #881

Add configs for BaseEntity subclasses exeriment and protocol to override overall notebook requirement.
The default for experiment remains true and the protocol requirement has now been switched to false by default.