### PR TITLE
Add ability to set listen address in acas and acas api

### DIFF
--- a/app_api_template.coffee
+++ b/app_api_template.coffee
@@ -31,6 +31,7 @@ startApp = ->
 
 	global.app = express()
 	app.set 'port', config.all.server.nodeapi.port
+	app.set 'listenHost', config.all.server.nodeapi.listenHost
 	app.set 'views', __dirname + '/views'
 	app.set 'view engine', 'jade'
 	app.use(logger('dev'))
@@ -53,8 +54,8 @@ startApp = ->
 
 	#TO_BE_REPLACED_BY_PREPAREMODULEINCLUDES
 
-	http.createServer(app).listen(app.get('port'), ->
-		console.log("ACAS API server listening on port " + app.get('port'))
+	http.createServer(app).listen(app.get('port'), app.get('listenHost'), ->
+		console.log("ACAS API server listening to #{app.get('listenHost')} on port #{app.get('port')}")
 		console.log "Bootstrap being called"
 		bootstrap = require "./src/javascripts/ServerAPI/Bootstrap.js"
 		if bootstrap.main?

--- a/app_template.coffee
+++ b/app_template.coffee
@@ -81,6 +81,7 @@ startApp = ->
 	sessionStore = new MemoryStore();
 	global.app = express()
 	app.set 'port', config.all.client.port
+	app.set 'listenHost', config.all.client.listenHost
 	app.set 'views', __dirname + '/views'
 	app.set 'view engine', 'jade'
 	app.use logger('dev')
@@ -138,8 +139,8 @@ startApp = ->
 
 
 	if not config.all.client.use.ssl
-		httpServer = http.createServer(app).listen(app.get('port'), ->
-			console.log("ACAS server listening on port " + app.get('port'))
+		httpServer = http.createServer(app).listen(app.get('port'), app.get('listenHost'), ->
+			console.log("ACAS server listening to #{app.get('listenHost')} on port #{app.get('port')}")
 		)
 	else
 		console.log "------ Starting in SSL Mode"
@@ -150,8 +151,8 @@ startApp = ->
 			cert: fs.readFileSync config.all.server.ssl.cert.file.path
 			ca: fs.readFileSync config.all.server.ssl.cert.authority.file.path
 			passphrase: config.all.server.ssl.cert.passphrase
-		https.createServer(sslOptions, app).listen(app.get('port'), ->
-			console.log("ACAS server listening on port " + app.get('port'))
+		https.createServer(sslOptions, app).listen(app.get('port'), app.get('listenHost'), ->
+			console.log("ACAS server listening to #{app.get('listenHost')} on port #{app.get('port')}")
 		)
 		#TODO hack to prevent bug: https://github.com/mikeal/request/issues/418
 		process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"

--- a/conf/acas-base.env
+++ b/conf/acas-base.env
@@ -4,8 +4,14 @@ CLIENT_HOST=acas
 # MAPS TO: client.port
 CLIENT_PORT=3000
 
+# MAPS TO: client.listenHost
+CLIENT_LISTENHOST=0.0.0.0
+
 # MAPS TO: server.nodeapi.port
 SERVER_NODEAPI_PORT=3001
+
+# MAPS TO: server.nodeapi.listenHost
+SERVER_NODEAPI_LISTENHOST=0.0.0.0
 
 # MAPS TO: server.nodeapi.host
 SERVER_NODEAPI_HOST=acas

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -91,6 +91,7 @@ client.host=${env.CLIENT_HOST}
 # Example: client.port=3000
 #
 client.port=${env.CLIENT_PORT}
+client.listenHost=${env.CLIENT_LISTENHOST}
 
 
 ###########################################################################
@@ -108,6 +109,7 @@ client.port=${env.CLIENT_PORT}
 # NOTE:        nodeapi.port must be different than client.port. It should be blocked by the server's firewall
 #
 server.nodeapi.port=${env.SERVER_NODEAPI_PORT}
+server.nodeapi.listenHost=${env.SERVER_NODEAPI_LISTENHOST}
 server.nodeapi.path=${env.SERVER_NODEAPI_PATH}
 
 client.service.persistence.path=${env.CLIENT_SERVICE_PERSISTENCE_PATH}


### PR DESCRIPTION
## Description
Added configurations for `client.listenHost` and `server.nodeapi.listenHost`.  The default is 0.0.0.0

## Related Issue
Fixes #910

## How Has This Been Tested?
_I verified the logs printed the correct after restarting:_
0.0.0.0 settings:
```
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.505Z info: "log level set to 'debug'"
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.573Z info: 'io standardizerController: connected'
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.623Z info: 'would have logged: ACAS Node server started with data: started and user: '
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.625Z info: 'ACAS server listening to 0.0.0.0 on port 3000'
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.626Z info: 'Created new directory: /home/runner/build/privateTempFiles/'
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.838Z info: 'just declared global cronJobs in setup'
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.870Z info: 'would have logged: ACAS API server started with data: started and user: '
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.878Z info: 'ACAS API server listening to 0.0.0.0 on port 3001'
acas-acas-1  | [ACAS] 2022-03-30T01:26:19.878Z info: 'Bootstrap being called'
```

127.0.0.1 settings:
```
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.096Z info: "log level set to 'debug'"
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.149Z info: 'io standardizerController: connected'
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.200Z info: 'would have logged: ACAS Node server started with data: started and user: '
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.202Z info: 'ACAS server listening to 127.0.0.1 on port 3000'
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.319Z info: 'just declared global cronJobs in setup'
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.349Z info: 'would have logged: ACAS API server started with data: started and user: '
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.353Z info: 'ACAS API server listening to 127.0.0.1 on port 3001'
acas-acas-1  | [ACAS] 2022-03-30T01:33:02.353Z info: 'Bootstrap being called'
```

_Ran netstat:_

```
docker-compose exec --user root acas /bin/bash
yum install -y net-tools
netstat -tulpn | grep LISTEN
```

0.0.0.0 settings:
```
tcp        0      0 127.0.0.11:33579        0.0.0.0:*               LISTEN      -                   
tcp        0      0 0.0.0.0:3000            0.0.0.0:*               LISTEN      -                   
tcp        0      0 0.0.0.0:3001            0.0.0.0:*               LISTEN      -    
```

127.0.0.1 settings:
```
tcp        0      0 127.0.0.11:33579        0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:3000          0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:3001          0.0.0.0:*               LISTEN      -    
```

_From rservices I tried to curl_

0.0.0.0 settings:
```
[runner@5ee044734b9a build]$ curl http://acas:3000/api/about
Found. Redirecting to /login?redirect_url=http://acas:3000/api/about
```

127.0.0.1 settings:
```
[runner@5ee044734b9a build]$ curl http://acas:3000/api/about
curl: (7) Failed to connect to acas port 3000: Connection refused
```