### PR TITLE
Validation error messages don't show up in CodeTableAdmin modules

### DIFF
--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdmin.coffee
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdmin.coffee
@@ -15,8 +15,8 @@ class AbstractCodeTablesAdminController extends AbstractFormController
 	template: _.template($("#AbstractCodeTablesAdminView").html())
 
 	events: ->
-		"keyup .bv_codeTablesAdminCode": "handleCodeTablesAdminCodeNameChanged"
-		"keyup .bv_codeTablesAdminName": "handleCodeTablesAdminNameChanged"
+		"input .bv_codeTablesAdminCode": "handleCodeTablesAdminCodeNameChanged"
+		"input .bv_codeTablesAdminName": "handleCodeTablesAdminNameChanged"
 		"click .bv_codeTablesAdminIgnore": "handleCodeTablesAdminIgnoreChanged"
 		"click .bv_save": "handleSaveClicked"
 		"click .bv_backToCodeTablesAdminBrowserBtn": "handleBackToCodeTablesAdminBrowserClicked"
@@ -76,6 +76,11 @@ class AbstractCodeTablesAdminController extends AbstractFormController
 			@$(".bv_group_codeTablesAdminIgnore").show()
 		else
 			@$(".bv_group_codeTablesAdminIgnore").hide()
+		@notificationController = new LSNotificationController
+			el: @$('.bv_notifications')
+			showPreview: false
+		@.on 'notifyError', @notificationController.addNotification
+		@.on 'clearErrors', @notificationController.clearAllNotificiations
 		@render()
 
 	render: =>
@@ -233,6 +238,7 @@ class AbstractCodeTablesAdminController extends AbstractFormController
 
 	clearValidationErrorStyles: =>
 		super()
+		@notificationController.clearAllNotificiations()
 		@$('.bv_save').removeAttr('disabled')
 
 	checkDisplayMode: =>

--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminView.html
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminView.html
@@ -1,7 +1,7 @@
 <script type="text/template" id="AbstractCodeTablesAdminView" xmlns="http://www.w3.org/1999/html">
     <div class="form-horizontal">
-        <div class="control-group">
-            <label class="control-label bv_group_codeTablesAdminCode">*<%-upperDisplayName%> Code</label>
+        <div class="control-group bv_group_codeTablesAdminCode">
+            <label class="control-label">*<%-upperDisplayName%> Code</label>
             <div class="controls">
                 <input class="bv_codeTablesAdminCode" style="width:336px;" type="text" placeholder="" />
             </div>
@@ -19,6 +19,7 @@
             </div>
         </div>
     </div>
+    <div class='bv_notifications row span7'></div>
 
 
     <!-- SAVE AND CANCEL -->

--- a/modules/CodeTablesAdmin/src/client/CodeTablesAssayScientist.coffee
+++ b/modules/CodeTablesAdmin/src/client/CodeTablesAssayScientist.coffee
@@ -15,16 +15,16 @@ class AssayScientist extends Backbone.Model
 			validChars = attrs.code.match(/[a-zA-Z0-9 _\-+]/g)
 			if !validChars? || validChars.length != attrs.code.length
 				errors.push
-					attribute: 'scientistCode'
+					attribute: 'codeTablesAdminCode'
 					message: "Assay Scientist code can not contain special characters"
 		if !attrs.code? or attrs.code is ""
 			errors.push
-				attribute: 'scientistCode'
+				attribute: 'codeTablesAdminCode'
 				message: "Assay Scientist code must be set and unique"
 		if !attrs.name? or attrs.name is ""
 			errors.push
-				attribute: 'scientistName'
-				message: "Assay Scientist name must be set and unique"
+				attribute: 'codeTablesAdminName'
+				message: "Assay Scientist name must be set"
 		if errors.length > 0
 			return errors
 		else

