### PR TITLE
Allow SEL upload w/ parent alias values within lot corp name

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -334,6 +334,7 @@ server.service.external.report.registration.url=
 server.service.external.user.authentication.url=
 server.service.external.user.information.url=
 server.service.external.logging.url=
+server.service.external.preferred.batchid.allowParentAliasLotNames=true
 
 # Required if using Spotfire
 client.service.spotfire.host=

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -559,9 +559,16 @@ validateCalculatedResults <- function(calculatedResults, dryRun, curveNames, tes
       }
     } else {
       for (row in 1:nrow(newBatchIds)) {
+        NOT_REGISTERED_MESSAGE <- paste0(mainCode, " '", newBatchIds$Requested.Name[row],
+                          "' has not been registered in the system.")
+        
+        # TODO: Put this behind the unique alias config when we add it to ACAS
+        if(applicationSettings$server.service.external.preferred.batchid.allowParentAliasLotNames && mainCode == "Corporate Batch ID") {
+          NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " If the ", mainCode, " is a Parent Alias Lot Name it may also mean that the Parent Alias is referenced by zero or multiple Parents.")
+        }
+        NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " Contact your system administrator for help." )
         if (is.null(newBatchIds$Reference.Code[row]) || is.na(newBatchIds$Reference.Code[row]) || newBatchIds$Reference.Code[row] == "") {
-          addError(paste0(mainCode, " '", newBatchIds$Requested.Name[row],
-                          "' has not been registered in the system. Contact your system administrator for help."))
+          addError(NOT_REGISTERED_MESSAGE)
         } else if (as.character(newBatchIds$Requested.Name[row]) != as.character(newBatchIds$Reference.Code[row])) {
           if (mainCode == "Corporate Batch ID" || inputFormat == "Gene ID Data") {
             warnUser(paste0("A ", mainCode, " that you entered, '", newBatchIds$Requested.Name[row],

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -563,7 +563,7 @@ validateCalculatedResults <- function(calculatedResults, dryRun, curveNames, tes
                           "' has not been registered in the system.")
         
         # TODO: Put this behind the unique alias config when we add it to ACAS
-        if(applicationSettings$server.service.external.preferred.batchid.allowParentAliasLotNames && mainCode == "Corporate Batch ID") {
+        if(applicationSettings$client.cmpdreg.metaLot.allowDuplicateParentAliases && applicationSettings$server.service.external.preferred.batchid.allowParentAliasLotNames && mainCode == "Corporate Batch ID") {
           NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " If the ", mainCode, " uses a Parent Alias Lot Name, please double-check that alias is registered to one and only one Parent.")
         }
         NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " Contact your system administrator for help." )

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -564,7 +564,7 @@ validateCalculatedResults <- function(calculatedResults, dryRun, curveNames, tes
         
         # TODO: Put this behind the unique alias config when we add it to ACAS
         if(applicationSettings$server.service.external.preferred.batchid.allowParentAliasLotNames && mainCode == "Corporate Batch ID") {
-          NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " If the ", mainCode, " is a Parent Alias Lot Name it may also mean that the Parent Alias is referenced by zero or multiple Parents.")
+          NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " If the ", mainCode, " uses a Parent Alias Lot Name, please double-check that alias is registered to one and only one Parent.")
         }
         NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " Contact your system administrator for help." )
         if (is.null(newBatchIds$Reference.Code[row]) || is.na(newBatchIds$Reference.Code[row]) || newBatchIds$Reference.Code[row] == "") {

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -562,7 +562,6 @@ validateCalculatedResults <- function(calculatedResults, dryRun, curveNames, tes
         NOT_REGISTERED_MESSAGE <- paste0(mainCode, " '", newBatchIds$Requested.Name[row],
                           "' has not been registered in the system.")
         
-        # TODO: Put this behind the unique alias config when we add it to ACAS
         if(applicationSettings$client.cmpdreg.metaLot.allowDuplicateParentAliases && applicationSettings$server.service.external.preferred.batchid.allowParentAliasLotNames && mainCode == "Corporate Batch ID") {
           NOT_REGISTERED_MESSAGE <- paste0(NOT_REGISTERED_MESSAGE, " If the ", mainCode, " uses a Parent Alias Lot Name, please double-check that alias is registered to one and only one Parent.")
         }


### PR DESCRIPTION
## Description
Adds a config `server.service.external.preferred.batchid.allowParentAliasLotNames`=true/false for allowing `Parent Alias Lot Names` to be used when requesting `Corporate Batch ID` preferred names in addition to actual  `Lot Corp Name`

`Lot Corp Name` format is defined by:
  - `client.cmpdreg.serverSettings.appendSaltCodeToLotName`= true/`false default` 
  - `client.cmpdreg.serverSettings.corpBatchFormat`= `corp_batch_saltcode` or `corp_saltcode_batch`


By default they are of the form:
 - CMPD-0000001-001
 
If `client.cmpdreg.serverSettings.appendSaltCodeToLotName` is set to true (which is rare), they could look like:
 - if `client.cmpdreg.serverSettings.corpBatchFormat`=`corp_batch_saltcode`
   - CMPD-0000001-001-HCl
 - or `client.cmpdreg.serverSettings.corpBatchFormat`=`corp_saltcode_batch`
   - CMPD-0000001-HCl-001

Additionally, the 3 configs listed here can play a role in how the lot corp names are configured.

```
client.cmpdreg.serverSettings.corpSeparator=-
client.cmpdreg.serverSettings.saltSeparator=
client.cmpdreg.serverSettings.batchSeparator=-
````

A `Parent Alias Lot Name` is formatted the same, except it replace `CMPD-0000001` with a `Parent Alias` e.g.:
 - `Asprin-001`

In order to match a `Parent Alias Lot Name`, the `Parent Alias` must be referenced by one and only one Parent.

## Related Issue
Fixes #942

## How Has This Been Tested?

- When 
  - `server.service.external.preferred.batchid.allowParentAliasLotNames=true`
  - AND
    -  One and only one Parent is found by Parent Alias
<img width="650" alt="Screen Shot 2022-05-06 at 10 45 05 AM" src="https://user-images.githubusercontent.com/868119/167202119-1f128732-faeb-4c80-979f-4d16548f61f4.png">

 - When
   -  `server.service.external.preferred.batchid.allowParentAliasLotNames=true`
   - and
      - Parent Alias is not referenced by any Parents
      - or
      - Parent Alias is referenced by multiple Parents
<img width="626" alt="Screen Shot 2022-05-06 at 11 47 32 AM" src="https://user-images.githubusercontent.com/868119/167202472-69d9c33b-2dbd-4858-82d6-59f3b827058c.png">

When
  - `server.service.external.preferred.batchid.allowParentAliasLotNames=false`
 
<img width="675" alt="Screen Shot 2022-05-06 at 12 14 18 PM" src="https://user-images.githubusercontent.com/868119/167203120-4f933eca-3636-45da-a71f-11ec641d99b0.png">

Verified that lot corp names with no relation to the parent corp name or when salts are appended to the lot corp name, this still works:
Case where salt added:
![Screen Shot 2022-05-10 at 7 39 56 AM](https://user-images.githubusercontent.com/868119/167668195-4cf96ac1-7735-4474-b2e8-100a55da24b7.png)
Manually updated the lot corp name using sql:
`update lot set corp_name = 'BRIANTEST-001' where corp_name =  'CMPD-0000001-002HCl';`
Result:
![Screen Shot 2022-05-10 at 7 41 14 AM](https://user-images.githubusercontent.com/868119/167668244-9eba5319-9245-4e73-87c4-3df366d61557.png)
 

Updated not registered message after PR feedback:
![Screen Shot 2022-05-10 at 8 56 28 AM](https://user-images.githubusercontent.com/868119/167671447-13aeb26b-9898-4ec8-9d96-be821fb94f38.png)

