### PR TITLE
ACAS-35: Fix SEL issue caused by file containing duplicate result type with different data types

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -971,6 +971,19 @@ validateValueKinds <- function(neededValueKinds, neededValueKindTypes, dryRun, r
   if (any(usedReservedWords)) {
     stopUser(paste0(sqliz(reserved[usedReservedWords]), " is reserved and cannot be used as a column header."))
   }
+
+  # Throw errors for duplicate value kinds with different types within the same upload
+  # make a dataframe of kind, type
+  # deduplicate unique combinations of kind, type
+  if (length(neededValueKinds) > 0) {
+    uniqueValueKindTypes = unique(data.frame(neededValueKinds, neededValueKindTypes))
+    # Check if there are any duplicate kinds
+    n_occur <- data.frame(table(uniqueValueKindTypes$neededValueKinds))
+    duplicateValueKinds <- n_occur[n_occur$Freq > 1,]$Var1
+    if (length(duplicateValueKinds) > 0) {
+      stopUser(paste0("The following header(s) are duplicated: ",sqliz(duplicateValueKinds), ". Uploads cannot contain the same result header twice. Please rename the duplicate headers or consolidate the data and try again."))
+    }
+  }
   
   currentValueKindsList <- getAllValueKinds()  
   


### PR DESCRIPTION
## Description
#494 is a known issue that yields no warning, but causes the upload to hard fail within Roo. Fixed this by adding an explicit check in SEL validation that will prevent users from proceeding with files like this.

## Related Issue
#494 

## How Has This Been Tested?
Added acasclient unit test for this issue, confirmed they were failing before this fix, and confirmed tests pass after adding this fix.
See https://github.com/mcneilco/acasclient/pull/54