### PR TITLE
Run acasclient tests on build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,48 +2,102 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ release/* ]
+    branches: ["**"]
   create:
     tags: "**"
 jobs:
   acas:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Docker meta
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
           # list of Docker images to use as base name for tags
           images: |
             ${{ github.repository }}-oss
-      -
-        name: Set up QEMU
+      - name: Set ACAS_TAG to ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+        run: echo "ACAS_TAG=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_ENV
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Checkout acasclient
+        uses: actions/checkout@v3
+        with:
+          repository: mcneilco/acasclient
+          path: acasclient
+          # Below checks out the same revision name as ACAS but skipping now
+          # because we don't want to keep acasclient version in sync with ACAS version
+          # at the moment.
+          # ref: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      - name: Build (no push)
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ env.ACAS_TAG }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+      - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
+        id: dockerComposeUp
+        run: |
+          echo ::set-output name=docker_compose_pull_failure::false
+          docker-compose -f "docker-compose.yml" up -d || echo ::set-output name=docker_compose_pull_failure::true
+      - name: Get docker images fallback tag name
+        run: |
+          echo "DEFAULT_BRANCH_ACAS_TAG=$(echo ${{ github.event.repository.default_branch }} | sed -e 's/\//-/g')" >> $GITHUB_ENV
+        if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure }}
+      - name: Falling back to ${{ env.DEFAULT_BRANCH_ACAS_TAG }} docker image tag for roo and racas tags
+        run: |
+          docker pull  mcneilco/acas-roo-server-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG }}-indigo
+          docker tag mcneilco/acas-roo-server-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG}}-indigo mcneilco/acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo
+          docker pull  mcneilco/racas-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG}}
+          docker tag mcneilco/racas-oss:${{ env.DEFAULT_BRANCH_ACAS_TAG }} mcneilco/racas-oss:${{ env.ACAS_TAG }}
+          docker-compose -f "docker-compose.yml" up -d
+        if: ${{ steps.dockerComposeUp.outputs.docker_compose_pull_failure }}
+      - name: Create docker bob
+        run: bash docker_bob_setup.sh
+      - name: Create bob credentials for acasclient
+        run: |
+          mkdir ~/.acas
+          echo "[default]" >> ~/.acas/credentials
+          echo "username=bob" >> ~/.acas/credentials
+          echo "password=secret" >> ~/.acas/credentials
+          echo "url=http://localhost:3000" >> ~/.acas/credentials
+      - name: Set Up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install acasclient and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ./acasclient
+      - name: Run tests
+        run: python -m unittest discover -s ./acasclient -p "test_*.py"
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          # Only push tags and release branches
+          push: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile
           platforms: linux/amd64,linux/arm64/v8
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            VERSION=${{ env.ACAS_TAG }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ venv
 chemaxon
 .chemaxon
 .vscode
+.github

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
      - acas
     env_file:
       - ./conf/docker/acas/environment/acas.env
-    command: catalina.sh run
+    command: /bin/bash ./wait-for-it.sh -t 1000 db:5432 -- catalina.sh run
 volumes:
   dbstore:
   filestore:

--- a/docker_bob_setup.sh
+++ b/docker_bob_setup.sh
@@ -1,7 +1,25 @@
-curl localhost:3001/api/systemTest/getOrCreateACASBob
-curl localhost:3001/api/systemTest/getOrCreateGlobalProject
-curl localhost:3001/api/systemTest/getOrCreateGlobalProjectRole
-curl localhost:3001/api/systemTest/giveBobRoles
-curl localhost:3001/api/systemTest/getOrCreateCmpdRegBob
-curl localhost:3001/api/systemTest/syncRoles
-#curl localhost:3001/api/systemTest/getOrCreateCmpds
+counter=0
+wait=300
+until $(curl --output /dev/null --silent --head --fail http://localhost:3001/api/authors) || [ $counter == $wait ]; do
+    if [ $counter == 0 ]; then
+        echo "Waiting for ACAS API to start..."
+    fi
+    sleep 1
+    remaining=$((wait - counter))
+    echo "Waiting for ACAS API to start...remaining attempts: $remaining"
+    counter=$((counter+1))
+done
+if [ $counter == $wait ]; then
+    echo "waited $wait seconds for acas to start, giving up"
+else
+    echo "ACAS started!"
+    # getOrCreateACASBob
+    curl --max-time 5 -i -X GET -H "Accept: application/json" http://localhost:3001/api/systemTest/getOrCreateACASBob
+    # getOrCreateGlobalProject
+    curl --max-time 5 -i -X GET -H "Accept: application/json" http://localhost:3001/api/systemTest/getOrCreateGlobalProject
+    # getOrCreateGlobalProjectRole
+    curl --max-time 5 -i -X GET -H "Accept: application/json" http://localhost:3001/api/systemTest/getOrCreateGlobalProjectRole
+    # giveBobRoles
+    curl --max-time 5 -i -X GET -H "Accept: application/json" http://localhost:3001/api/systemTest/giveBobRoles
+fi
+docker-compose logs


### PR DESCRIPTION
## Description

Main features
 - Startup basic acas oss instance, download the acasclient and run tests
    - If the build does not have equivalent branches in roo/rservices, it falls back to release/1.13.7 (using default git branch as a guide)
 - Build all branches but only push release and tags (previously built only tags)
 - Make roo wait for database to fully start
   - I was seeing some slow database startup times and it was causing an issue where roo wasn't coming up

See action build logs for this here: https://github.com/mcneilco/acas/actions/runs/1989388121

## Related Issue
Fixes #896


## How Has This Been Tested?
Built on a "release/" branch to make sure build test and push works
Built on a regular "brianbolt/" branch to make sure build and test works but does not push a docker image