### PR TITLE
Barcode not saved properly in Creg single loader UI

### DIFF
--- a/modules/CmpdReg/src/client/custom/LotView_Custom.inc
+++ b/modules/CmpdReg/src/client/custom/LotView_Custom.inc
@@ -89,7 +89,7 @@
             </div>
 			<div class="barcodeWrapper">
 				<label class="FormLabel">Barcode:</label>
-				<input type="textfield" class="FormInput barcode" value="<%= supplierLot %>" /><br />
+				<input type="textfield" class="FormInput barcode" value="<%= barcode %>" /><br />
 			</div>
 			<div>
 				<label class="FormLabel">Supplier lot:</label>


### PR DESCRIPTION
## Description
Update LotView_Custom.inc had the model "supplierLot" instead of "barcode" mapped to it.

## Related Issue
Fixes #890

## How Has This Been Tested?
The barcode was being saved correctly on first save, but an update to the lot was setting the barcode to null because of this.
I tested by updating a lot and verifying that the barcode remained.