### PR TITLE
Add max auto lot number, fix radio button selection on label

### DIFF
--- a/conf/acas-base.env
+++ b/conf/acas-base.env
@@ -868,6 +868,12 @@ CLIENT_CMPDREG_METALOT_ALLOWMANUALLOTNUMBER=false
 # MAPS TO: client.cmpdreg.metaLot.autoPopulateNextLotNumber
 CLIENT_CMPDREG_METALOT_AUTOPOPULATENEXTLOTNUMBER=false
 
+# MAPS TO: client.cmpdreg.metaLot.maxAutoLotNumber
+# DESCRIPTION: Currently UI only setting. When auto populating the next lot number in the UI, the UI will filter out any lot numbers > the max auto lot number. So if there are lots which were manually registered with lot number > 1000 and you set the maxAutoLotNumber to 999, then ACAS will remove lot 1000 before calculating the next lot number increment. A null value mean that ACAS will not filter any lot numbers.
+# TYPE: Integer
+# REQUIREMENTS: client.cmpdreg.metaLot.autoPopulateNextLotNumber=true
+CLIENT_CMPDREG_METALOT_MAXAUTOLOTNUMBER=
+
 # MAPS TO: client.cmpdreg.serverSettings.corpPrefix
 CLIENT_CMPDREG_SERVERSETTINGS_CORPPREFIX=CMPD
 

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -695,6 +695,7 @@ client.cmpdreg.metaLot.disableEditMyParents=${env.CLIENT_CMPDREG_METALOT_DISABLE
 client.cmpdreg.metaLot.requireLotNumber=${env.CLIENT_CMPDREG_METALOT_REQUIRELOTNUMBER}
 client.cmpdreg.metaLot.allowManualLotNumber=${env.CLIENT_CMPDREG_METALOT_ALLOWMANUALLOTNUMBER}
 client.cmpdreg.metaLot.autoPopulateNextLotNumber=${env.CLIENT_CMPDREG_METALOT_AUTOPOPULATENEXTLOTNUMBER}
+client.cmpdreg.metaLot.maxAutoLotNumber=${env.CLIENT_CMPDREG_METALOT_MAXAUTOLOTNUMBER}
 client.cmpdreg.serverSettings.corpPrefix=${env.CLIENT_CMPDREG_SERVERSETTINGS_CORPPREFIX}
 client.cmpdreg.serverSettings.corpSeparator=${env.CLIENT_CMPDREG_SERVERSETTINGS_CORPSEPARATOR}
 client.cmpdreg.serverSettings.saltSeparator=${env.CLIENT_CMPDREG_SERVERSETTINGS_SALTSEPARATOR}

--- a/modules/CmpdReg/src/client/custom/LotView_Custom.inc
+++ b/modules/CmpdReg/src/client/custom/LotView_Custom.inc
@@ -62,7 +62,7 @@
 			<div>
 				<label class="FormLabel">Lot Number:</label>
 				<input type="textfield" class="FormInput lotNumber" <%- (saved | isVirtual | !allowManualLotNumber) ? 'disabled=true': '' %> value="<%- lotNumber %>"/>
-				<img class="insertNextAutoLotNumberButton" href="#" title="Fill with next lot number" src="/CmpdReg/client/images/edit.png" <%- (saved | isVirtual | !allowManualLotNumber) ? 'style="display:none;"': 'style="width: 15px;"' %>/>
+				<img class="insertNextAutoLotNumberButton" href="#" title="Fill with next lot number" src="/CmpdReg/client/images/edit.png" <%= (saved | isVirtual | !allowManualLotNumber) ? 'style="display:none;"': 'style="width: 15px;"' %>/>
 			</div>
 			<div>
 				<label class="FormLabel">*Project:</label>

--- a/modules/CmpdReg/src/client/custom/Lot_Custom.js
+++ b/modules/CmpdReg/src/client/custom/Lot_Custom.js
@@ -1,4 +1,4 @@
-$(function() {
+$(function () {
 
   window.Lot = Lot_Abstract.extend({
     defaults: {
@@ -42,166 +42,166 @@ $(function() {
       // Example for setting a maxAutoLotNumber (see below for Lot validation, LotController getNextAutoLot)
       // maxAutoLotNumber: 1000
     },
-    
-    initialize: function(){
-      if (this.has('json') ) {
+
+    initialize: function () {
+      if (this.has('json')) {
         var js = this.get('json');
         // set all attributes, realizing that some need to be replaced by real objcts
-        this.set(js,{silent: true});
-                this.set({
-                    physicalState: new PickList(js.physicalState),
-                    amountUnits: new PickList(js.amountUnits),
-                    retainUnits: new PickList(js.retainUnits),
-                    solutionAmountUnits: new PickList(js.solutionAmountUnits),
-                    tareWeightUnits: new PickList(js.tareWeightUnits),
-                    totalAmountStoredUnits: new PickList(js.totalAmountStoredUnits),
-                    purityMeasuredBy: new PickList(js.purityMeasuredBy),
-                    purityOperator: new PickList(js.purityOperator),
-                    chemist: new PickList({selectedCode: js.chemist}),
-                    project: new PickList({selectedCode: js.project}),
-                    vendor: new PickList(js.vendor)
-                })
+        this.set(js, { silent: true });
+        this.set({
+          physicalState: new PickList(js.physicalState),
+          amountUnits: new PickList(js.amountUnits),
+          retainUnits: new PickList(js.retainUnits),
+          solutionAmountUnits: new PickList(js.solutionAmountUnits),
+          tareWeightUnits: new PickList(js.tareWeightUnits),
+          totalAmountStoredUnits: new PickList(js.totalAmountStoredUnits),
+          purityMeasuredBy: new PickList(js.purityMeasuredBy),
+          purityOperator: new PickList(js.purityOperator),
+          chemist: new PickList({ selectedCode: js.chemist }),
+          project: new PickList({ selectedCode: js.project }),
+          vendor: new PickList(js.vendor)
+        })
         // replace composite object pointers with real objects
-        this.set({fileList: new BackboneFileList()}, {silent: true});
+        this.set({ fileList: new BackboneFileList() }, { silent: true });
         this.get('fileList').model = BackboneFileDesc;
         this.get('fileList').add(js.fileList);
 
-      } else if (this.isNew()){
+      } else if (this.isNew()) {
         this.set({
           fileList: new BackboneFileList()
-        }, {silent: true});
+        }, { silent: true });
         this.get('fileList').model = BackboneFileDesc;
       }
     },
-    
-    validate: function(attr) {
+
+    validate: function (attr) {
 
       this.requireLotNumber = false
       this.autoPopulateNextLotNumber = false
       this.allowManualLotNumber = false
-      if(typeof window.configuration.metaLot.requireLotNumber !== "undefined" && window.configuration.metaLot.requireLotNumber !== null) {
+      if (typeof window.configuration.metaLot.requireLotNumber !== "undefined" && window.configuration.metaLot.requireLotNumber !== null) {
         this.requireLotNumber = window.configuration.metaLot.requireLotNumber
       }
-      if(typeof window.configuration.metaLot.autoPopulateNextLotNumber !== "undefined" && window.configuration.metaLot.autoPopulateNextLotNumber !== null) {
+      if (typeof window.configuration.metaLot.autoPopulateNextLotNumber !== "undefined" && window.configuration.metaLot.autoPopulateNextLotNumber !== null) {
         this.autoPopulateNextLotNumber = window.configuration.metaLot.autoPopulateNextLotNumber
       }
-      if(typeof window.configuration.metaLot.allowManualLotNumber !== "undefined" && window.configuration.metaLot.allowManualLotNumber !== null) {
+      if (typeof window.configuration.metaLot.allowManualLotNumber !== "undefined" && window.configuration.metaLot.allowManualLotNumber !== null) {
         this.allowManualLotNumber = window.configuration.metaLot.allowManualLotNumber
       }
-      if(this.requireLotNumber && !this.autoPopulateNextLotNumber && !this.allowManualLotNumber) {
+      if (this.requireLotNumber && !this.autoPopulateNextLotNumber && !this.allowManualLotNumber) {
         alert("Server configuration error, metaLot.requireLotNumber is true but both metaLot.autoPopulateNextLotNumber and metaLot.allowManualLotNumber are set to false.  Either set metaLot.requireLotNumber to false or set one of the other properties to true")
       }
 
       var errors = new Array();
-            
-            var nbAndDateReq = true;
-            if(attr.isVirtual !=null) {
-                if(attr.isVirtual) {
-                    nbAndDateReq = false;
-                }
-            } else if (this.get('isVirtual')) {
-                nbAndDateReq = false;
-            }
-            
-            
-            if (attr.notebookPage != null) {
-                if(nbAndDateReq || (!nbAndDateReq && attr.notebookPage != '')) {
-                
-                    if(!(/.+/.test(attr.notebookPage))) {
-                        errors.push({attribute: 'notebookPage', message: "Notebook Page must be provided"});
-                    }
-                 } else if (attr.notebookPage == '') {
-                    attr.notebookPage = null;
-                }
-            }
-            if (attr.synthesisDate != null) {
-                if(nbAndDateReq || (!nbAndDateReq && attr.synthesisDate != '')) {
-                    if(!(/^[0-1][0-9]\/[0-3][0-9]\/[0-9]{4}$/.test(attr.synthesisDate))) {
-                        errors.push({attribute: 'synthesisDate', message: "Synthesis Date must be provided and formatted like mm/dd/yyyy"});
-                    }
-                } else if (attr.synthesisDate == '') {
-                    attr.synthesisDate = null;
-                }
-            }
 
-      if (attr.percentEE!=null) {
-        if(isNaN(attr.percentEE) && attr.percentEE!='') { 
-          errors.push({'attribute': 'percentEE', 'message':  "%e.e. must be a number if provided"});
+      var nbAndDateReq = true;
+      if (attr.isVirtual != null) {
+        if (attr.isVirtual) {
+          nbAndDateReq = false;
         }
+      } else if (this.get('isVirtual')) {
+        nbAndDateReq = false;
       }
-      if (attr.amount!=null) {
-        if(isNaN(attr.amount) && attr.amount!='') { 
-          errors.push({'attribute': 'amount', 'message':  "Amount must be a number if provided"});
-        }
-      }
-      if (attr.amount!=null && attr.amount!='') {
-        if(attr.amountUnits==null || attr.amountUnits=='unassigned') {
-          errors.push({'attribute': 'amountUnits', 'message':  "Amount units must be set if amount set"});
-        }
-      }
-      if (attr.retain!=null) {
-        if(isNaN(attr.retain) && attr.retain!='') {
-          errors.push({'attribute': 'retain', 'message':  "Retain must be a number if provided"});
-        }
-      }
-      if (attr.solutionAmount!=null) {
-        if(isNaN(attr.solutionAmount) && attr.solutionAmount!='') {
-          errors.push({'attribute': 'solutionAmount', 'message':  "Solution Amount must be a number if provided"});
-        }
-      }
-      if (attr.solutionAmount!=null && attr.solutionAmount!='') {
-        if(attr.solutionAmountUnits==null || attr.solutionAmountUnits=='unassigned') {
-          errors.push({'attribute': 'solutionAmountUnits', 'message':  "Solution amount units must be set if amount set"});
-        }
-      }
-      if (attr.tareWeight!=null) {
-        if(isNaN(attr.tareWeight) && attr.tareWeight!='') {
-          errors.push({'attribute': 'tareWeight', 'message':  "Tare weight must be a number if provided"});
-        }
-      }
-      if (attr.totalAmountStored!=null) {
-        if(isNaN(attr.totalAmountStored) && attr.totalAmountStored!='') {
-          errors.push({'attribute': 'totalAmountStored', 'message':  "Total amount stored must be a number if provided"});
-        }
-      }
-      if (attr.purity!=null) {
-        if(isNaN(attr.purity) && attr.purity!='') { 
-          errors.push({'attribute': 'purity', 'message':  "Purity must be a number if provided"});
-        }
-      }
-      if (attr.purity!=null && attr.purity!='') {
-        if(attr.purityOperator==null || attr.purityOperator=='unassigned') {
-          errors.push({'attribute': 'purityOperator', 'message':  "Purity operator must be set if purity set"});
-        }
-      }
-      if (attr.meltingPoint!=null) {
-        if(isNaN(attr.meltingPoint) && attr.meltingPoint!='') { 
-          errors.push({'attribute': 'meltingPoint', 'message':  "MP must be a number if provided"});
-        }
-      }
-      if (attr.boilingPoint!=null) {
-        if(isNaN(attr.boilingPoint) && attr.boilingPoint!='') { 
-          errors.push({'attribute': 'boilingPoint', 'message':  "BP must be a number if provided"});
-        }
-      }
-      if (attr.project != null && typeof(attr.project) == 'undefined'){
-        errors.push({'attribute': 'project', 'message':  "Project must be provided"});
-      }
-      if(this.isNew() & !this.get('isVirtual')) {
-        if("lotNumber" in attr) {
-          if(window.configuration.metaLot.requireLotNumber && attr.lotNumber == null) {
-             errors.push({'attribute': 'lotNumber', 'message':  "Please fill in Lot Number"});
+
+
+      if (attr.notebookPage != null) {
+        if (nbAndDateReq || (!nbAndDateReq && attr.notebookPage != '')) {
+
+          if (!(/.+/.test(attr.notebookPage))) {
+            errors.push({ attribute: 'notebookPage', message: "Notebook Page must be provided" });
           }
-          if (attr.lotNumber!=null) {
-            if(isNaN(attr.lotNumber) && attr.lotNumber!='') {
-              errors.push({'attribute': 'lotNumber', 'message':  "Lot Number must be an integer"});
+        } else if (attr.notebookPage == '') {
+          attr.notebookPage = null;
+        }
+      }
+      if (attr.synthesisDate != null) {
+        if (nbAndDateReq || (!nbAndDateReq && attr.synthesisDate != '')) {
+          if (!(/^[0-1][0-9]\/[0-3][0-9]\/[0-9]{4}$/.test(attr.synthesisDate))) {
+            errors.push({ attribute: 'synthesisDate', message: "Synthesis Date must be provided and formatted like mm/dd/yyyy" });
+          }
+        } else if (attr.synthesisDate == '') {
+          attr.synthesisDate = null;
+        }
+      }
+
+      if (attr.percentEE != null) {
+        if (isNaN(attr.percentEE) && attr.percentEE != '') {
+          errors.push({ 'attribute': 'percentEE', 'message': "%e.e. must be a number if provided" });
+        }
+      }
+      if (attr.amount != null) {
+        if (isNaN(attr.amount) && attr.amount != '') {
+          errors.push({ 'attribute': 'amount', 'message': "Amount must be a number if provided" });
+        }
+      }
+      if (attr.amount != null && attr.amount != '') {
+        if (attr.amountUnits == null || attr.amountUnits == 'unassigned') {
+          errors.push({ 'attribute': 'amountUnits', 'message': "Amount units must be set if amount set" });
+        }
+      }
+      if (attr.retain != null) {
+        if (isNaN(attr.retain) && attr.retain != '') {
+          errors.push({ 'attribute': 'retain', 'message': "Retain must be a number if provided" });
+        }
+      }
+      if (attr.solutionAmount != null) {
+        if (isNaN(attr.solutionAmount) && attr.solutionAmount != '') {
+          errors.push({ 'attribute': 'solutionAmount', 'message': "Solution Amount must be a number if provided" });
+        }
+      }
+      if (attr.solutionAmount != null && attr.solutionAmount != '') {
+        if (attr.solutionAmountUnits == null || attr.solutionAmountUnits == 'unassigned') {
+          errors.push({ 'attribute': 'solutionAmountUnits', 'message': "Solution amount units must be set if amount set" });
+        }
+      }
+      if (attr.tareWeight != null) {
+        if (isNaN(attr.tareWeight) && attr.tareWeight != '') {
+          errors.push({ 'attribute': 'tareWeight', 'message': "Tare weight must be a number if provided" });
+        }
+      }
+      if (attr.totalAmountStored != null) {
+        if (isNaN(attr.totalAmountStored) && attr.totalAmountStored != '') {
+          errors.push({ 'attribute': 'totalAmountStored', 'message': "Total amount stored must be a number if provided" });
+        }
+      }
+      if (attr.purity != null) {
+        if (isNaN(attr.purity) && attr.purity != '') {
+          errors.push({ 'attribute': 'purity', 'message': "Purity must be a number if provided" });
+        }
+      }
+      if (attr.purity != null && attr.purity != '') {
+        if (attr.purityOperator == null || attr.purityOperator == 'unassigned') {
+          errors.push({ 'attribute': 'purityOperator', 'message': "Purity operator must be set if purity set" });
+        }
+      }
+      if (attr.meltingPoint != null) {
+        if (isNaN(attr.meltingPoint) && attr.meltingPoint != '') {
+          errors.push({ 'attribute': 'meltingPoint', 'message': "MP must be a number if provided" });
+        }
+      }
+      if (attr.boilingPoint != null) {
+        if (isNaN(attr.boilingPoint) && attr.boilingPoint != '') {
+          errors.push({ 'attribute': 'boilingPoint', 'message': "BP must be a number if provided" });
+        }
+      }
+      if (attr.project != null && typeof (attr.project) == 'undefined') {
+        errors.push({ 'attribute': 'project', 'message': "Project must be provided" });
+      }
+      if (this.isNew() & !this.get('isVirtual')) {
+        if ("lotNumber" in attr) {
+          if (window.configuration.metaLot.requireLotNumber && attr.lotNumber == null) {
+            errors.push({ 'attribute': 'lotNumber', 'message': "Please fill in Lot Number" });
+          }
+          if (attr.lotNumber != null) {
+            if (isNaN(attr.lotNumber) && attr.lotNumber != '') {
+              errors.push({ 'attribute': 'lotNumber', 'message': "Lot Number must be an integer" });
             } else {
-              if(attr.lotNumber == 0) {
-                errors.push({'attribute': 'lotNumber', 'message':  "Lot Number 0 is reserved for virtual lots"});
+              if (attr.lotNumber == 0) {
+                errors.push({ 'attribute': 'lotNumber', 'message': "Lot Number 0 is reserved for virtual lots" });
               } else {
                 lotNumbers = this.get('lotNumbers');
-                if(lotNumbers.includes(attr.lotNumber)) {
-                  errors.push({'attribute': 'lotNumber', 'message':  "This lot number is already taken by one of the lots for this compound "+lotNumbers.join(',')});
+                if (lotNumbers.includes(attr.lotNumber)) {
+                  errors.push({ 'attribute': 'lotNumber', 'message': "This lot number is already taken by one of the lots for this compound " + lotNumbers.join(',') });
                 }
                 // Example validation for some maximum maxAutoLotNumber set on the model (see Lot model above and LotController.getNextAutoLot)
                 //  else {
@@ -218,179 +218,179 @@ $(function() {
           }
         }
       }
-      if (errors.length > 0) {return errors;}
+      if (errors.length > 0) { return errors; }
     }
   });
-  
+
   window.LotController = LotController_Abstract.extend({
     template: _.template($('#LotForm_LotView_Labsynch_template').html()),
-    
+
     defaults: {
       readyForRender: false
     },
-    events: function(){
-        return _.extend({},LotController_Abstract.prototype.events,{
-          'click .insertNextAutoLotNumberButton': 'handleInsertNextAutoLotNumberButtonClicked'
-        })
-    },      
-    initialize: function() {
+    events: function () {
+      return _.extend({}, LotController_Abstract.prototype.events, {
+        'click .insertNextAutoLotNumberButton': 'handleInsertNextAutoLotNumberButtonClicked'
+      })
+    },
+    initialize: function () {
       LotController_Abstract.prototype.initialize.apply(this, arguments);
       this.requireLotNumber = false
       this.autoPopulateNextLotNumber = false
       this.allowManualLotNumber = false
-      if(typeof window.configuration.metaLot.requireLotNumber !== "undefined" && window.configuration.metaLot.requireLotNumber !== null) {
-      	this.requireLotNumber = window.configuration.metaLot.requireLotNumber
+      if (typeof window.configuration.metaLot.requireLotNumber !== "undefined" && window.configuration.metaLot.requireLotNumber !== null) {
+        this.requireLotNumber = window.configuration.metaLot.requireLotNumber
       }
-      if(typeof window.configuration.metaLot.autoPopulateNextLotNumber !== "undefined" && window.configuration.metaLot.autoPopulateNextLotNumber !== null) {
-      	this.autoPopulateNextLotNumber = window.configuration.metaLot.autoPopulateNextLotNumber
+      if (typeof window.configuration.metaLot.autoPopulateNextLotNumber !== "undefined" && window.configuration.metaLot.autoPopulateNextLotNumber !== null) {
+        this.autoPopulateNextLotNumber = window.configuration.metaLot.autoPopulateNextLotNumber
       }
-      if(typeof window.configuration.metaLot.allowManualLotNumber !== "undefined" && window.configuration.metaLot.allowManualLotNumber !== null) {
-      	this.allowManualLotNumber = window.configuration.metaLot.allowManualLotNumber
+      if (typeof window.configuration.metaLot.allowManualLotNumber !== "undefined" && window.configuration.metaLot.allowManualLotNumber !== null) {
+        this.allowManualLotNumber = window.configuration.metaLot.allowManualLotNumber
       }
-      if(this.requireLotNumber && !this.autoPopulateNextLotNumber && !this.allowManualLotNumber) {
-      	alert("Server configuration error, metaLot.requireLotNumber is true but both metaLot.autoPopulateNextLotNumber and metaLot.allowManualLotNumber are set to false.  Either set metaLot.requireLotNumber to false or set one of the other properties to true")
+      if (this.requireLotNumber && !this.autoPopulateNextLotNumber && !this.allowManualLotNumber) {
+        alert("Server configuration error, metaLot.requireLotNumber is true but both metaLot.autoPopulateNextLotNumber and metaLot.allowManualLotNumber are set to false.  Either set metaLot.requireLotNumber to false or set one of the other properties to true")
       }
-      
-      if(this.model.isNew()) {
-        if(this.autoPopulateNextLotNumber | this.allowManualLotNumber | this.requireLotNumber) {
+
+      if (this.model.isNew()) {
+        if (this.autoPopulateNextLotNumber | this.allowManualLotNumber | this.requireLotNumber) {
           _.bindAll(this, 'handleLotNumbersPopulated');
           this.model.bind('change:lotNumbers', this.handleLotNumbersPopulated);
           this.populateModelWithCurrentLotNumbers();
 
-        }  else {
+        } else {
           this.triggerReadyForRender()
         }
       } else {
         this.triggerReadyForRender()
       }
     },
-    render: function() {
+    render: function () {
       this.model.set({
-                saved: !this.model.isNew(),
-                allowManualLotNumber: this.allowManualLotNumber
-            }, {silent:true});
+        saved: !this.model.isNew(),
+        allowManualLotNumber: this.allowManualLotNumber
+      }, { silent: true });
       $(this.el).html(this.template(this.model.toJSON()));
-      this.model.unset('saved', {silent:true});
+      this.model.unset('saved', { silent: true });
 
-            if (this.model.get('lotMolWeight') != null) {
-                this.$('.lotMolWeight').val(
-                    parseFloat(this.model.get('lotMolWeight')).toFixed(2)
-                );
-            }
+      if (this.model.get('lotMolWeight') != null) {
+        this.$('.lotMolWeight').val(
+          parseFloat(this.model.get('lotMolWeight')).toFixed(2)
+        );
+      }
 
-            this.chemistCodeController = 
-                this.setupCodeController('chemist', 'scientists', 'chemist');
-            this.projectCodeController = 
-                this.setupCodeController('project', 'projects', 'project');
+      this.chemistCodeController =
+        this.setupCodeController('chemist', 'scientists', 'chemist');
+      this.projectCodeController =
+        this.setupCodeController('project', 'projects', 'project');
 
-            if(!this.model.get('isVirtual')) {
-                // setup selects
-                this.physicalStateCodeController = 
-                    this.setupCodeController('physicalStateCode', 'physicalStates', 'physicalState');
-                this.physicalStateCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select State"
-                  })
-                this.vendorCodeController = 
-                    this.setupCodeController('vendorCode', 'vendors', 'vendor');
-                this.vendorCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Vendor"
-                  })
-                this.operatorCodeController =
-                    this.setupCodeController('purityOperatorCode', 'operators', 'purityOperator');
-                this.operatorCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Units"
-                  })
-                this.amountUnitsCodeController =
-                    this.setupCodeController('amountUnitsCode', 'units', 'amountUnits');
-                this.amountUnitsCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Units"
-                  })
-                this.retainUnitsCodeController =
-                    this.setupCodeController('retainUnitsCode', 'units', 'retainUnits');
-                this.retainUnitsCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Units"
-                  })
-                this.solutionAmountUnitsCodeController =
-                    this.setupCodeController('solutionAmountUnitsCode', 'solutionUnits', 'solutionAmountUnits');
-                this.solutionAmountUnitsCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Units"
-                  })
-                this.tareWeightUnitsCodeController =
-                    this.setupCodeController('tareWeightUnitsCode', 'units', 'tareWeightUnits');
-                this.tareWeightUnitsCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Units"
-                  })
-                this.totalAmountStoredUnitsCodeController =
-                    this.setupCodeController('totalAmountStoredUnitsCode', 'units', 'totalAmountStoredUnits');
-                this.totalAmountStoredUnitsCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Units"
-                  })
-                this.purityMeasuredByCodeController =
-                    this.setupCodeController('purityMeasuredByCode', 'purityMeasuredBys', 'purityMeasuredBy');
-                this.purityMeasuredByCodeController.insertFirstOption = new PickList({
-                    code: "unassigned",
-                    name: "Select Method"
-                  })
+      if (!this.model.get('isVirtual')) {
+        // setup selects
+        this.physicalStateCodeController =
+          this.setupCodeController('physicalStateCode', 'physicalStates', 'physicalState');
+        this.physicalStateCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select State"
+        })
+        this.vendorCodeController =
+          this.setupCodeController('vendorCode', 'vendors', 'vendor');
+        this.vendorCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Vendor"
+        })
+        this.operatorCodeController =
+          this.setupCodeController('purityOperatorCode', 'operators', 'purityOperator');
+        this.operatorCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Units"
+        })
+        this.amountUnitsCodeController =
+          this.setupCodeController('amountUnitsCode', 'units', 'amountUnits');
+        this.amountUnitsCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Units"
+        })
+        this.retainUnitsCodeController =
+          this.setupCodeController('retainUnitsCode', 'units', 'retainUnits');
+        this.retainUnitsCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Units"
+        })
+        this.solutionAmountUnitsCodeController =
+          this.setupCodeController('solutionAmountUnitsCode', 'solutionUnits', 'solutionAmountUnits');
+        this.solutionAmountUnitsCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Units"
+        })
+        this.tareWeightUnitsCodeController =
+          this.setupCodeController('tareWeightUnitsCode', 'units', 'tareWeightUnits');
+        this.tareWeightUnitsCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Units"
+        })
+        this.totalAmountStoredUnitsCodeController =
+          this.setupCodeController('totalAmountStoredUnitsCode', 'units', 'totalAmountStoredUnits');
+        this.totalAmountStoredUnitsCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Units"
+        })
+        this.purityMeasuredByCodeController =
+          this.setupCodeController('purityMeasuredByCode', 'purityMeasuredBys', 'purityMeasuredBy');
+        this.purityMeasuredByCodeController.insertFirstOption = new PickList({
+          code: "unassigned",
+          name: "Select Method"
+        })
 
-                if (window.configuration.metaLot.showTareWeight) {
-                    this.$('.bv_tareWeightContainer').show();
-          } else {
-            this.$('.bv_tareWeightContainer').hide();
-          }
-                if (window.configuration.metaLot.showTotalAmountStored) {
-                    this.$('.bv_totalAmountStoredContainer').show();
-          } else {
-            this.$('.bv_totalAmountStoredContainer').hide();
-          }
+        if (window.configuration.metaLot.showTareWeight) {
+          this.$('.bv_tareWeightContainer').show();
+        } else {
+          this.$('.bv_tareWeightContainer').hide();
+        }
+        if (window.configuration.metaLot.showTotalAmountStored) {
+          this.$('.bv_totalAmountStoredContainer').show();
+        } else {
+          this.$('.bv_totalAmountStoredContainer').hide();
+        }
 
-                this.fileListRenderer = new FileRenderer(this.model.get('fileList'));
-                this.$('.analyticalFiles').append(this.fileListRenderer.el);
-                $(this.el).append(this.fileUploadController.el);
-            } else {
-                this.$('.notForVirtual').hide();
-//                this.$('.notForVirtual2').hide();
-//                this.$('.notForVirtual3').hide();
-            }
-            
-            if(this.model.isNew()) {
-                this.$('.synthesisDate').datepicker( );
-                this.$('.synthesisDate').datepicker( "option", "dateFormat", "mm/dd/yy" );
-                this.$('.editAnalyticalFiles').hide();
-                this.$('.analyticalFiles').html('Add analytical files by editing lot after it is saved');
-                if(!this.model.get('isVirtual') & this.autoPopulateNextLotNumber) {
-                  this.fillNextAutoLot();
-                }
-            } else {
-              if (window.configuration.metaLot.showLotInventory) {
-                this.$('.amountWrapper').hide();
-                this.$('.barcodeWrapper').hide();
-              }
-            }
+        this.fileListRenderer = new FileRenderer(this.model.get('fileList'));
+        this.$('.analyticalFiles').append(this.fileListRenderer.el);
+        $(this.el).append(this.fileUploadController.el);
+      } else {
+        this.$('.notForVirtual').hide();
+        //                this.$('.notForVirtual2').hide();
+        //                this.$('.notForVirtual3').hide();
+      }
+
+      if (this.model.isNew()) {
+        this.$('.synthesisDate').datepicker();
+        this.$('.synthesisDate').datepicker("option", "dateFormat", "mm/dd/yy");
+        this.$('.editAnalyticalFiles').hide();
+        this.$('.analyticalFiles').html('Add analytical files by editing lot after it is saved');
+        if (!this.model.get('isVirtual') & this.autoPopulateNextLotNumber) {
+          this.fillNextAutoLot();
+        }
+      } else {
+        if (window.configuration.metaLot.showLotInventory) {
+          this.$('.amountWrapper').hide();
+          this.$('.barcodeWrapper').hide();
+        }
+      }
       return this;
     },
-    triggerReadyForRender: function() {
+    triggerReadyForRender: function () {
       this.readyForRender = true
       this.trigger('readyForRender')
     },
-    fillNextAutoLot: function() {
-      this.model.set({nextAutoLot: this.getNextAutoLot()});
+    fillNextAutoLot: function () {
+      this.model.set({ nextAutoLot: this.getNextAutoLot() });
       this.$('.lotNumber').val(this.getNextAutoLot());
     },
-    getNextAutoLot: function() {
+    getNextAutoLot: function () {
       var nextAutoLot = 1
-      if(this.model.get("parent") != null && this.model.get("parent").get("corpName") != null && this.model.get("parent").get("corpName") != "") {
+      if (this.model.get("parent") != null && this.model.get("parent").get("corpName") != null && this.model.get("parent").get("corpName") != "") {
         lotNumbers = this.model.get('lotNumbers')
 
-        if(lotNumbers.length > 0) {
-          nextAutoLot = Math.max.apply(Math, lotNumbers)+1;
+        if (lotNumbers.length > 0) {
+          nextAutoLot = Math.max.apply(Math, lotNumbers) + 1;
         }
         // Example of setting nextAutoLot by excluding numbers over some maximum maxAutoLotNumber (see Lot model above and Lot validation)
         // lotNumbersLessThanMaxAuto = lotNumbers.filter(function(x){return x <= this.model.get('maxAutoLotNumber')})
@@ -398,19 +398,19 @@ $(function() {
         //   nextAutoLot = Math.max.apply(Math, lotNumbersLessThanMaxAuto)+1;
         // }
       }
-      return(nextAutoLot)
+      return (nextAutoLot)
     },
     handleInsertNextAutoLotNumberButtonClicked: function () {
       this.fillNextAutoLot()
     },
-    handleLotNumbersPopulated: function() {
+    handleLotNumbersPopulated: function () {
       this.triggerReadyForRender();
     },
-    populateModelWithCurrentLotNumbers: function() {
+    populateModelWithCurrentLotNumbers: function () {
       lotNumbers = [];
       model = this.model
-      if(this.model.get("parent") != null && this.model.get("parent").get("corpName") != null && this.model.get("parent").get("corpName") != "") {
-        var url = window.configuration.serverConnection.baseServerURL+"parentLot/getLotsByParent?parentCorpName="+this.model.get("parent").get("corpName")+"&with=fullobject";
+      if (this.model.get("parent") != null && this.model.get("parent").get("corpName") != null && this.model.get("parent").get("corpName") != "") {
+        var url = window.configuration.serverConnection.baseServerURL + "parentLot/getLotsByParent?parentCorpName=" + this.model.get("parent").get("corpName") + "&with=fullobject";
         $.ajax({
           type: "GET",
           url: url,
@@ -423,7 +423,7 @@ $(function() {
               lotNumbers: lotNumbers
             })
           },
-          error: function(error) {
+          error: function (error) {
             model.set({
               lotNumbers: lotNumbers
             })
@@ -435,135 +435,135 @@ $(function() {
         })
       }
     },
-    updateModel: function() {
-      if (this.projectCodeController.collection.length == 0){
+    updateModel: function () {
+      if (this.projectCodeController.collection.length == 0) {
         alert('System Configuration Error: There must be at least one project to proceed')
       }
       this.clearValidationErrors();
-            
-            if (this.model.isNew() ) {
-                this.model.set({
-                    notebookPage: jQuery.trim(this.$('.notebookPage').val()),
-                    synthesisDate: jQuery.trim(this.$('.synthesisDate').val()),
-                    chemist: this.chemistCodeController.getSelectedModel(),
-                    lotNumber:
-                      (jQuery.trim(this.$('.lotNumber').val())=='') ? null :
-                            parseInt(jQuery.trim(this.$('.lotNumber').val()))
 
-                  });
-            }
- 
-            if(this.model.get('isVirtual')) {
-                this.model.set({
-                    supplier: '',
-                    supplierID: '',
-                    percentEE: null,
-                    comments: '',
-                    color: '',
-                    amount: null,
-                    barcode: null,
-                    purity: null,
-                    vendorID: null,
-                    physicalState: null,
-                    purityOperator: null,
-                    amountUnits: null,
-                    purityMeasuredBy: null,
-                    project: this.projectCodeController.getSelectedModel(),
-                    supplierLot: '',
-                    meltingPoint: null,
-                    boilingPoint: null,
-                    retain: null,
-                    retainUnits: null,
-                    solutionAmount: null,
-                    solutionAmountUnits: null,
-                    tareWeight: null,
-                    tareWeightUnits: null,
-                    totalAmountStored: null,
-                    totalAmountStoredUnits: null,
-                    vendor: null,
-                    vendorID: null
-                });
-            } else {
-              //set unselected properties to null
-              
-              var physicalState;
-              if (this.physicalStateCodeController.getSelectedModel().isNew()) physicalState = null;
-              else physicalState = this.physicalStateCodeController.getSelectedModel();
-                var amountUnits; 
-              if (this.amountUnitsCodeController.getSelectedModel().isNew()) amountUnits = null;
-              else amountUnits = this.amountUnitsCodeController.getSelectedModel();
-                var retainUnits; 
-              if (this.retainUnitsCodeController.getSelectedModel().isNew()) retainUnits = null;
-              else retainUnits = this.retainUnitsCodeController.getSelectedModel();
-                var solutionAmountUnits; 
-              if (this.solutionAmountUnitsCodeController.getSelectedModel().isNew()) solutionAmountUnits = null;
-              else solutionAmountUnits = this.solutionAmountUnitsCodeController.getSelectedModel();
-                var tareWeightUnits; 
-              if (this.tareWeightUnitsCodeController.getSelectedModel().isNew()) tareWeightUnits = null;
-              else tareWeightUnits = this.tareWeightUnitsCodeController.getSelectedModel();
-                var totalAmountStoredUnits; 
-              if (this.totalAmountStoredUnitsCodeController.getSelectedModel().isNew()) totalAmountStoredUnits = null;
-              else totalAmountStoredUnits = this.totalAmountStoredUnitsCodeController.getSelectedModel();
-                var purityMeasuredBy; 
-              if (this.purityMeasuredByCodeController.getSelectedModel().isNew()) purityMeasuredBy = null;
-              else purityMeasuredBy = this.purityMeasuredByCodeController.getSelectedModel();
-                var vendor;
-              var purityOperator; 
-              if (this.operatorCodeController.getSelectedModel().isNew()) purityOperator = null;
-              else purityOperator = this.operatorCodeController.getSelectedModel();
-              if (this.vendorCodeController.getSelectedModel().isNew()) vendor = null;
-              else vendor = this.vendorCodeController.getSelectedModel();
-                this.model.set({
-                    supplier: jQuery.trim(this.$('.supplier').val()),
-                    supplierID: jQuery.trim(this.$('.supplierID').val()),
-                    percentEE: 
-                        (jQuery.trim(this.$('.percentEE').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.percentEE').val())),
-                    comments: jQuery.trim(this.$('.comments').val()),
-                    color: jQuery.trim(this.$('.color').val()),
-                    amount: 
-                        (jQuery.trim(this.$('.amount').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.amount').val())),
-                    barcode: (jQuery.trim(this.$('.barcode').val())=='') ? null : jQuery.trim(this.$('.barcode').val()),
-                    retain:
-                        (jQuery.trim(this.$('.retain').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.retain').val())),
-                    solutionAmount:
-                        (jQuery.trim(this.$('.solutionAmount').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.solutionAmount').val())),
-                    tareWeight:
-                        (jQuery.trim(this.$('.tareWeight').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.tareWeight').val())),
-                    totalAmountStored:
-                        (jQuery.trim(this.$('.totalAmountStored').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.totalAmountStored').val())),
-                    purity:
-                        (jQuery.trim(this.$('.purity').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.purity').val())),
-                    vendorID: jQuery.trim(this.$('.vendorID').val()),
-                    physicalState: physicalState,
-                    purityOperator: purityOperator,
-                    amountUnits: amountUnits,
-                    retainUnits: retainUnits,
-                    solutionAmountUnits: solutionAmountUnits,
-                    tareWeightUnits: tareWeightUnits,
-                    totalAmountStoredUnits: totalAmountStoredUnits,
-                    purityMeasuredBy: purityMeasuredBy,
-                    chemist: this.chemistCodeController.getSelectedModel(),
-                    project: this.projectCodeController.getSelectedModel(),
-                    vendor: vendor,
-                    supplierLot: jQuery.trim(this.$('.supplierLot').val()),
-                    meltingPoint: 
-                        (jQuery.trim(this.$('.meltingPoint').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.meltingPoint').val())),
-                    boilingPoint: 
-                        (jQuery.trim(this.$('.boilingPoint').val())=='') ? null :
-                        parseFloat(jQuery.trim(this.$('.boilingPoint').val()))
-                });
-            }
+      if (this.model.isNew()) {
+        this.model.set({
+          notebookPage: jQuery.trim(this.$('.notebookPage').val()),
+          synthesisDate: jQuery.trim(this.$('.synthesisDate').val()),
+          chemist: this.chemistCodeController.getSelectedModel(),
+          lotNumber:
+            (jQuery.trim(this.$('.lotNumber').val()) == '') ? null :
+              parseInt(jQuery.trim(this.$('.lotNumber').val()))
+
+        });
+      }
+
+      if (this.model.get('isVirtual')) {
+        this.model.set({
+          supplier: '',
+          supplierID: '',
+          percentEE: null,
+          comments: '',
+          color: '',
+          amount: null,
+          barcode: null,
+          purity: null,
+          vendorID: null,
+          physicalState: null,
+          purityOperator: null,
+          amountUnits: null,
+          purityMeasuredBy: null,
+          project: this.projectCodeController.getSelectedModel(),
+          supplierLot: '',
+          meltingPoint: null,
+          boilingPoint: null,
+          retain: null,
+          retainUnits: null,
+          solutionAmount: null,
+          solutionAmountUnits: null,
+          tareWeight: null,
+          tareWeightUnits: null,
+          totalAmountStored: null,
+          totalAmountStoredUnits: null,
+          vendor: null,
+          vendorID: null
+        });
+      } else {
+        //set unselected properties to null
+
+        var physicalState;
+        if (this.physicalStateCodeController.getSelectedModel().isNew()) physicalState = null;
+        else physicalState = this.physicalStateCodeController.getSelectedModel();
+        var amountUnits;
+        if (this.amountUnitsCodeController.getSelectedModel().isNew()) amountUnits = null;
+        else amountUnits = this.amountUnitsCodeController.getSelectedModel();
+        var retainUnits;
+        if (this.retainUnitsCodeController.getSelectedModel().isNew()) retainUnits = null;
+        else retainUnits = this.retainUnitsCodeController.getSelectedModel();
+        var solutionAmountUnits;
+        if (this.solutionAmountUnitsCodeController.getSelectedModel().isNew()) solutionAmountUnits = null;
+        else solutionAmountUnits = this.solutionAmountUnitsCodeController.getSelectedModel();
+        var tareWeightUnits;
+        if (this.tareWeightUnitsCodeController.getSelectedModel().isNew()) tareWeightUnits = null;
+        else tareWeightUnits = this.tareWeightUnitsCodeController.getSelectedModel();
+        var totalAmountStoredUnits;
+        if (this.totalAmountStoredUnitsCodeController.getSelectedModel().isNew()) totalAmountStoredUnits = null;
+        else totalAmountStoredUnits = this.totalAmountStoredUnitsCodeController.getSelectedModel();
+        var purityMeasuredBy;
+        if (this.purityMeasuredByCodeController.getSelectedModel().isNew()) purityMeasuredBy = null;
+        else purityMeasuredBy = this.purityMeasuredByCodeController.getSelectedModel();
+        var vendor;
+        var purityOperator;
+        if (this.operatorCodeController.getSelectedModel().isNew()) purityOperator = null;
+        else purityOperator = this.operatorCodeController.getSelectedModel();
+        if (this.vendorCodeController.getSelectedModel().isNew()) vendor = null;
+        else vendor = this.vendorCodeController.getSelectedModel();
+        this.model.set({
+          supplier: jQuery.trim(this.$('.supplier').val()),
+          supplierID: jQuery.trim(this.$('.supplierID').val()),
+          percentEE:
+            (jQuery.trim(this.$('.percentEE').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.percentEE').val())),
+          comments: jQuery.trim(this.$('.comments').val()),
+          color: jQuery.trim(this.$('.color').val()),
+          amount:
+            (jQuery.trim(this.$('.amount').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.amount').val())),
+          barcode: (jQuery.trim(this.$('.barcode').val()) == '') ? null : jQuery.trim(this.$('.barcode').val()),
+          retain:
+            (jQuery.trim(this.$('.retain').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.retain').val())),
+          solutionAmount:
+            (jQuery.trim(this.$('.solutionAmount').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.solutionAmount').val())),
+          tareWeight:
+            (jQuery.trim(this.$('.tareWeight').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.tareWeight').val())),
+          totalAmountStored:
+            (jQuery.trim(this.$('.totalAmountStored').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.totalAmountStored').val())),
+          purity:
+            (jQuery.trim(this.$('.purity').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.purity').val())),
+          vendorID: jQuery.trim(this.$('.vendorID').val()),
+          physicalState: physicalState,
+          purityOperator: purityOperator,
+          amountUnits: amountUnits,
+          retainUnits: retainUnits,
+          solutionAmountUnits: solutionAmountUnits,
+          tareWeightUnits: tareWeightUnits,
+          totalAmountStoredUnits: totalAmountStoredUnits,
+          purityMeasuredBy: purityMeasuredBy,
+          chemist: this.chemistCodeController.getSelectedModel(),
+          project: this.projectCodeController.getSelectedModel(),
+          vendor: vendor,
+          supplierLot: jQuery.trim(this.$('.supplierLot').val()),
+          meltingPoint:
+            (jQuery.trim(this.$('.meltingPoint').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.meltingPoint').val())),
+          boilingPoint:
+            (jQuery.trim(this.$('.boilingPoint').val()) == '') ? null :
+              parseFloat(jQuery.trim(this.$('.boilingPoint').val()))
+        });
+      }
     }
-      
+
   });
-  
-  
+
+
 });

--- a/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
+++ b/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
@@ -1,8 +1,8 @@
 <script type="text/template" id="LotForm_ParentView_template">
 
     <div class="radioWrapper">
-        <input type="radio" name="regPick" class="regPick" ></input>
-        <label>New <span class="lotOrBatch"></span> <span class="corpName"></span></label>
+        <input id="newLot" type="radio" name="regPick" class="regPick" ></input>
+        <label for="newLot">New <span class="lotOrBatch"></span> <span class="corpName"></span></label>
         <select class="FormInput saltFormCorpNames"></select>
     </div>
 

--- a/modules/CmpdReg/src/client/templates/RegSearchResults/RegSearchResultsView.inc
+++ b/modules/CmpdReg/src/client/templates/RegSearchResults/RegSearchResultsView.inc
@@ -8,8 +8,8 @@
             </div>
 		</div>
         <div class="row2">
-            <input type="radio" name="regPick" class="regPick" value="new"  checked="checked" />
-            <label class="FormLabel">Register new structure</label>
+            <input id="registerNew" type="radio" name="regPick" class="regPick" value="new"  checked="checked" />
+            <label for="registerNew" class="FormLabel">Register new structure</label>
         </div>
         <div class="row1 isVirtualContainer">
             <input type="checkbox" class="isVirtual" />


### PR DESCRIPTION
## Description
 - First commit was to run an auto format on LotCustom.js, the file was badly formatted (mixed indentation).
 - Fixed issue with template escape on safe variable evaluation
 - Fixed unrelated annoying issue where you click on a radio label and it doesn't select the radio button
 - 

## Related Issue
Fixes #926 

## How Has This Been Tested?

**Default behavior:**
 - Verified default behavior unchanged (no editing lot numbers, auto lot number not filled, auto assigned by backend service).

**autoPopulateNextLotNumber = true**
 - Verified UI fills the next lot number (highest saved lot + 1)
 - Verified new compounds still get lot 1 as default

**autoPopulateNextLotNumber = true, maxAutoLotNumber=999**
 - Verified same behavior as **autoPopulateNextLotNumber = true**
 - Verified that if I add a lot 1000 the next auto lot is not 1001 but rather the highest lot + 1 for lots <= 999 (i.e. 999 is the maximum assigned auto lot.
 
**allowManualLotNumber = true, autoPopulateNextLotNumber = true, maxAutoLotNumber=999**
  - Verified same behavior as **autoPopulateNextLotNumber = true, maxAutoLotNumber=999**
  - Verified I cannot assign a lot number = another already registered lot number.
  - Verified that if I try to manually set a number less than maxAutoLotNumber, then I get an error that I must assign a number > 999 and not any of the previously assigned lot numbers.