--- a/modules/CodeTablesAdmin/src/client/CodeTablesCompoundScientist.coffee
+++ b/modules/CodeTablesAdmin/src/client/CodeTablesCompoundScientist.coffee
@@ -15,15 +15,15 @@ class CompoundScientist extends Backbone.Model
 			validChars = attrs.code.match(/[a-zA-Z0-9 _\-+]/g)
 			if !validChars? || validChars.length != attrs.code.length
 				errors.push
-					attribute: 'scientistCode'
+					attribute: 'codeTablesAdminCode'
 					message: "Compound Scientist code can not contain special characters"
 		if !attrs.code? or attrs.code is ""
 			errors.push
-				attribute: 'scientistCode'
+				attribute: 'codeTablesAdminCode'
 				message: "Compound Scientist code must be set and unique"
 		if !attrs.name? or attrs.name is ""
 			errors.push
-				attribute: 'scientistName'
+				attribute: 'codeTablesAdminName'
 				message: "Compound Scientist name must be set and unique"
 		if errors.length > 0
 			return errors

--- a/modules/Components/src/client/LSErrorNotification.coffee
+++ b/modules/Components/src/client/LSErrorNotification.coffee
@@ -139,6 +139,7 @@ class LSNotificationController extends Backbone.View
 	warningList: null
 	infoList: null
 	showPreview: true
+	showOnMessageAdd: true # Shows messages if they are added
 
 	events:
 		'click .bv_notificationCountContainer': 'toggleShowNotificationMessages'
@@ -157,6 +158,9 @@ class LSNotificationController extends Backbone.View
 
 		if @options.showPreview?
 			@showPreview = @options.showPreview
+
+		if @options.showOnAdd?
+			@showOnMessageAdd = @options.showOnMessageAdd
 
 		@render()
 		
@@ -186,6 +190,7 @@ class LSNotificationController extends Backbone.View
 		@$('.bv_notificationMessagePreview').hide()
 		@$('.bv_notificationMessagePreview').html(message)
 		if @showPreview then @$('.bv_notificationMessagePreview').show("slide", @hideMessagePreview)
+		if @showOnMessageAdd then @$('.bv_notificationMessages').show()
 		@errorController.notificationsList.add(new LSNotificationMessageModel({content: message}))
 	
 	getErrorCount: ->
@@ -195,6 +200,7 @@ class LSNotificationController extends Backbone.View
 		@$('.bv_notificationMessagePreview').hide()
 		@$('.bv_notificationMessagePreview').html(message)
 		if @showPreview then @$('.bv_notificationMessagePreview').show("slide", @hideMessagePreview)
+		if @showOnMessageAdd then @$('.bv_notificationMessages').show()
 		@warningController.notificationsList.add(new LSNotificationMessageModel({content: message}))
 	
 	getWarningCount: ->
@@ -205,6 +211,7 @@ class LSNotificationController extends Backbone.View
 		@$('.bv_notificationMessagePreview').hide()
 		@$('.bv_notificationMessagePreview').html(message)
 		if @showPreview then @$('.bv_notificationMessagePreview').show("slide", @hideMessagePreview)
+		if @showOnMessageAdd then @$('.bv_notificationMessages').show()
 		@infoController.notificationsList.add(new LSNotificationMessageModel({content: message}))
 	
 	hideMessagePreview: ->


### PR DESCRIPTION
## Description
Added LsNotificiation widget to the module
Made change to LsNotification widget to show message when they are added (default is true but option to turn off)
Changed attribute name/html to match expected naming in [AbstractFormController](https://github.com/mcneilco/acas/blob/e792b459182406534bf5cffafbb0571ddfc8978f/modules/Components/src/client/AbstractFormController.coffee#L49) 
Changed the event name to `input` which is a more modern browser way of detect field changes (detects any change including pasting)

## Related Issue
Fixes #900


## How Has This Been Tested?
Added various errors, cleared them, made sure notifications showed up properly. Made sure I could still register codes
<img width="837" alt="Screen Shot 2022-03-16 at 10 16 20 AM" src="https://user-images.githubusercontent.com/868119/158624171-2760931c-f570-4c21-9af5-2382590b1019.png">
.