### PR TITLE
ACAS-330: Improved "Open In" button UX for SEL summary

### DIFF
--- a/modules/Components/src/client/BasicFileValidateAndSave.coffee
+++ b/modules/Components/src/client/BasicFileValidateAndSave.coffee
@@ -202,8 +202,14 @@ class BasicFileValidateAndSaveController extends Backbone.View
 		else
 			summaryStr += "Failed due to errors "
 		@notificationController.addNotifications(@errorOwnerName, json.errorMessages)
-		@$('.bv_htmlSummary').html(json.results.htmlSummary)
 		@newExperimentCode = json.results.experimentCode
+		if json.results?.htmlSummary?
+			@$('.bv_htmlSummary').html(json.results.htmlSummary)
+			@openExperimentInQueryToolController = new OpenExperimentInQueryToolController
+				code: @newExperimentCode 
+				experimentStatus: 'approved'
+			$('.bv_openExptInQueryToolSection').html @openExperimentInQueryToolController.render().el
+		
 		@showFileUploadCompletePhase()
 		if json.results?.preProcessorHTMLSummary?
 			@showPreProcessorHTMLSUmmary json.results.preProcessorHTMLSummary

--- a/modules/Components/src/client/OpenExperimentInQueryTool.coffee
+++ b/modules/Components/src/client/OpenExperimentInQueryTool.coffee
@@ -77,7 +77,8 @@ class OpenExperimentInQueryToolController extends Backbone.View
             for viewer in configuredViewers
                 viewerName = $.trim viewer                    
                 href = "'/openExptInQueryTool?tool=#{viewerName}&experiment=#{@code}','_blank'"
-                if @experimentStatus.get('codeValue') != "approved" and viewerName is "LiveDesign"
+                # TODO: look up default experiment status
+                if @experimentStatus != "approved" and viewerName is "LiveDesign"
                     @$('.bv_viewerOptions').append '<li class="disabled"><a href='+href+' target="_blank">'+viewerName+'</a></li>'
                 else
                     @$('.bv_viewerOptions').append '<li><a href='+href+' target="_blank">'+viewerName+'</a></li>'

--- a/modules/Components/src/client/OpenExperimentInQueryTool.coffee
+++ b/modules/Components/src/client/OpenExperimentInQueryTool.coffee
@@ -44,21 +44,19 @@ class OpenExperimentInQueryToolController extends Backbone.View
         # Add Generating Link Loading Mask 
         @$('.bv_generatingLink').show()
         # Call to Route to Get URL 
-        setTimeout(=>  
-            $.ajax
-                type: 'GET'
-                url: "/api/getLinkExptQueryTool?experiment=#{@code}"
-                success: (response) => 
-                    # Take Away Generating Progress Mask 
-                    @$('.bv_generatingLink').hide()
-                    @$('.bv_getLinkResults').show()
-                    @$('.bv_exptLink').val(response)
-                error: (err) =>
-                    # Take Away Generating Progress Mask 
-                    @$('.bv_generatingLink').hide()
-                    console.log err
-                datatype: 'json'
-            , 3000);
+        $.ajax
+            type: 'GET'
+            url: "/api/getLinkExptQueryTool?experiment=#{@code}"
+            success: (response) => 
+                # Take Away Generating Progress Mask 
+                @$('.bv_generatingLink').hide()
+                @$('.bv_getLinkResults').show()
+                @$('.bv_exptLink').val(response)
+            error: (err) =>
+                # Take Away Generating Progress Mask 
+                @$('.bv_generatingLink').hide()
+                console.log err
+            datatype: 'json'
 
     handleCopyLinkClicked: =>
         link = @$('.bv_exptLink').val()
@@ -77,7 +75,6 @@ class OpenExperimentInQueryToolController extends Backbone.View
             for viewer in configuredViewers
                 viewerName = $.trim viewer                    
                 href = "'/openExptInQueryTool?tool=#{viewerName}&experiment=#{@code}','_blank'"
-                # TODO: look up default experiment status
                 if @experimentStatus != "approved" and viewerName is "LiveDesign"
                     @$('.bv_viewerOptions').append '<li class="disabled"><a href='+href+' target="_blank">'+viewerName+'</a></li>'
                 else

--- a/modules/Components/src/client/OpenExperimentInQueryTool.coffee
+++ b/modules/Components/src/client/OpenExperimentInQueryTool.coffee
@@ -13,7 +13,6 @@ class OpenExperimentInQueryToolController extends Backbone.View
         $(@el).empty()
         $(@el).html @template()
         @formatOpenInQueryToolButton()
-        # Some elements might be hidden to star with; check on that
 
         @
         
@@ -30,8 +29,6 @@ class OpenExperimentInQueryToolController extends Backbone.View
             # Call to Route to Get URL 
             $.ajax
                 type: 'GET'
-                # This route priorities LD -> Seurat -> DataViewer -> CurveCurator
-                # Whichever is 
                 url: "/api/getLinkExptQueryTool?experiment=#{@code}"
                 success: (response) => 
                     # Take Away Generating Progress Mask 
@@ -44,25 +41,24 @@ class OpenExperimentInQueryToolController extends Backbone.View
                 datatype: 'json'
 
     handleGetLinkQueryToolClicked: => 
