### PR TITLE
ACAS-328 shift endpoint behind /api so it does not require new proxy settings

### DIFF
--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -679,7 +679,8 @@ class ExperimentBrowserController extends Backbone.View
 	handleCopyLinkClicked: =>
 		link = @$('.bv_exptLink').val()
 		if link? # Defined and not null
-			alert("Link copied to clipboard!")
+			navigator.clipboard.writeText(link).then ->
+				alert("Link copied to clipboard!")
 		else
 			alert("Unable to copy link to clipboard")
 

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -677,7 +677,7 @@ class ExperimentBrowserController extends Backbone.View
 				datatype: 'json'
 
 	handleCopyLinkClicked: =>
-		link = @$('.bv_exptLink').value
+		link = @$('.bv_exptLink').val()
 		if link? # Defined and not null
 			alert("Link copied to clipboard!")
 		else

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -632,7 +632,7 @@ class ExperimentBrowserController extends Backbone.View
 			# Call to Route to Get URL 
 			$.ajax
 				type: 'GET'
-				url: "/getLinkExptQueryTool?experiment=#{code}"
+				url: "/api/getLinkExptQueryTool?experiment=#{code}"
 				success: (response) => 
 					# Take Away Generating Progress Mask 
 					@$('.bv_generatingLink').hide()
@@ -664,7 +664,7 @@ class ExperimentBrowserController extends Backbone.View
 			# Call to Route to Get URL 
 			$.ajax
 				type: 'GET'
-				url: "/getLinkExptQueryTool?experiment=#{code}"
+				url: "/api/getLinkExptQueryTool?experiment=#{code}"
 				success: (response) => 
 					# Take Away Generating Progress Mask 
 					@$('.bv_generatingLink').hide()

--- a/modules/ServerAPI/src/server/routes/GetLinkExptQueryTool.coffee
+++ b/modules/ServerAPI/src/server/routes/GetLinkExptQueryTool.coffee
@@ -1,5 +1,5 @@
 exports.setupRoutes = (app, loginRoutes) ->
-	app.get '/getLinkExptQueryTool', loginRoutes.ensureAuthenticated, exports.getLinkQueryToolForExperiment
+	app.get '/api/getLinkExptQueryTool', loginRoutes.ensureAuthenticated, exports.getLinkQueryToolForExperiment
 
 
 exports.getLinkQueryToolForExperiment = (req, resp) ->


### PR DESCRIPTION
## Description
When deployed in production, ACAS is behind an nginx proxy that only routes certain urls to ACAS. ACAS-277 added a new `/getLinkExptQueryTool` URL but we did not add it to the configuration service that controls that nginx proxy. A simpler solution is to move this route behind a pre-existing url beginning, namely `/api`.

After fixing initial issue, noticed and fixed 2 more issues with the copy link button.

## Related Issue

## How Has This Been Tested?
Patched these into javascript on live server, tested features in UI