### PR TITLE
Enhance Open in LD UX Experience 

### DIFF
--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -612,22 +612,8 @@ class ExperimentBrowserController extends Backbone.View
 
 	handleOpenInQueryToolClicked: =>
 		unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
-			if @experimentController.model.get('lsLabels') not instanceof LabelList
-				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-			subclass = @experimentController.model.get('subclass')
-			if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-				if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-				else
-					code = @experimentController.model.get("codeName")
-			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			else
-				code = @experimentController.model.get('codeName')
-
-			window.open("/openExptInQueryTool?experiment=#{code}",'_blank')
+			handleGetLinkQueryToolClicked()
+			window.open(@$('.bv_exptLink'),'_blank')
 
 	handleGetLinkQueryToolClicked: => 
 			# Preparatory Logic to Get Code to Pass to Generate Link Route 

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -679,7 +679,7 @@ class ExperimentBrowserController extends Backbone.View
 	handleCopyLinkClicked: =>
     	link = @$('.bv_exptLink').value
     	if link? # Defined and not null
-        	alert("Link copied to clipboard!")
+			alert("Link copied to clipboard!")
     	else
 			alert("Unable to copy link to clipboard")
 

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -612,8 +612,34 @@ class ExperimentBrowserController extends Backbone.View
 
 	handleOpenInQueryToolClicked: =>
 		unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
-			handleGetLinkQueryToolClicked()
-			window.open(@$('.bv_exptLink'),'_blank')
+			# Preparatory Logic to Get Code to Pass to Generate Link Route 
+			if @experimentController.model.get('lsLabels') not instanceof LabelList
+				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
+			subclass = @experimentController.model.get('subclass')
+			if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
+				if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
+					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+				else
+					code = @experimentController.model.get("codeName")
+			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			else
+				code = @experimentController.model.get('codeName')
+			# Add Generating Link Loading Mask 
+			@$('.bv_generatingLink').show()
+			# Call to Route to Get URL 
+			$.ajax
+				type: 'GET'
+				url: "/getLinkExptQueryTool?experiment=#{code}"
+				success: (response) => 
+					window.open(response,'_blank')
+				error: (err) =>
+					console.log err
+				datatype: 'json'
+			# Take Away Generating Progress Mask 
+			@$('.bv_generatingLink').hide()
 
 	handleGetLinkQueryToolClicked: => 
 			# Preparatory Logic to Get Code to Pass to Generate Link Route 

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -679,7 +679,7 @@ class ExperimentBrowserController extends Backbone.View
 	handleCopyLinkClicked: =>
     	link = @$('.bv_exptLink').value
     	if link? # Defined and not null
-            alert("Link copied to clipboard!")
+        	alert("Link copied to clipboard!")
     	else
 			alert("Unable to copy link to clipboard")
 

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -634,12 +634,14 @@ class ExperimentBrowserController extends Backbone.View
 				type: 'GET'
 				url: "/getLinkExptQueryTool?experiment=#{code}"
 				success: (response) => 
+					# Take Away Generating Progress Mask 
+					@$('.bv_generatingLink').hide()
 					window.open(response,'_blank')
 				error: (err) =>
+					# Take Away Generating Progress Mask 
+					@$('.bv_generatingLink').hide()
 					console.log err
 				datatype: 'json'
-			# Take Away Generating Progress Mask 
-			@$('.bv_generatingLink').hide()
 
 	handleGetLinkQueryToolClicked: => 
 			# Preparatory Logic to Get Code to Pass to Generate Link Route 
@@ -664,18 +666,22 @@ class ExperimentBrowserController extends Backbone.View
 				type: 'GET'
 				url: "/getLinkExptQueryTool?experiment=#{code}"
 				success: (response) => 
+					# Take Away Generating Progress Mask 
+					@$('.bv_generatingLink').hide()
 					@$('.bv_getLinkResults').show()
 					@$('.bv_exptLink').val(response)
 				error: (err) =>
+					# Take Away Generating Progress Mask 
+					@$('.bv_generatingLink').hide()
 					console.log err
 				datatype: 'json'