-        #unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
-            # Add Generating Link Loading Mask 
-            @$('.bv_generatingLink').show()
-            # Call to Route to Get URL 
-            setTimeout(=>  
-                $.ajax
-                    type: 'GET'
-                    url: "/api/getLinkExptQueryTool?experiment=#{@code}"
-                    success: (response) => 
-                        # Take Away Generating Progress Mask 
-                        @$('.bv_generatingLink').hide()
-                        @$('.bv_getLinkResults').show()
-                        @$('.bv_exptLink').val(response)
-                    error: (err) =>
-                        # Take Away Generating Progress Mask 
-                        @$('.bv_generatingLink').hide()
-                        console.log err
-                    datatype: 'json'
-              , 3000);
+        # Add Generating Link Loading Mask 
+        @$('.bv_generatingLink').show()
+        # Call to Route to Get URL 
+        setTimeout(=>  
+            $.ajax
+                type: 'GET'
+                url: "/api/getLinkExptQueryTool?experiment=#{@code}"
+                success: (response) => 
+                    # Take Away Generating Progress Mask 
+                    @$('.bv_generatingLink').hide()
+                    @$('.bv_getLinkResults').show()
+                    @$('.bv_exptLink').val(response)
+                error: (err) =>
+                    # Take Away Generating Progress Mask 
+                    @$('.bv_generatingLink').hide()
+                    console.log err
+                datatype: 'json'
+            , 3000);
 
     handleCopyLinkClicked: =>
         link = @$('.bv_exptLink').val()

--- a/modules/Components/src/client/OpenExperimentInQueryTool.coffee
+++ b/modules/Components/src/client/OpenExperimentInQueryTool.coffee
@@ -1,0 +1,93 @@
+class OpenExperimentInQueryToolController extends Backbone.View
+
+    code: null
+    experimentStatus: null
+
+    template: _.template($("#OpenExperimentInQueryToolView").html())
+
+    initialize: ->
+        @code = @options.code
+        @experimentStatus = @options.experimentStatus
+
+    render: => 
+        $(@el).empty()
+        $(@el).html @template()
+        @formatOpenInQueryToolButton()
+        # Some elements might be hidden to star with; check on that
+
+        @
+        
+
+    events:
+        "click .bv_openInQueryToolButton": "handleOpenInQueryToolClicked"
+        "click .bv_getLinkQueryToolButton": "handleGetLinkQueryToolClicked"
+        "click .bv_copyExptLink" : "handleCopyLinkClicked"
+
+    handleOpenInQueryToolClicked: =>
+        unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
+            # Add Generating Link Loading Mask 
+            @$('.bv_generatingLink').show()
+            # Call to Route to Get URL 
+            $.ajax
+                type: 'GET'
+                # This route priorities LD -> Seurat -> DataViewer -> CurveCurator
+                # Whichever is 
+                url: "/api/getLinkExptQueryTool?experiment=#{@code}"
+                success: (response) => 
+                    # Take Away Generating Progress Mask 
+                    @$('.bv_generatingLink').hide()
+                    window.open(response,'_blank')
+                error: (err) =>
+                    # Take Away Generating Progress Mask 
+                    @$('.bv_generatingLink').hide()
+                    console.log err
+                datatype: 'json'
+
+    handleGetLinkQueryToolClicked: => 
+        #unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
+            # Add Generating Link Loading Mask 
+            @$('.bv_generatingLink').show()
+            # Call to Route to Get URL 
+            setTimeout(=>  
+                $.ajax
+                    type: 'GET'
+                    url: "/api/getLinkExptQueryTool?experiment=#{@code}"
+                    success: (response) => 
+                        # Take Away Generating Progress Mask 
+                        @$('.bv_generatingLink').hide()
+                        @$('.bv_getLinkResults').show()
+                        @$('.bv_exptLink').val(response)
+                    error: (err) =>
+                        # Take Away Generating Progress Mask 
+                        @$('.bv_generatingLink').hide()
+                        console.log err
+                    datatype: 'json'
+              , 3000);
+
+    handleCopyLinkClicked: =>
+        link = @$('.bv_exptLink').val()
+        if link? # Defined and not null
+            navigator.clipboard.writeText(link).then ->
+                alert("Link copied to clipboard!")
+        else
+            alert("Unable to copy link to clipboard")
+
+    formatOpenInQueryToolButton: =>
+        @$('.bv_viewerOptions').empty()
+        configuredViewers = window.conf.service.result.viewer.configuredViewers
+        if configuredViewers?
+            configuredViewers = configuredViewers.split(",")
+        if configuredViewers? and configuredViewers.length>1
+            for viewer in configuredViewers
+                viewerName = $.trim viewer                    
+                href = "'/openExptInQueryTool?tool=#{viewerName}&experiment=#{@code}','_blank'"
+                if @experimentStatus.get('codeValue') != "approved" and viewerName is "LiveDesign"
+                    @$('.bv_viewerOptions').append '<li class="disabled"><a href='+href+' target="_blank">'+viewerName+'</a></li>'
+                else
+                    @$('.bv_viewerOptions').append '<li><a href='+href+' target="_blank">'+viewerName+'</a></li>'
+        else
+            @$('.bv_openInQueryToolButton').removeAttr 'data-toggle', 'dropdown'
+            @$('.bv_openInQueryToolButton').removeClass 'dropdown-toggle'
+            @$('.bv_openInQueryToolButton .caret').hide()
+            @$('.bv_openInQueryToolButton').html("Open In " + window.conf.service.result.viewer.displayName)
+            @$('.bv_openInQueryTool').removeClass "btn-group"

