### PR TITLE
Additional Assay Scientist and Compound scientists fail on all invalid characters

### DIFF
--- a/modules/CmpdRegAdmin/src/client/CmpdRegStereoCategory.coffee
+++ b/modules/CmpdRegAdmin/src/client/CmpdRegStereoCategory.coffee
@@ -12,7 +12,7 @@ class StereoCategory extends Backbone.Model
 		errors = []
 		if attrs.code? and @isNew()
 			validChars = attrs.code.match(/[a-zA-Z0-9 _\-+]/g)
-			unless validChars.length is attrs.code.length
+			if !validChars? || validChars.length != attrs.code.length
 				errors.push
 					attribute: 'code'
 					message: "Stereo Category code can not contain special characters"

--- a/modules/CmpdRegAdmin/src/client/CmpdRegVendor.coffee
+++ b/modules/CmpdRegAdmin/src/client/CmpdRegVendor.coffee
@@ -12,7 +12,7 @@ class Vendor extends Backbone.Model
 		errors = []
 		if attrs.code? and @isNew()
 			validChars = attrs.code.match(/[a-zA-Z0-9 _\-+]/g)
-			unless validChars.length is attrs.code.length
+			if !validChars? || validChars.length != attrs.code.length
 				errors.push
 					attribute: 'vendorCode'
 					message: "Vendor code can not contain special characters"

--- a/modules/CodeTablesAdmin/src/client/CodeTablesAssayScientist.coffee
+++ b/modules/CodeTablesAdmin/src/client/CodeTablesAssayScientist.coffee
@@ -13,7 +13,7 @@ class AssayScientist extends Backbone.Model
 		errors = []
 		if attrs.code? and @isNew()
 			validChars = attrs.code.match(/[a-zA-Z0-9 _\-+]/g)
-			unless validChars.length is attrs.code.length
+			if !validChars? || validChars.length != attrs.code.length
 				errors.push
 					attribute: 'scientistCode'
 					message: "Assay Scientist code can not contain special characters"

--- a/modules/CodeTablesAdmin/src/client/CodeTablesCompoundScientist.coffee
+++ b/modules/CodeTablesAdmin/src/client/CodeTablesCompoundScientist.coffee
@@ -13,7 +13,7 @@ class CompoundScientist extends Backbone.Model
 		errors = []
 		if attrs.code? and @isNew()
 			validChars = attrs.code.match(/[a-zA-Z0-9 _\-+]/g)
-			unless validChars.length is attrs.code.length
+			if !validChars? || validChars.length != attrs.code.length
 				errors.push
 					attribute: 'scientistCode'
 					message: "Compound Scientist code can not contain special characters"


### PR DESCRIPTION

Fixes #898

## Description
Fixed validation to check if valid characters is null (0 valid characters)

## Related Issue
Fixes #898

## How Has This Been Tested?
Went to each module and verified each disabled the save button when only invalid characters were supplied
Went to each module and saved a code value and verified they showed up in the browser (saved properly).