-			# Take Away Generating Progress Mask 
-			@$('.bv_generatingLink').hide()
 
-	handleCopyLinkClicked: => 
-		@$('.bv_exptLink').select()
-		document.execCommand("copy")
-		alert("Link Copied to Clipboard!")
+	handleCopyLinkClicked: =>
+    	link = @$('.bv_exptLink').value
+    	if link? # Defined and not null
+            alert("Link copied to clipboard!")
+    	else
+			alert("Unable to copy link to clipboard")
 
 	formatOpenInQueryToolButton: =>
 		@$('.bv_viewerOptions').empty()

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -677,10 +677,10 @@ class ExperimentBrowserController extends Backbone.View
 				datatype: 'json'
 
 	handleCopyLinkClicked: =>
-    	link = @$('.bv_exptLink').value
-    	if link? # Defined and not null
+		link = @$('.bv_exptLink').value
+		if link? # Defined and not null
 			alert("Link copied to clipboard!")
-    	else
+		else
 			alert("Unable to copy link to clipboard")
 
 	formatOpenInQueryToolButton: =>

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -346,6 +346,8 @@ class ExperimentBrowserController extends Backbone.View
 		"click .bv_confirmDeleteExperimentButton": "handleConfirmDeleteExperimentClicked"
 		"click .bv_cancelDelete": "handleCancelDeleteClicked"
 		"click .bv_openInQueryToolButton": "handleOpenInQueryToolClicked"
+		"click .bv_getLinkQueryToolButton": "handleGetLinkQueryToolClicked"
+		"click .bv_copyExptLink" : "handleCopyLinkClicked"
 
 	initialize: ->
 		template = _.template( $("#ExperimentBrowserView").html(),  {includeDuplicateAndEdit: @includeDuplicateAndEdit} );
@@ -384,6 +386,7 @@ class ExperimentBrowserController extends Backbone.View
 			$(".bv_experimentTableController").html @experimentSummaryTable.render().el
 
 	selectedExperimentUpdated: (experiment) =>
+		@$('.bv_getLinkResults').hide()
 		@trigger "selectedExperimentUpdated"
 		$.ajax
 			type: 'GET'
@@ -625,6 +628,42 @@ class ExperimentBrowserController extends Backbone.View
 				code = @experimentController.model.get('codeName')
 
 			window.open("/openExptInQueryTool?experiment=#{code}",'_blank')
+
+	handleGetLinkQueryToolClicked: => 
+			# Preparatory Logic to Get Code to Pass to Generate Link Route 
+			if @experimentController.model.get('lsLabels') not instanceof LabelList
+				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
+			subclass = @experimentController.model.get('subclass')
+			if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
+				if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
+					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+				else
+					code = @experimentController.model.get("codeName")
+			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			else
+				code = @experimentController.model.get('codeName')
+			# Add Generating Link Loading Mask 
+			@$('.bv_generatingLink').show()
+			# Call to Route to Get URL 
+			$.ajax
+				type: 'GET'
+				url: "/getLinkExptQueryTool?experiment=#{code}"
+				success: (response) => 
+					@$('.bv_getLinkResults').show()
+					@$('.bv_exptLink').val(response)
+				error: (err) =>
+					console.log err
+				datatype: 'json'
+			# Take Away Generating Progress Mask 
+			@$('.bv_generatingLink').hide()
+
+	handleCopyLinkClicked: => 
+		@$('.bv_exptLink').select()
+		document.execCommand("copy")
+		alert("Link Copied to Clipboard!")
 
 	formatOpenInQueryToolButton: =>
 		@$('.bv_viewerOptions').empty()

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
@@ -163,6 +163,12 @@
 	<!--
 	<h5>Selected Experiment Details</h5>
 	-->
+	<div class="hide bv_generatingLink" style="margin: auto;">
+		<h5>Generating Link...</h5>
+		<div class="progress progress-striped active " style="width: 90%; margin: auto;">
+			<div class="bar" style="width: 100%; margin: auto;"></div>
+		</div>
+	</div>
 	<div class="well well-small bv_experimentBaseControllerContainer hide" style="margin-top: 10px;">
 		<div>
             <button class="btn btn-danger bv_deleteExperiment">Delete</button>