--- a/modules/Components/src/client/OpenExperimentInQueryToolView.html
+++ b/modules/Components/src/client/OpenExperimentInQueryToolView.html
@@ -1,32 +1,32 @@
 <script type="text/template" id="OpenExperimentInQueryToolView" xmlns="http://www.w3.org/1999/html">
-    <div class="hide bv_generatingLink" style="margin: auto;">
+    <div class="hide bv_generatingLink" style="margin-bottom: 10px;">
         <h5>Generating Link...</h5>
         <div class="progress progress-striped active " style="width: 90%; margin: auto;">
             <div class="bar" style="width: 100%; margin: auto;"></div>
         </div>
     </div>
 
-    <span class="btn-group pull-right bv_getLinkQueryTool" style="margin-right:5px;">
-        <button type="button" class="btn btn-default bv_getLinkQueryToolButton">
-            Generate Link
-        </button>
-        <div class="hide bv_getLinkResults" style="margin: auto;">
-            <br>
+    <div style="display: inline-block; margin-bottom: 10px;">
+        <span class="btn-group bv_openInQueryTool" style="margin-right:5px;">
+            <button type="button" class="btn btn-default bv_openInQueryToolButton dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Open In <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu bv_viewerOptions">
+                <!--<li><a href="#">Data Viewer</a></li>-->
+                <!--<li><a href="#">Seurat</a></li>-->
+                <!--<li><a href="#">Live Design</a></li>-->
+            </ul>
+        </span>
+        <span class="btn-group bv_getLinkQueryTool" style="margin-right:5px; margin-bottom:10px;">
+            <button type="button" class="btn btn-default bv_getLinkQueryToolButton">
+                Generate Link
+            </button>
+        </span>
+        <div class="hide bv_getLinkResults pull-right" style="margin-left: 5px; display: none;">
             <input type="text" class="bv_exptLink" name="exptLink" value="" readonly style="margin-right:5px;">
             <button type="button" class="btn btn-default bv_copyExptLink" style="margin-bottom: 10px;">
                 Copy Link
             </button>
         </div>
-    </span>
-
-    <span class="btn-group pull-right bv_openInQueryTool" style="margin-right:5px;">
-        <button type="button" class="btn btn-default bv_openInQueryToolButton dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Open In <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu bv_viewerOptions">
-            <!--<li><a href="#">Data Viewer</a></li>-->
-            <!--<li><a href="#">Seurat</a></li>-->
-            <!--<li><a href="#">Live Design</a></li>-->
-        </ul>
-    </span>
+    </div>
 </script>

--- a/modules/Components/src/client/OpenExperimentInQueryToolView.html
+++ b/modules/Components/src/client/OpenExperimentInQueryToolView.html
@@ -1,0 +1,32 @@
+<script type="text/template" id="OpenExperimentInQueryToolView" xmlns="http://www.w3.org/1999/html">
+    <div class="hide bv_generatingLink" style="margin: auto;">
+        <h5>Generating Link...</h5>
+        <div class="progress progress-striped active " style="width: 90%; margin: auto;">
+            <div class="bar" style="width: 100%; margin: auto;"></div>
+        </div>
+    </div>
+
+    <span class="btn-group pull-right bv_getLinkQueryTool" style="margin-right:5px;">
+        <button type="button" class="btn btn-default bv_getLinkQueryToolButton">
+            Generate Link
+        </button>
+        <div class="hide bv_getLinkResults" style="margin: auto;">
+            <br>
+            <input type="text" class="bv_exptLink" name="exptLink" value="" readonly style="margin-right:5px;">
+            <button type="button" class="btn btn-default bv_copyExptLink" style="margin-bottom: 10px;">
+                Copy Link
+            </button>
+        </div>
+    </span>
+
+    <span class="btn-group pull-right bv_openInQueryTool" style="margin-right:5px;">
+        <button type="button" class="btn btn-default bv_openInQueryToolButton dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Open In <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu bv_viewerOptions">
+            <!--<li><a href="#">Data Viewer</a></li>-->
+            <!--<li><a href="#">Seurat</a></li>-->
+            <!--<li><a href="#">Live Design</a></li>-->
+        </ul>
+    </span>
+</script>

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -502,20 +502,7 @@ class ExperimentBrowserController extends Backbone.View
 		return true
 
 	handleDeleteExperimentClicked: =>
-		if @experimentController.model.get('lsLabels') not instanceof LabelList
-			@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-		subclass = @experimentController.model.get('subclass')
-		if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-			if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].escape('labelText')
-			else if @model.get('lsKind') is "study" and @model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-				code = @model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].escape('labelText')
-			else
-				code = @experimentController.model.get("codeName")
-		else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].escape('labelText')
-		else
-			code = @experimentController.model.escape('codeName')
+		code = @getExperimentCode() 
 
 		@$(".bv_experimentCodeName").html code
 		@$(".bv_deleteButtons").removeClass "hide"
