### PR TITLE
output verbose output when running acasclient tests during GitHub Actions builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -87,7 +87,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install ./acasclient
       - name: Run tests
-        run: python -m unittest discover -s ./acasclient -p "test_*.py"
+        run: python -m unittest discover -s ./acasclient -p "test_*.py" -v
       - name: Build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
## Description
Added `-v` argument to python unittest command

## Related Issue
Fixes #935

## How Has This Been Tested?
Ran GitHub Actions and verified updated output during tests

Before:
<img width="892" alt="Screen Shot 2022-04-22 at 3 59 57 PM" src="https://user-images.githubusercontent.com/868119/164815264-cb6328c7-6429-4427-99b5-bec31042c627.png">


After:
<img width="934" alt="Screen Shot 2022-04-22 at 3 58 51 PM" src="https://user-images.githubusercontent.com/868119/164815209-352767b1-a9a5-4817-82d9-fdb57e459f14.png">