@@ -170,6 +176,18 @@
             <button class="btn bv_duplicateExperiment pull-right hide" style="margin-left: 0.5em;">Duplicate</button>
             <button class="btn bv_editExperiment pull-right">Edit</button>
             <% } %>
+			<span class="btn-group pull-right bv_getLinkQueryTool" style="margin-right:5px;">
+				<button type="button" class="btn btn-default bv_getLinkQueryToolButton">
+					Generate Link
+				</button>
+				<div class="hide bv_getLinkResults" style="margin: auto;">
+					<br>
+					<input type="text" class="bv_exptLink" name="exptLink" value="" readonly style="margin-right:5px;>">
+					<button type="button" class="btn btn-default bv_copyExptLink">
+						Copy Link
+					</button>
+				</div>
+			</span>
 			<!--<button class="btn bv_openInQueryTool pull-right" style="margin-right:5px;">Open in <span class="bv_queryToolDisplayName"></span></button>-->
 			<span class="btn-group pull-right bv_openInQueryTool" style="margin-right:5px;">
 				<button type="button" class="btn btn-default bv_openInQueryToolButton dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/modules/ServerAPI/src/server/routes/GetLinkExptQueryTool.coffee
+++ b/modules/ServerAPI/src/server/routes/GetLinkExptQueryTool.coffee
@@ -1,0 +1,36 @@
+exports.setupRoutes = (app, loginRoutes) ->
+	app.get '/getLinkExptQueryTool', loginRoutes.ensureAuthenticated, exports.getLinkQueryToolForExperiment
+
+
+exports.getLinkQueryToolForExperiment = (req, resp) ->
+	config = require '../conf/compiled/conf.js'
+	tool = req.query.tool
+	if not tool?
+		tool = config.all.client.service.result.viewer.defaultViewer
+		if not tool? 
+			tool = 'LiveDesign'
+	if tool is 'LiveDesign'
+		getLdUrl = require './CreateLiveDesignLiveReportForACAS.js'
+		username = req.session.passport.user.username
+		getLdUrl.getUrlForNewLiveDesignLiveReportForExperimentInternal req.query.experiment, username, (url) ->
+			url = url.replace /(\r\n|\n|\r)/gm,""
+			console.log "generating link: #{url}"
+			resp.status(200).send url
+			# Need to Send This Link Back to UI To Add to Link
+	else if tool is 'Seurat'
+		expRoutes = require './ExperimentServiceRoutes.js'
+		expRoutes.resultViewerURLFromExperimentCodeName req.query.experiment, (err, res) ->
+			if err? or not res.resultViewerURL?
+				resp.status(404).send "Could not get Seurat link"
+			else
+				resp.status(200).send res.resultViewerURL
+	else if tool is 'DataViewer'
+		url = '/dataViewer/filterByExpt/'+req.query.experiment
+		url = url.replace /(\r\n|\n|\r)/gm,""
+		console.log "generating link:  #{url}"
+		resp.status(200).send '/dataViewer/filterByExpt/'+req.query.experiment
+	else if tool is 'CurveCurator'
+		url = '/curveCurator/'+encodeURIComponent(req.query.experiment)
+		resp.status(200).send url
+	else
+		resp.status(500).send('Could not generate any valid links')


### PR DESCRIPTION
Implemented "Generate Link" button and "Copy Link" to clipboard button for experiments alongside the "Open In" button.

## Description

Added a new option that can generate a LR link and shows it to the user in a way that is easy to copy. Also added a "Copy Link" button to enable one-click copying. 

The goal of this is to click "generate link" and then wait for the Live Report link to be generated on the ACAS page instead of having the "Open In LiveDesign" selection take the user to a separate page that takes a long time to load. 

## Related Issue
Information for this can be found under SDGR [ACAS-272](https://jira.schrodinger.com/browse/ACAS-272)

This work also overlaps with [ACAS-277](https://jira.schrodinger.com/browse/ACAS-277). 

## How Has This Been Tested?
This has been tested using a stubbed LD route and LR link 