@@ -553,49 +540,13 @@ class ExperimentBrowserController extends Backbone.View
 		@$(".bv_confirmDeleteExperiment").modal('hide')
 
 	handleEditExperimentClicked: =>
-		if @experimentController.model.get('lsLabels') not instanceof LabelList
-			@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-		subclass = @experimentController.model.get('subclass')
-		if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-			if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			else
-				code = @experimentController.model.get("codeName")
-		else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-		else
-			code = @experimentController.model.get('codeName')
-#
-#		if @experimentController.model.get('lsKind') is 'study'
-#			if @experimentController.model.get('lsLabels') not instanceof LabelList
-#				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-#			if @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-#				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-#			else
-#				code = @experimentController.model.get("codeName")
-#		else
-#			code = @experimentController.model.get("codeName")
+		code = @getExperimentCode()
 		window.open("/entity/edit/codeName/#{code}",'_blank');
 
 	handleDuplicateExperimentClicked: =>
 		experimentKind = @experimentController.model.get('lsKind')
-		if @experimentController.model.get('lsLabels') not instanceof LabelList
-			@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-		subclass = @experimentController.model.get('subclass')
-		if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-			if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			else
-				code = @experimentController.model.get("codeName")
-		else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-		else
-			code = @experimentController.model.get('codeName')
-		
+		code = @getExperimentCode()
+
 		if experimentKind is "Bio Activity"
 			window.open("/entity/copy/primary_screen_experiment/#{@experimentController.model.get("codeName")}",'_blank');
 		else if experimentKind is "study"

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -345,9 +345,6 @@ class ExperimentBrowserController extends Backbone.View
 		"click .bv_duplicateExperiment": "handleDuplicateExperimentClicked"
 		"click .bv_confirmDeleteExperimentButton": "handleConfirmDeleteExperimentClicked"
 		"click .bv_cancelDelete": "handleCancelDeleteClicked"
-		# "click .bv_openInQueryToolButton": "handleOpenInQueryToolClicked"
-		# "click .bv_getLinkQueryToolButton": "handleGetLinkQueryToolClicked"
-		# "click .bv_copyExptLink" : "handleCopyLinkClicked"
 
 	initialize: ->
 		template = _.template( $("#ExperimentBrowserView").html(),  {includeDuplicateAndEdit: @includeDuplicateAndEdit} );
@@ -360,7 +357,6 @@ class ExperimentBrowserController extends Backbone.View
 		@searchController.render()
 		@searchController.on "searchReturned", @setupExperimentSummaryTable.bind(@)
 		#@searchController.on "resetSearch", @destroyExperimentSummaryTable
-#		@$('.bv_queryToolDisplayName').html window.conf.service.result.viewer.displayName
 
 	setupExperimentSummaryTable: (experiments) =>
 		@destroyExperimentSummaryTable()
@@ -440,8 +436,6 @@ class ExperimentBrowserController extends Backbone.View
 				code: code 
 				experimentStatus: @experimentController.model.getStatus()
 			$('.bv_openExperimentInQueryToolPlaceholder').html @openExperimentInQueryToolController.render().el
-			#@$('.bv_openInQueryTool').show()
-			#@formatOpenInQueryToolButton() 
 			if @canEdit()
 				@$('.bv_editExperiment').show()
 			else
@@ -615,114 +609,6 @@ class ExperimentBrowserController extends Backbone.View
 		else
 			window.open("/entity/copy/experiment_base/#{@experimentController.model.get("codeName")}",'_blank');
 
