### PR TITLE
Added file links to Purge Files page before purging files

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -926,10 +926,18 @@ class FileRowSummaryController extends Backbone.View
 			fileDate = ""
 		else
 			fileDate = UtilityFunctions::convertMSToYMDDate(fileDate)
+
+		fileName = @model.get('fileName')
+		# Replace .sdf with .zip since the report file shares the same name 
+		reportName = fileName.replace "\.sdf", ".zip"
+
 		toDisplay =
-			fileName: @model.get('fileName')
+			fileName: fileName
 			loadDate: fileDate
 			loadUser: @model.get('recordedBy')
+			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + fileName
+			reportName: reportName
+			reportLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + reportName
 		$(@el).html(@template(toDisplay))
 
 		@

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -261,9 +261,10 @@
 </script>
 
 <script type="text/template" id="FileRowSummaryView" xmlns="http://www.w3.org/1999/html">
-    <td class='bv_fileName'><%-fileName%></td>
+    <td class='bv_fileName'><a href='<%-fileLink%>'><%-fileName%></a></td>
     <td class='bv_loadDate'><%-loadDate%></td>
     <td class='bv_loadUser'><%-loadUser%></td>
+    <td class='bv_Report'><a href='<%-reportLink%>'><%-reportName%></a></td>
 </script>
 
 <script type="text/template" id="FileSummaryTableView" xmlns="http://www.w3.org/1999/html">
@@ -273,6 +274,7 @@
                 <th>File</th>
                 <th>Load Date</th>
                 <th>Load User</th>
+                <th>Report</th>
             </tr>
         </thead>
         <tbody style="">


### PR DESCRIPTION
## Description
Previously on the CmpdReg Bulk Loader Admin "Purge Files" menu AFTER you purge a file, you could only download the original SDF. There was no way to access this download through the UI before purging.

- Changed the "File" column to an active hyperlink that downloads the original file 
- Added a new "Report" column to the table of files that has links to download the summary zip associated with each file 

## How Has This Been Tested?
- Tested locally with example .sdf files