### PR TITLE
Scope ACASThingBrowserController HTML changes to only current element

### DIFF
--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -339,7 +339,7 @@ class ACASThingBrowserController extends Backbone.View
 	setupThingSummaryTable: (things) =>
 		@destroyThingSummaryTable()
 
-		$(".bv_searchingThingsMessage").addClass "hide"
+		@$(".bv_searchingThingsMessage").addClass "hide"
 		if things is null
 			@$(".bv_errorOccurredPerformingSearch").removeClass "hide"
 
@@ -357,7 +357,7 @@ class ACASThingBrowserController extends Backbone.View
 				columnFilters: @columnFilters
 
 			@thingSummaryTable.on "selectedRowUpdated", @selectedThingUpdated
-			$(".bv_thingTableController").html @thingSummaryTable.render().el
+			@$(".bv_thingTableController").html @thingSummaryTable.render().el
 
 	selectedThingUpdated: (thing) =>
 		@$('.bv_thingControllerWrapper').append("<div class='bv_thingController'></div>")


### PR DESCRIPTION
Fixes #892

Scope jquery changes to only current element

## Description
Found a few places in ACASThingBrowserController where changes to HTML were not scoped to current element, so they were unintentionally affecting all ThingBrowser instances.

Used search pattern `[\s+]\$\(["'].bv` to locate these, and didn't find any more within Thing components. There are some hits for this pattern across many files that I did not choose to fix.

## Related Issue
#892

## How Has This Been Tested?
I had this situation set up in my local environment, and when I patched this change into the javascript, it fixes the issue. Browsers still each work normally but now the browser + embedded browser situation also works.