-	# handleOpenInQueryToolClicked: =>
-		# unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
-			# Preparatory Logic to Get Code to Pass to Generate Link Route 
-			# if @experimentController.model.get('lsLabels') not instanceof LabelList
-			# 	@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-			# subclass = @experimentController.model.get('subclass')
-			# if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-			# 	if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-			# 	else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			# 	else
-			# 		code = @experimentController.model.get("codeName")
-			# else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			# 	code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			# else
-			# 	code = @experimentController.model.get('codeName')
-			# # Add Generating Link Loading Mask 
-			# @$('.bv_generatingLink').show()
-			# # Call to Route to Get URL 
-			# $.ajax
-			# 	type: 'GET'
-			# 	url: "/api/getLinkExptQueryTool?experiment=#{code}"
-			# 	success: (response) => 
-			# 		# Take Away Generating Progress Mask 
-			# 		@$('.bv_generatingLink').hide()
-			# 		window.open(response,'_blank')
-			# 	error: (err) =>
-			# 		# Take Away Generating Progress Mask 
-			# 		@$('.bv_generatingLink').hide()
-			# 		console.log err
-			# 	datatype: 'json'
-
-	# handleGetLinkQueryToolClicked: => 
-			# # Preparatory Logic to Get Code to Pass to Generate Link Route 
-			# if @experimentController.model.get('lsLabels') not instanceof LabelList
-			# 	@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-			# subclass = @experimentController.model.get('subclass')
-			# if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-			# 	if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-			# 	else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			# 	else
-			# 		code = @experimentController.model.get("codeName")
-			# else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-			# 	code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			# else
-			# 	code = @experimentController.model.get('codeName')
-			# # Add Generating Link Loading Mask 
-			# @$('.bv_generatingLink').show()
-			# # Call to Route to Get URL 
-			# $.ajax
-			# 	type: 'GET'
-			# 	url: "/api/getLinkExptQueryTool?experiment=#{code}"
-			# 	success: (response) => 
-			# 		# Take Away Generating Progress Mask 
-			# 		@$('.bv_generatingLink').hide()
-			# 		@$('.bv_getLinkResults').show()
-			# 		@$('.bv_exptLink').val(response)
-			# 	error: (err) =>
-			# 		# Take Away Generating Progress Mask 
-			# 		@$('.bv_generatingLink').hide()
-			# 		console.log err
-			# 	datatype: 'json'
-
-	# handleCopyLinkClicked: =>
-	# 	link = @$('.bv_exptLink').val()
-	# 	if link? # Defined and not null
-	# 		navigator.clipboard.writeText(link).then ->
-	# 			alert("Link copied to clipboard!")
-	# 	else
-	# 		alert("Unable to copy link to clipboard")
-
-	# formatOpenInQueryToolButton: =>
-	# 	@$('.bv_viewerOptions').empty()
-	# 	configuredViewers = window.conf.service.result.viewer.configuredViewers
-	# 	if configuredViewers?
-	# 		configuredViewers = configuredViewers.split(",")
-	# 	if configuredViewers? and configuredViewers.length>1
-	# 		for viewer in configuredViewers
-	# 			viewerName = $.trim viewer
-	# 			if @experimentController.model.get('lsLabels') not instanceof LabelList
-	# 				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-	# 			subclass = @experimentController.model.get('subclass')
-	# 			if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-	# 				if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-	# 					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-	# 				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-	# 					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-	# 				else
-	# 					code = @experimentController.model.get("codeName")
-	# 			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-	# 				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-	# 			else
-	# 				code = @experimentController.model.get('codeName')
-					
-	# 			href = "'/openExptInQueryTool?tool=#{viewerName}&experiment=#{code}','_blank'"
-	# 			if @experimentController.model.getStatus().get('codeValue') != "approved" and viewerName is "LiveDesign"
-	# 				@$('.bv_viewerOptions').append '<li class="disabled"><a href='+href+' target="_blank">'+viewerName+'</a></li>'
-	# 			else
-	# 				@$('.bv_viewerOptions').append '<li><a href='+href+' target="_blank">'+viewerName+'</a></li>'
-	# 	else
-	# 		@$('.bv_openInQueryToolButton').removeAttr 'data-toggle', 'dropdown'
-	# 		@$('.bv_openInQueryToolButton').removeClass 'dropdown-toggle'
-	# 		@$('.bv_openInQueryToolButton .caret').hide()
-	# 		@$('.bv_openInQueryToolButton').html("Open In " + window.conf.service.result.viewer.displayName)
-	# 		@$('.bv_openInQueryTool').removeClass "btn-group"
 
 	getExperimentCode: => 
 		if @experimentController.model.get('lsLabels') not instanceof LabelList

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -356,7 +356,6 @@ class ExperimentBrowserController extends Backbone.View
 			includeDuplicateAndEdit: @includeDuplicateAndEdit
 		@searchController.render()
 		@searchController.on "searchReturned", @setupExperimentSummaryTable.bind(@)
-		#@searchController.on "resetSearch", @destroyExperimentSummaryTable
 
 	setupExperimentSummaryTable: (experiments) =>
 		@destroyExperimentSummaryTable()

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -434,7 +434,7 @@ class ExperimentBrowserController extends Backbone.View
 			code = @getExperimentCode()
 			@openExperimentInQueryToolController = new OpenExperimentInQueryToolController
 				code: code 
-				experimentStatus: @experimentController.model.getStatus()
+				experimentStatus: @experimentController.model.getStatus().get('codeValue')
 			$('.bv_openExperimentInQueryToolPlaceholder').html @openExperimentInQueryToolController.render().el
 			if @canEdit()
 				@$('.bv_editExperiment').show()

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -345,9 +345,9 @@ class ExperimentBrowserController extends Backbone.View
 		"click .bv_duplicateExperiment": "handleDuplicateExperimentClicked"
 		"click .bv_confirmDeleteExperimentButton": "handleConfirmDeleteExperimentClicked"
 		"click .bv_cancelDelete": "handleCancelDeleteClicked"
-		"click .bv_openInQueryToolButton": "handleOpenInQueryToolClicked"
-		"click .bv_getLinkQueryToolButton": "handleGetLinkQueryToolClicked"
-		"click .bv_copyExptLink" : "handleCopyLinkClicked"
+		# "click .bv_openInQueryToolButton": "handleOpenInQueryToolClicked"
+		# "click .bv_getLinkQueryToolButton": "handleGetLinkQueryToolClicked"
+		# "click .bv_copyExptLink" : "handleCopyLinkClicked"
 
 	initialize: ->
 		template = _.template( $("#ExperimentBrowserView").html(),  {includeDuplicateAndEdit: @includeDuplicateAndEdit} );
