### PR TITLE
Don't disable standardization if dry run changes is < 1

### DIFF
--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -732,8 +732,7 @@ class window.StandardizationController extends Backbone.View
 		#Execute Standardization Disabled when most recent history dryRunStatus != "complete" or standardizationStatus == "running" or standardization == "complete"
 		if dryRunStatus != 'complete' or standardizationStatus is 'running' or standardizationStatus is 'complete'
 			@$('.bv_executeStandardization').attr 'disabled', 'disabled'
-		if mostRecentHistory.dryRunStandardizationChangesCount < 1
-			@$('.bv_executeStandardization').attr 'disabled', 'disabled'
+
 
 	setupLastDryRunReportSummary: (mostRecentHistory)->		
 		standardizationStatus = mostRecentHistory.standardizationStatus


### PR DESCRIPTION
## Description
If Creg detects that standardization settings have changed but the changed settings do not produced compound changes ACAS should still allow standardization execution otherwise users are blocked from registering compounds and the system is stuck in a state where it "needs standardization".

## Related Issue
ACAS-338

## How Has This Been Tested?
Patched fix in server which was exhibiting the behavior above. Enabling standardization allowed for the button to be active regardless of number of changes when the dry run was complete.  Executing stanadarization had the desired effect where no structures were changed but the "needs standardization" flag was set to false when complete.