### PR TITLE
get meta lot and  post meta lot acls server side checks

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -615,7 +615,7 @@ client.protocol.mainControllerClassName=ProtocolBaseController
 client.experiment.mainControllerClassName=ExperimentBaseController
 
 # Behavior without this config set to true is to give all users access to all projects
-server.project.roles.enable=false
+server.project.roles.enable=true
 
 #Controls whether to try to sync projects list from ACAS to CmpdReg
 server.project.sync.cmpdReg=true
@@ -692,7 +692,7 @@ client.cmpdreg.metaLot.showSelectCompoundTypeList=false
 client.cmpdreg.metaLot.showSelectParentAnnotationList=false
 client.cmpdreg.metaLot.fileSaveDirNamedForBatchName=true
 client.cmpdreg.metaLot.useExactMass=true
-client.cmpdreg.metaLot.useProjectRolesToRestrictLotDetails=false
+client.cmpdreg.metaLot.useProjectRolesToRestrictLotDetails=true
 client.cmpdreg.metaLot.showTareWeight=false
 client.cmpdreg.metaLot.showTotalAmountStored=false
 client.cmpdreg.metaLot.disableAliasEdit=false

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -176,7 +176,7 @@ $(function() {
 			} else {
 				this.lotController.render();
 			}
-		    if (!this.model.get('lot').get("acls").write) {
+		    if (!this.model.isNew() && !this.model.get('lot').get("acls").write) {
 			    this.lotController.disableAll();
 			    this.parentController.setAliasToReadOnly();
 		    } else {
@@ -414,7 +414,7 @@ $(function() {
 	    },
 
 	    saltFormAllowedToUpdate: function () {
-		    if (!this.model.get('lot').get("acls").write) return false;
+		    if (!this.model.get('lot').isNew() && !this.model.get('lot').get("acls").write) return false;
 
 		    if (window.configuration.metaLot.saltBeforeLot && this.model.get('lot').isNew()
 			    && !this.model.get('parent').isNew() && !this.model.get('saltForm').isNew()) {
@@ -430,17 +430,9 @@ $(function() {
 				if (!this.user.get('isAdmin')) return false;
 			}
 			// Further check to see if the parent is editable by checking the metalot allowedToUpdate function
-			if (!this.model.get('lot').get("acls").write) return false;
+			if (!this.model.get('lot').isNew() && !this.model.get('lot').get("acls").write) return false;
 
-			// If we get here, then just check if the lot is new or not
-		    if (this.model.get('lot').isNew()) {
-			    return false;
-		    } else {
-			    return true;
-			}
-
-			// We shouldn't get here but lets disable edit parent by default to be safe
-			return false
+		    return true
 	    }
     });
 });

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -176,7 +176,7 @@ $(function() {
 			} else {
 				this.lotController.render();
 			}
-		    if (!this.allowedToUpdate()) {
+		    if (!this.model.get('lot').get("acls").write) {
 			    this.lotController.disableAll();
 			    this.parentController.setAliasToReadOnly();
 		    } else {
@@ -224,7 +224,7 @@ $(function() {
 			    this.$('.cancelButton').removeClass('cancelImage');
 			    this.$('.cancelButton').addClass('closeImage');
 			    this.$('.backButton').hide();
-			    if (this.allowedToUpdate()) {
+			    if (this.model.get('lot').get("acls").write) {
 				    this.$('.formTitle').html('Edit ' + (lisb ? 'Batch' : 'Lot') + ' ' + this.model.get('lot').get('corpName'));
 			    } else {
 				    this.$('.formTitle').html((lisb ? 'Batch' : 'Lot') + ' Details for ' + this.model.get('lot').get('corpName'));
@@ -234,7 +234,7 @@ $(function() {
 				    this.$('.newLotButton').hide();
 				    this.$('.saveButton').hide();
 			    }
-			    if (!this.allowedToUpdate()) {
+			    if (!this.model.get('lot').get("acls").write) {
 				    this.$('.saveButton').hide();
 			    }
 			    console.log("about to load inventory");
@@ -413,23 +413,8 @@ $(function() {
 
 	    },
 
-	    allowedToUpdate: function () {
-				var chemist = this.model.get('lot').get('chemist').get('selectedCode');
-				var registeredBy = this.model.get('lot').get('registeredBy');
-
-		    if (this.user == null || chemist == null || this.model.get('lot').isNew()) return true; // test mode or new
-
-		    if (this.user.get('isAdmin')) {
-			    return true;
-		    }else if (!window.configuration.metaLot.disableEditMyLots && (this.user.get('code') == chemist || (registeredBy != null && this.user.get('code') == registeredBy))) {
-				return true;
-			} else {
-			    return false;
-		    }
-	    },
-
 	    saltFormAllowedToUpdate: function () {
-		    if (!this.allowedToUpdate()) return false;
+		    if (!this.model.get('lot').get("acls").write) return false;
 
 		    if (window.configuration.metaLot.saltBeforeLot && this.model.get('lot').isNew()
 			    && !this.model.get('parent').isNew() && !this.model.get('saltForm').isNew()) {
@@ -445,7 +430,7 @@ $(function() {
 				if (!this.user.get('isAdmin')) return false;
 			}
 			// Further check to see if the parent is editable by checking the metalot allowedToUpdate function
-			if (!this.allowedToUpdate()) return false;
+			if (!this.model.get('lot').get("acls").write) return false;
 
 			// If we get here, then just check if the lot is new or not
 		    if (this.model.get('lot').isNew()) {

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -1,7 +1,7 @@
 exports.setupAPIRoutes = (app) ->
 	app.get '/cmpdReg/scientists', exports.getScientists
 	app.get '/cmpdReg/metalots/corpName/:lotCorpName', exports.getMetaLot
-	app.post '/cmpdReg/metalots', exports.metaLots
+	app.post '/cmpdReg/metalots', exports.saveMetaLot
 	app.get '/cmpdReg/parentLot/getAllAuthorizedLots', exports.getAllAuthorizedLots
 
 exports.setupRoutes = (app, loginRoutes) ->
@@ -29,7 +29,7 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/cmpdReg/regsearches/parent', loginRoutes.ensureAuthenticated, exports.regSearch
 	app.post '/cmpdReg/structuresearch', loginRoutes.ensureAuthenticated, exports.structureSearch
 	app.post '/cmpdReg/filesave', loginRoutes.ensureAuthenticated, exports.fileSave
-	app.post '/cmpdReg/metalots', loginRoutes.ensureAuthenticated, exports.metaLots
+	app.post '/cmpdReg/metalots', loginRoutes.ensureAuthenticated, exports.saveMetaLot
 	app.post '/cmpdReg/salts', loginRoutes.ensureAuthenticated, exports.saveSalts
 	app.post '/cmpdReg/isotopes', loginRoutes.ensureAuthenticated, exports.saveIsotopes
 	app.post '/cmpdReg/api/v1/structureServices/molconvert', loginRoutes.ensureAuthenticated, exports.molConvert
@@ -369,7 +369,7 @@ exports.fileSave = (req, resp) ->
 	cmpdRegCall = config.all.client.service.cmpdReg.persistence.fullpath + '/filesave'
 	req.pipe(request[req.method.toLowerCase()](cmpdRegCall)).pipe(resp)
 
-exports.metaLots = (req, resp) ->
+exports.saveMetaLot = (req, resp) ->
 	metaLot = req.body;
 
 	# Verify that lot is included as a metalot with no lot is not allowed

--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -146,7 +146,20 @@ exports.ensureCmpdRegAdmin = (req, res, next) ->
 		res.json 'Unathorized: You have attempted an action that requires CmpdReg Admin permissions! This incident will be reported to your system administrator.'
 	else
 		return next()
-	
+
+exports.ensureACASAdmin = (req, res, next) ->
+	if req.session?.passport?.user?
+		user = req.session.passport.user
+	else
+		user =
+			username: 'anonymous'
+			roles: []
+	hasRole = exports.checkHasRole(user, config.all.client.roles.acas.adminRole)
+	if !hasRole
+		res.statusCode = 401
+		res.json 'Unathorized: You have attempted an action that requires ACAS Admin permissions! This incident will be reported to your system administrator.'
+	else
+		return next()
 
 exports.checkHasRole = (user, roleConfig, callback) ->
 	_ = require 'underscore'

--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -140,28 +140,25 @@ exports.ensureCmpdRegAdmin = (req, res, next) ->
 		user =
 			username: 'anonymous'
 			roles: []
-	exports.checkHasRole user, config.all.client.roles.cmpdreg.adminRole, (err, hasRole) ->
-		console.log "Checked role: #{config.all.client.roles.cmpdreg.adminRole}, for user: #{user.username}, for path #{req.url}, result: #{hasRole}"
-		if !hasRole
-			res.statusCode = 401
-			res.json 'Unathorized: You have attempted an action that requires CmpdReg Admin permissions! This incident will be reported to your system administrator.'
-		else
-			return next()
+	hasRole = exports.checkHasRole(user, config.all.client.roles.cmpdreg.adminRole)
+	if !hasRole
+		res.statusCode = 401
+		res.json 'Unathorized: You have attempted an action that requires CmpdReg Admin permissions! This incident will be reported to your system administrator.'
+	else
+		return next()
 	
 
 exports.checkHasRole = (user, roleConfig, callback) ->
 	_ = require 'underscore'
 	userRoles = parseUserRoles user
+	hasRole = false
 	if !roleConfig
 		validRoles = []
 	else
 		validRoles = roleConfig.split(",")
 	if validRoles? and validRoles.length > 0
 		hasRole = ((_.intersection userRoles, validRoles).length > 0)
-		callback null, hasRole
-	else
-		# if role is not configured, default to not giving access
-		callback null, false
+	return hasRole
 
 parseUserRoles = (user) ->
 	_ = require 'underscore'

--- a/modules/ServerAPI/src/server/routes/AuthorRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/AuthorRoutes.coffee
@@ -69,6 +69,7 @@ exports.allowedProjectsInternal = (user, callback) ->
 				else if role.roleEntry.roleName == config.all.client.roles.acas.adminRole
 					isAdmin = true
 			if isAdmin
+				console.log "User #{user.username} granted admin role so returning all projects"
 				filteredProjects = allProjects
 			else
 				allProjects.forEach (project) ->
@@ -76,11 +77,14 @@ exports.allowedProjectsInternal = (user, callback) ->
 					if isRestricted
 						if _.contains(allowedProjectCodes, project.code)
 							filteredProjects.push(project)
+						else
+							console.log "User #{user.username} is not allowed to see project #{project.code}"
 					else 
 						filteredProjects.push(project)
 			projects = filteredProjects
 		else
 			projects = allProjects
+		console.log "User #{user.username} has access to #{projects.length} projects: #{projects.map (project) -> project.code}"
 		callback 200, projects
 
 

--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -90,6 +90,7 @@ exports.experimentByCodename = (req, resp) ->
 				if json.codeName?
 					if json.ignored
 						if json.deleted
+							console.log "Experiment #{req.params.code} exists but is deleted"
 							resp.statusCode = 500
 							resp.end JSON.stringify "Experiment does not exist"
 						else
@@ -99,11 +100,14 @@ exports.experimentByCodename = (req, resp) ->
 								viewDeletedRoles = []
 							grantedRoles = _.map req.user.roles, (role) ->
 								role.roleEntry.roleName
-							canViewDeleted = (viewDeletedRoles in grantedRoles)
+							canViewDeleted = true
+							if viewDeletedRoles.length > 0
+								canViewDeleted = ((_.intersection viewDeletedRoles, grantedRoles).length > 0)
 							if canViewDeleted
 								resp.statusCode = statusCode
 								resp.end JSON.stringify json
 							else
+								console.log "User #{req.user.username} does not have privs to view deleted experiments they are not in viewDeletedRoles #{viewDeletedRoles} they are in grantedRoles #{grantedRoles}"
 								resp.statusCode = 500
 								resp.end JSON.stringify "Experiment does not exist"
 					else

--- a/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
+++ b/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
@@ -53,6 +53,23 @@ exports.promisifyRequestResponseStatus = (fun, args) ->
 		)
 	return await exports.promiseifyCatch(fun, args)
 
+exports.promisifyRequestStatusResponse = (fun, args) ->
+	# Custom promisify function to convert "status, json" type callback
+	# functions where status > 400 is an error to a standard err, response
+	# promise return
+	fun[util.promisify.custom] = (...args) =>
+		new Promise((resolve, reject) =>
+			fun ...args, (status, json) =>
+				if typeof status != 'number' || status >= 400
+					if json?
+						reject(json)
+					else
+						reject(err)
+				else
+					resolve(json)
+		)
+	return await exports.promiseifyCatch(fun, args)
+
 exports.runRFunction_HIDDEN = (request, rScript, rFunction, returnFunction, preValidationFunction) ->
 	config = require '../conf/compiled/conf.js'
 	serverUtilityFunctions = require './ServerUtilityFunctions.js'

--- a/modules/ServerAPI/src/server/routes/SetupRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/SetupRoutes.coffee
@@ -1,5 +1,8 @@
-exports.setupRoutes = (app, loginRoutes) ->
+exports.setupAPIRoutes = (app) ->
 	app.post '/api/setup/:typeOrKind', exports.setupTypeOrKind
+
+exports.setupRoutes = (app, loginRoutes) ->
+	app.post '/api/setup/:typeOrKind', loginRoutes.ensureAuthenticated, loginRoutes.ensureACASAdmin, exports.setupTypeOrKind
 
 exports.setupTypeOrKindInternal = (typeOrKind, roles, callback) ->
 	console.log "setupTypeOrKind"
@@ -16,7 +19,6 @@ exports.setupTypeOrKindInternal = (typeOrKind, roles, callback) ->
 	, (error, response, json) =>
 		callback json, response.statusCode
 	)
-
 
 exports.setupTypeOrKind = (req, resp) ->
 	exports.setupTypeOrKindInternal req.params.typeOrKind, req.body, (json, statusCode) =>

--- a/modules/SystemTest/src/server/routes/SystemTestRoutes.coffee
+++ b/modules/SystemTest/src/server/routes/SystemTestRoutes.coffee
@@ -101,6 +101,7 @@ exports.getOrCreateTestUser = (req, resp) ->
 				projectNames = if req.body.projectNames? then req.body.projectNames else []
 				exports.giveTestUserRolesInternal username, acasUser, acasAdmin, cmpdregUser, cmpdregAdmin, projectNames, (statusCode, output) ->
 					# Get the user
+					console.log "getOrCreateTestUser: output: #{JSON.stringify(output)}"
 					exports.getTestUser username, (user) ->
 						callback 200, {
 							hasError: false
@@ -158,12 +159,15 @@ addProjectRoles = (projectNames, roles, username, callback) ->
 		_.each projectNames, (projectName) ->
 			project = _.findWhere body, {"name":projectName}
 			if project?
+				console.log "Adding project name #{projectName}  to user #{username}"
 				roles.push {
 					roleType: 'Project'
 					roleKind: project.code
 					roleName: 'User'
 					userName: username
 				}
+			else 
+				throw new Error("Project not found: #{projectName}")
 		callback roles
 
 # Grant roles to a test user

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "mongojs": "3.1.0",
     "morgan": "^1.10.0",
     "multer": "^1.4.2",
+    "node-fetch": "3.2.6",
     "ncp": "2.0.0",
     "passport": ">=0.4.1",
     "passport-local": ">=1.0.0",


### PR DESCRIPTION
## Description
 - Changed to project roles enable = true and restrict project details by project default to true
 - Added acls checks to POST meta lot route
 - Added additional acls checks to get met alot route
 - Removed checks on client side to just use server side acls
 - Introduced node-fetch package
 - Fixed some a few minor issues with check has roles and view deleted experiments

## Related Issue
ACAS-314

## How Has This Been Tested?
Ran acas client tests
Ran through single reg multiple scenarios with project acls, cmpd reg user vs cmpd reg admin...etc.