@@ -435,8 +435,13 @@ class ExperimentBrowserController extends Backbone.View
 			@$('.bv_deleteExperiment').hide()
 			@$('.bv_editExperiment').hide() #TODO for future releases, add in hiding duplicateExperiment
 		else
-			@$('.bv_openInQueryTool').show()
-			@formatOpenInQueryToolButton()
+			code = @getExperimentCode()
+			@openExperimentInQueryToolController = new OpenExperimentInQueryToolController
+				code: code 
+				experimentStatus: @experimentController.model.getStatus()
+			$('.bv_openExperimentInQueryToolPlaceholder').html @openExperimentInQueryToolController.render().el
+			#@$('.bv_openInQueryTool').show()
+			#@formatOpenInQueryToolButton() 
 			if @canEdit()
 				@$('.bv_editExperiment').show()
 			else
@@ -610,114 +615,131 @@ class ExperimentBrowserController extends Backbone.View
 		else
 			window.open("/entity/copy/experiment_base/#{@experimentController.model.get("codeName")}",'_blank');
 
-	handleOpenInQueryToolClicked: =>
-		unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
+	# handleOpenInQueryToolClicked: =>
+		# unless @$('.bv_openInQueryToolButton').hasClass 'dropdown-toggle'
 			# Preparatory Logic to Get Code to Pass to Generate Link Route 
-			if @experimentController.model.get('lsLabels') not instanceof LabelList
-				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-			subclass = @experimentController.model.get('subclass')
-			if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-				if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-				else
-					code = @experimentController.model.get("codeName")
-			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			else
-				code = @experimentController.model.get('codeName')
-			# Add Generating Link Loading Mask 
-			@$('.bv_generatingLink').show()
-			# Call to Route to Get URL 
-			$.ajax
-				type: 'GET'
-				url: "/api/getLinkExptQueryTool?experiment=#{code}"
-				success: (response) => 
-					# Take Away Generating Progress Mask 
-					@$('.bv_generatingLink').hide()
-					window.open(response,'_blank')
-				error: (err) =>
-					# Take Away Generating Progress Mask 
-					@$('.bv_generatingLink').hide()
-					console.log err
-				datatype: 'json'
+			# if @experimentController.model.get('lsLabels') not instanceof LabelList
+			# 	@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
+			# subclass = @experimentController.model.get('subclass')
+			# if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
+			# 	if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
+			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+			# 	else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			# 	else
+			# 		code = @experimentController.model.get("codeName")
+			# else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+			# 	code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			# else
+			# 	code = @experimentController.model.get('codeName')
+			# # Add Generating Link Loading Mask 
+			# @$('.bv_generatingLink').show()
+			# # Call to Route to Get URL 
+			# $.ajax
+			# 	type: 'GET'
+			# 	url: "/api/getLinkExptQueryTool?experiment=#{code}"
+			# 	success: (response) => 
+			# 		# Take Away Generating Progress Mask 
+			# 		@$('.bv_generatingLink').hide()
+			# 		window.open(response,'_blank')
+			# 	error: (err) =>
+			# 		# Take Away Generating Progress Mask 
+			# 		@$('.bv_generatingLink').hide()
+			# 		console.log err
+			# 	datatype: 'json'
 
-	handleGetLinkQueryToolClicked: => 
-			# Preparatory Logic to Get Code to Pass to Generate Link Route 
-			if @experimentController.model.get('lsLabels') not instanceof LabelList
-				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-			subclass = @experimentController.model.get('subclass')
-			if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-				if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-				else
-					code = @experimentController.model.get("codeName")
-			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-			else
-				code = @experimentController.model.get('codeName')
-			# Add Generating Link Loading Mask 
-			@$('.bv_generatingLink').show()
-			# Call to Route to Get URL 
-			$.ajax
-				type: 'GET'
-				url: "/api/getLinkExptQueryTool?experiment=#{code}"
-				success: (response) => 
-					# Take Away Generating Progress Mask 
-					@$('.bv_generatingLink').hide()
-					@$('.bv_getLinkResults').show()
-					@$('.bv_exptLink').val(response)
-				error: (err) =>
-					# Take Away Generating Progress Mask 
-					@$('.bv_generatingLink').hide()
-					console.log err
-				datatype: 'json'
+	# handleGetLinkQueryToolClicked: => 
+			# # Preparatory Logic to Get Code to Pass to Generate Link Route 
+			# if @experimentController.model.get('lsLabels') not instanceof LabelList
+			# 	@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
+			# subclass = @experimentController.model.get('subclass')
+			# if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
+			# 	if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
+			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+			# 	else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+			# 		code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			# 	else
+			# 		code = @experimentController.model.get("codeName")
+			# else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+			# 	code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			# else
+			# 	code = @experimentController.model.get('codeName')
+			# # Add Generating Link Loading Mask 
+			# @$('.bv_generatingLink').show()
+			# # Call to Route to Get URL 
+			# $.ajax
+			# 	type: 'GET'
+			# 	url: "/api/getLinkExptQueryTool?experiment=#{code}"
+			# 	success: (response) => 
+			# 		# Take Away Generating Progress Mask 
+			# 		@$('.bv_generatingLink').hide()
+			# 		@$('.bv_getLinkResults').show()
+			# 		@$('.bv_exptLink').val(response)
+			# 	error: (err) =>
+			# 		# Take Away Generating Progress Mask 
+			# 		@$('.bv_generatingLink').hide()
+			# 		console.log err
+			# 	datatype: 'json'
 
