### PR TITLE
ACAS-84: Update the "Project" field in "Protocol Editor".

### DIFF
--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -360,7 +360,7 @@ class ProtocolBaseController extends BaseEntityController
 			collection: @projectList
 			insertFirstOption: new PickList
 				code: "unassigned"
-				name: "Select Project"
+				name: "Not Restricted"
 			selectedCode: @model.getProjectCode().get('codeValue')
 
 	finishSetupAttachFileListController: (attachFileList, fileTypeList) ->

--- a/modules/ServerAPI/src/client/Protocol.html
+++ b/modules/ServerAPI/src/client/Protocol.html
@@ -56,6 +56,7 @@
                 <label class="control-label bv_projectLabel">Project</label>
                 <div class="controls">
                     <select class="bv_projectCode" style="width:350px;"></select>
+                    <i class="icon-info-sign" style="margin-left:4px;" title="If a project is specified then the protocol can only be used with the specified project."></i>
                 </div>
             </div>
             <div class="control-group bv_group_notebook">


### PR DESCRIPTION
## Description
#### Issue
Default option of the `Project` field on the Protocol Editor page is `Select Project` which when chosen means the protocol is available to all projects and not bound to one project and so the text is not truly reflecting the behaviour.

#### Fix
We change the text from `Select Project` to `Not Restricted` and add an info icon with a tooltip to explain the behaviour.


## How Has This Been Tested?
<img width="769" alt="Protocol_Editor" src="https://user-images.githubusercontent.com/63348593/169299692-85e23b34-1748-427d-8ff3-c53038a3d70c.png">

