### PR TITLE
Brianbolt/issue918

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -127,7 +127,7 @@ server.datafiles.without.login=false
 # specify relative to ACAS_HOME without leading slash
 server.datafiles.relative_path=privateUploads
 server.tempfiles.relative_path=privateTempFiles
-
+server.datafiles.dissallowedFileTypes=["svg", "bat", "exe", "cmd", "sh", "php([0-9])?", "pl", "cgi", "386", "dll", "com", "torrent", "js", "app", "jar", "pif", "vb", "vbscript", "wsf", "asp", "cer", "csr", "jsp", "drv", "sys", "ade", "adp", "bas", "chm", "cpl", "crt", "csh", "fxp", "hlp", "hta", "inf", "ins", "isp", "jse", "htaccess", "htpasswd", "ksh", "lnk", "mdb", "mde", "mdt", "mdw", "msc", "msi", "msp", "mst", "ops", "pcd", "prg", "reg", "scr", "sct", "shb", "shs", "url", "vbe", "vbs", "wsc", "wsf", "wsh"]
 # prefix for the client to prepend the fileValues to allow a user to download
 client.datafiles.downloadurl.prefix=/dataFiles/
 

--- a/modules/ServerAPI/src/server/routes/FileServices.coffee
+++ b/modules/ServerAPI/src/server/routes/FileServices.coffee
@@ -39,23 +39,44 @@ setupRoutes = (app, loginRoutes, requireLogin) ->
 			destination: dataFilesPath
 			filename: fileRename
 		)
-		dataFileUploads = multer({dest:dataFilesPath, storage: storage}).any();
+		
+		fileFilterFunction = (req, file, cb) ->
+			# Join the filtered file types by |
+			disallowedTypesSetting = config.all.server.datafiles.dissallowedFileTypes
+			if disallowedTypesSetting?
+				disallowedTypesArray = JSON.parse(disallowedTypesSetting)
+				dissallowedFileTypes = new RegExp(disallowedTypesArray.join('|'))
+
+				# Check if the file type is allowed
+				mimetype = dissallowedFileTypes.test(file.mimetype)
+				extname = dissallowedFileTypes.test(path.extname(file.originalname).toLowerCase())
+				if mimetype || extname
+					return cb 'Error (415) - The following file types are dissallowed: ' + disallowedTypesArray.join(', ')
+			cb(null, true);
+			return
+
+		dataFileUploads = multer({dest:dataFilesPath, storage: storage, fileFilter: fileFilterFunction}).any();
 
 		# Function to handle request after files have been saved and added
 		# to the request by multer
 		dataFileUploads req, resp, (err) ->
 			if req.fileValidationError
 				console.error(err)
-				return resp.send(req.fileValidationError)
+				return resp.status(500).send(req.fileValidationError)
 			else if !req.files
-				console.error(err)
-				return resp.send('Please post a file')
+				# Set status to 204 No Content
+				return resp.status(204).send('Please post a file')
 			else if err instanceof multer.MulterError
 				console.error(err)
-				return resp.send(err)
+				return resp.status(500).send(err)
 			else if err
+				# Set status code to 'Unsupported Media Type'
 				console.error(err)
-				return resp.send(err)
+				if err.indexOf('Error (415)') == 0
+					console.log(err.indexOf('Error (415)'))
+					return resp.status(415).send(err)
+				else
+					return resp.status(500).send(err)
 			# No errors 
 			else
 				try

--- a/modules/ServerAPI/src/server/routes/FileServices.coffee
+++ b/modules/ServerAPI/src/server/routes/FileServices.coffee
@@ -41,6 +41,9 @@ setupRoutes = (app, loginRoutes, requireLogin) ->
 		)
 		
 		fileFilterFunction = (req, file, cb) ->
+
+			# Get config for dissallowed file types
+			# Return error if dissallowed file type is found and don't write it to the file system
 			disallowedTypesSetting = config.all.server.datafiles.dissallowedFileTypes
 			if disallowedTypesSetting?
 				disallowedTypesArray = JSON.parse(disallowedTypesSetting)
@@ -54,6 +57,8 @@ setupRoutes = (app, loginRoutes, requireLogin) ->
 				# If either test fails, return the error
 				if mimetype || extname
 					return cb 'Error (415) - The following file types are dissallowed: ' + disallowedTypesArray.join(', ')
+			
+			# If no error, return null
 			cb(null, true);
 			return
 

--- a/modules/ServerAPI/src/server/routes/FileServices.coffee
+++ b/modules/ServerAPI/src/server/routes/FileServices.coffee
@@ -41,15 +41,17 @@ setupRoutes = (app, loginRoutes, requireLogin) ->
 		)
 		
 		fileFilterFunction = (req, file, cb) ->
-			# Join the filtered file types by |
 			disallowedTypesSetting = config.all.server.datafiles.dissallowedFileTypes
 			if disallowedTypesSetting?
 				disallowedTypesArray = JSON.parse(disallowedTypesSetting)
+				# Join the filtered file types by | and create regex
 				dissallowedFileTypes = new RegExp(disallowedTypesArray.join('|'))
 
-				# Check if the file type is allowed
+				# Do regex tests
 				mimetype = dissallowedFileTypes.test(file.mimetype)
 				extname = dissallowedFileTypes.test(path.extname(file.originalname).toLowerCase())
+
+				# If either test fails, return the error
 				if mimetype || extname
 					return cb 'Error (415) - The following file types are dissallowed: ' + disallowedTypesArray.join(', ')
 			cb(null, true);


### PR DESCRIPTION
## Description
Added big list of unsafe, disallowed file types by default

## Related Issue
Fixes #918 

## How Has This Been Tested?
- Sent in disallowed file type and got error in UI
<img width="500" alt="Screen Shot 2022-04-01 at 6 53 08 PM" src="https://user-images.githubusercontent.com/868119/161361656-fc302f43-7ea1-4844-a8bb-a9692dd6e161.png">
- Edited the list to allow the file type and it was then successfully uploaded
- Set the config to no value and  verified that no filter was applied
- Set the config to an empty list and verified that no filter was applied