-	handleCopyLinkClicked: =>
-		link = @$('.bv_exptLink').val()
-		if link? # Defined and not null
-			navigator.clipboard.writeText(link).then ->
-				alert("Link copied to clipboard!")
-		else
-			alert("Unable to copy link to clipboard")
+	# handleCopyLinkClicked: =>
+	# 	link = @$('.bv_exptLink').val()
+	# 	if link? # Defined and not null
+	# 		navigator.clipboard.writeText(link).then ->
+	# 			alert("Link copied to clipboard!")
+	# 	else
+	# 		alert("Unable to copy link to clipboard")
 
-	formatOpenInQueryToolButton: =>
-		@$('.bv_viewerOptions').empty()
-		configuredViewers = window.conf.service.result.viewer.configuredViewers
-		if configuredViewers?
-			configuredViewers = configuredViewers.split(",")
-		if configuredViewers? and configuredViewers.length>1
-			for viewer in configuredViewers
-				viewerName = $.trim viewer
-				if @experimentController.model.get('lsLabels') not instanceof LabelList
-					@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
-				subclass = @experimentController.model.get('subclass')
-				if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
-					if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
-						code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
-					else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-						code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-					else
-						code = @experimentController.model.get("codeName")
-				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
-					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
-				else
-					code = @experimentController.model.get('codeName')
+	# formatOpenInQueryToolButton: =>
+	# 	@$('.bv_viewerOptions').empty()
+	# 	configuredViewers = window.conf.service.result.viewer.configuredViewers
+	# 	if configuredViewers?
+	# 		configuredViewers = configuredViewers.split(",")
+	# 	if configuredViewers? and configuredViewers.length>1
+	# 		for viewer in configuredViewers
+	# 			viewerName = $.trim viewer
+	# 			if @experimentController.model.get('lsLabels') not instanceof LabelList
+	# 				@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
+	# 			subclass = @experimentController.model.get('subclass')
+	# 			if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
+	# 				if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
+	# 					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+	# 				else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+	# 					code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+	# 				else
+	# 					code = @experimentController.model.get("codeName")
+	# 			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+	# 				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+	# 			else
+	# 				code = @experimentController.model.get('codeName')
 					
-				href = "'/openExptInQueryTool?tool=#{viewerName}&experiment=#{code}','_blank'"
-				if @experimentController.model.getStatus().get('codeValue') != "approved" and viewerName is "LiveDesign"
-					@$('.bv_viewerOptions').append '<li class="disabled"><a href='+href+' target="_blank">'+viewerName+'</a></li>'
-				else
-					@$('.bv_viewerOptions').append '<li><a href='+href+' target="_blank">'+viewerName+'</a></li>'
+	# 			href = "'/openExptInQueryTool?tool=#{viewerName}&experiment=#{code}','_blank'"
+	# 			if @experimentController.model.getStatus().get('codeValue') != "approved" and viewerName is "LiveDesign"
+	# 				@$('.bv_viewerOptions').append '<li class="disabled"><a href='+href+' target="_blank">'+viewerName+'</a></li>'
+	# 			else
+	# 				@$('.bv_viewerOptions').append '<li><a href='+href+' target="_blank">'+viewerName+'</a></li>'
+	# 	else
+	# 		@$('.bv_openInQueryToolButton').removeAttr 'data-toggle', 'dropdown'
+	# 		@$('.bv_openInQueryToolButton').removeClass 'dropdown-toggle'
+	# 		@$('.bv_openInQueryToolButton .caret').hide()
+	# 		@$('.bv_openInQueryToolButton').html("Open In " + window.conf.service.result.viewer.displayName)
+	# 		@$('.bv_openInQueryTool').removeClass "btn-group"
+
+	getExperimentCode: => 
+		if @experimentController.model.get('lsLabels') not instanceof LabelList
+			@experimentController.model.set 'lsLabels',  new LabelList @experimentController.model.get('lsLabels')
+		subclass = @experimentController.model.get('subclass')
+		if window.conf.entity?.saveInitialsCorpName? and window.conf.entity.saveInitialsCorpName is true
+			if @experimentController.model.get('lsLabels').getLabelByTypeAndKind("corpName", subclass + ' corpName').length > 0
+				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('corpName', subclass + ' corpName')[0].get('labelText')
+			else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+				code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
+			else
+				code = @experimentController.model.get("codeName")
+		else if @experimentController.model.get('lsKind') is "study" and @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id').length > 0
+			code = @experimentController.model.get('lsLabels').getLabelByTypeAndKind('id', 'study id')[0].get('labelText')
 		else
