### PR TITLE
Prepare Config files should override the order of configs using the order of config files readings

### DIFF
--- a/modules/BuildUtilities/src/server/PrepareConfigFiles.coffee
+++ b/modules/BuildUtilities/src/server/PrepareConfigFiles.coffee
@@ -182,7 +182,14 @@ getProperties = (configDir) =>
 	allConf = []
 	for configFile in configFiles
 		console.info "reading conf file: #{configFile}"
-		allConf = _.extend allConf, propertiesParser.read(configFile)
+		conf = propertiesParser.read(configFile)
+		# Fill overwrite allConf with conf keeping conf variables at the bottom
+		# It's important that overwritten configs get moved to the bottom of the list
+		# as the variable interpolation is done in the order of the list
+		for key in Object.keys(conf)
+			if allConf[key] != undefined
+				delete allConf[key]
+			allConf[key] = conf[key]
 		console.info "read conf file: #{configFile}"
 
 	configString = ""


### PR DESCRIPTION
## Description
When overriding configs, delete key and add it back to the object rather than just replacing in place. This moves the key to the bottom and allows for interpolation

## Related Issue
Fixes #930

## How Has This Been Tested?
Added a zzz config like:

```
deployName=blahblah
client.cmpdreg.clientUILabels.applicationNameForTitleBar=${deployName}
```
Verified prepared config files worked instead of erorring
I printed the entire config before parsing and made sure `client.cmpdreg.clientUILabels.applicationNameForTitleBar=${deployName}` was moved to the bottom before ACAS tried to do interpolation. 
I verified that `client.cmpdreg.clientUILabels.applicationNameForTitleBar=blahblah` was set in the final configuration file.