-			@$('.bv_openInQueryToolButton').removeAttr 'data-toggle', 'dropdown'
-			@$('.bv_openInQueryToolButton').removeClass 'dropdown-toggle'
-			@$('.bv_openInQueryToolButton .caret').hide()
-			@$('.bv_openInQueryToolButton').html("Open In " + window.conf.service.result.viewer.displayName)
-			@$('.bv_openInQueryTool').removeClass "btn-group"
+			code = @experimentController.model.get('codeName')
+		return code
 
 	destroyExperimentSummaryTable: =>
 		if @experimentSummaryTable?

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
@@ -163,12 +163,6 @@
 	<!--
 	<h5>Selected Experiment Details</h5>
 	-->
-	<div class="hide bv_generatingLink" style="margin: auto;">
-		<h5>Generating Link...</h5>
-		<div class="progress progress-striped active " style="width: 90%; margin: auto;">
-			<div class="bar" style="width: 100%; margin: auto;"></div>
-		</div>
-	</div>
 	<div class="well well-small bv_experimentBaseControllerContainer hide" style="margin-top: 10px;">
 		<div>
             <button class="btn btn-danger bv_deleteExperiment">Delete</button>
@@ -176,30 +170,8 @@
             <button class="btn bv_duplicateExperiment pull-right hide" style="margin-left: 0.5em;">Duplicate</button>
             <button class="btn bv_editExperiment pull-right">Edit</button>
             <% } %>
-			<span class="btn-group pull-right bv_getLinkQueryTool" style="margin-right:5px;">
-				<button type="button" class="btn btn-default bv_getLinkQueryToolButton">
-					Generate Link
-				</button>
-				<div class="hide bv_getLinkResults" style="margin: auto;">
-					<br>
-					<input type="text" class="bv_exptLink" name="exptLink" value="" readonly style="margin-right:5px;>">
-					<button type="button" class="btn btn-default bv_copyExptLink" style="margin-bottom: 10px;>">
-						Copy Link
-					</button>
-				</div>
-			</span>
-			<!--<button class="btn bv_openInQueryTool pull-right" style="margin-right:5px;">Open in <span class="bv_queryToolDisplayName"></span></button>-->
-			<span class="btn-group pull-right bv_openInQueryTool" style="margin-right:5px;">
-				<button type="button" class="btn btn-default bv_openInQueryToolButton dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-					Open In <span class="caret"></span>
-				</button>
-				<ul class="dropdown-menu bv_viewerOptions">
-					<!--<li><a href="#">Data Viewer</a></li>-->
-					<!--<li><a href="#">Seurat</a></li>-->
-					<!--<li><a href="#">Live Design</a></li>-->
-				</ul>
-			</span>
 		</div>
+		<div class="bv_openExperimentInQueryToolPlaceholder"></div>
         <hr />
 		<div class="">
 			<div class="bv_experimentBaseController row hide" style="margin-left:0px;"></div>

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
@@ -170,8 +170,8 @@
             <button class="btn bv_duplicateExperiment pull-right hide" style="margin-left: 0.5em;">Duplicate</button>
             <button class="btn bv_editExperiment pull-right">Edit</button>
             <% } %>
+			<div class="bv_openExperimentInQueryToolPlaceholder pull-right" style="margin-right: 5px;"></div>
 		</div>
-		<div class="bv_openExperimentInQueryToolPlaceholder"></div>
         <hr />
 		<div class="">
 			<div class="bv_experimentBaseController row hide" style="margin-left:0px;"></div>


### PR DESCRIPTION
**Steps to Reproduce**

Load an Experiment through the Experiment Loader, and look at the summary from a successful upload.

**Expected Results**

There is a button to Generate Link which will yield a copyable LiveReport link.

The Open in LiveDesign button UX is improved (See [ACAS-277](https://jira.schrodinger.com/browse/ACAS-277))

 **Extra Information**

This was an oversight in the spec for [ACAS-272](https://jira.schrodinger.com/browse/ACAS-272) and [ACAS-277](https://jira.schrodinger.com/browse/ACAS-277). Those improvements are live on Experiment Browser but are not present in the SEL summary which is generated in R.

Brian Bolt and Brian Frost discussed a potential technical route to take here, since this fix is non-obvious.
In Brian Bolt's recent Dose Response work, he established a pattern of modifying the HTML summary after it's returned from the backend, to enhance the UX. See "BasicFileValidateAndSave.coffee" and the "handleValidationReturnSuccess" function: https://github.com/mcneilco/acas/blob/5ce299ae908b7a69cbec418d564d8bec07e823fa/modules/Components/src/client/BasicFileValidateAndSave.coffee#L161

We can take the same approach with this ticket by looking for the existing "open in" buttons within the returned HTML, then replacing them with elements like those developed in [ACAS-277](https://jira.schrodinger.com/browse/ACAS-277).
There's also a refactor we should do along the way, which is to put the HTML elements and the javascript code that [Dale Erikson](https://jira.schrodinger.com/secure/ViewProfile.jspa?name=erikson) implemented in [ACAS-277](https://jira.schrodinger.com/browse/ACAS-277) and put them into their own controller, so that we can reuse that whole controller within both Experiment Browser and this SEL summary.

## How Has This Been Tested?
Interacting w/ UI Across Various Use Cases 