### PR TITLE
ACAS-346 SSO and direct login redirect clean up (external link UI, host checking and better redirect consistenty)

### DIFF
--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -127,10 +127,15 @@ exports.ensureAuthenticated = (req, res, next) ->
 		req.session.returnTo = req.url
 
 	basePath = req.protocol + '://' + req.get('host')
-	if req.originalUrl == "/" && config.all.client.basePath?
+
+	requestedUrl = "#{req.originalUrl || req.url}"
+	if config.all.client.basePath? && requestedUrl == "/"
 		redirectURL = "#{basePath}#{config.all.client.basePath}"
+		console.log "redirecting to base url: #{redirectURL}"
 	else
 		redirectURL = "#{basePath}#{req.originalURL || req.url}"
+		console.log "redirecting to requested url: #{redirectURL}"
+	console.log "redirectURL: #{redirectURL}"
 	res.redirect '/login?redirect_url='+redirectURL
 
 exports.ensureCmpdRegAdmin = (req, res, next) ->

--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -16,7 +16,7 @@ exports.setupRoutes = (app, passport) ->
 		app.get '/login', exports.loginPage
 	app.get '/login/direct', exports.loginPage
 	app.post '/login',
-		passport.authenticate('local', { failureRedirect: '/login', failureFlash: true, keepSessionInfo: true }), exports.loginPost
+		passport.authenticate('local', { failureRedirect: '/login', failureFlash: true }), exports.loginPost
 	app.get '/logout*', exports.logout
 	app.post '/api/userAuthentication', exports.authenticationService
 	app.get '/passwordReset', exports.resetpage

--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -164,19 +164,11 @@ exports.ensureAuthenticated = (req, res, next) ->
 		query = {
 			redirect_url: redirectUrl
 		}
-	# res.redirect(url.format(
-	# 	pathname:"/login",
-	# 	query: query
-	# ))
-	res.render 'login',
-		title: "ACAS Login"
-		scripts: []
-		user: user
-		message: errorMsg
-		resetPasswordOption: resetPasswordOption
-		redirectUrl: redirect_url
-		logoText: config.all.client.moduleMenus.logoText
-		
+	res.redirect(url.format(
+		pathname:"/login",
+		query: query
+	))
+
 exports.ensureCmpdRegAdmin = (req, res, next) ->
 	if req.session?.passport?.user?
 		user = req.session.passport.user

--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -40,13 +40,11 @@ exports.getRedirectUrl = (req) ->
 	# Check to see if the RelayState value is set in the request
 	if req.body?.RelayState? && req.body.RelayState != ""
 		redirectUrl = req.body.RelayState
+		console.log "redirecting to #{redirectUrl}"
 	else
 		parsedUrl = url.parse(req.originalUrl || req.url)
 		if parsedUrl.pathname? && parsedUrl.pathname != "/" && parsedUrl.pathname != "/login" && parsedUrl.pathname != "/login/direct" && parsedUrl.pathname != "/login/callback" && parsedUrl.pathname != config.all.client.basePath 
 			redirectUrl = parsedUrl.path
-
-	if !redirectUrl?
-	
 	return redirectUrl
 
 exports.loginPage = (req, res) ->
@@ -131,7 +129,12 @@ exports.logout = (req, res) ->
 		res.redirect redirectMatch
 
 exports.ssoLogin = (req, res, next) ->
-	req.query.RelayState = exports.getRedirectUrl(req)
+	if req.query.redirect_url?
+		redirectUrl = req.query.redirect_url
+	else
+		console.log "No redirect_url"
+		redirectUrl = exports.getRedirectUrl(req)
+	req.query.RelayState = redirectUrl
 	next()
 
 exports.ssoCallback = (req, res, next) ->

--- a/modules/ServerAPI/src/client/externalRedirect.jade
+++ b/modules/ServerAPI/src/client/externalRedirect.jade
@@ -1,0 +1,17 @@
+extends layout
+block content
+    div.navbar.navbar-inverse.navbar-fixed-top
+        div.navbar-inner
+            div.container-fluid
+                div.brand #{logoText}
+
+    div.container.externalLinkContainer
+        div.span8.offset1
+            h3 Redirect notice
+            div.well.alert.alert-warn
+                - if (redirectUrl)
+                    div You are being redirected to an external site 
+                        a(href="#{redirectUrl}") #{redirectUrl}
+                br
+                div If you do not want to be redirected you can return 
+                    a(href="#{homeUrl}") home

--- a/modules/ServerAPI/src/client/login.jade
+++ b/modules/ServerAPI/src/client/login.jade
@@ -9,7 +9,10 @@ block content
         div.span8.offset1
             h3 Please Login
             div.well
-                form.form-horizontal(action="/login", method="post")
+                - var action = "/login"
+                if redirectUrl
+                    - var action = '/login?redirect_url=' + redirectUrl
+                form.form-horizontal(action="#{action}", method="post")
                     div.control-group
                         label.control-label Username:
                         div.controls
@@ -25,6 +28,8 @@ block content
                                 input.btn.btn-primary(type="submit", value="Submit")
                                 - if (resetPasswordOption)
                                     a.forgotPasswordLink(href="/passwordReset") Forgot your password?
+        - if (redirectUrl)
+            div.span7.offset1.alert.alert-success.loginError After login your will be redirected to #{redirectUrl}
         - if (message == "Your new password is set.")
             div.span7.offset1.alert.alert-success.loginError #{message}
         - else if (message != "")

--- a/modules/ServerAPI/src/client/login.jade
+++ b/modules/ServerAPI/src/client/login.jade
@@ -29,7 +29,7 @@ block content
                                 - if (resetPasswordOption)
                                     a.forgotPasswordLink(href="/passwordReset") Forgot your password?
         - if (redirectUrl)
-            div.span7.offset1.alert.alert-success.loginError After login your will be redirected to #{redirectUrl}
+            div.span7.offset1.alert.alert-success.loginError After login you will be redirected to #{redirectUrl}
         - if (message == "Your new password is set.")
             div.span7.offset1.alert.alert-success.loginError #{message}
         - else if (message != "")


### PR DESCRIPTION
## Description

### Issue
**Steps to Reproduce**
On an ACAS server configured with SAML, when not logged in, try to navigate directly to the acas homepage, i.e. https://example.com/acas

**Expected Results**
Get redirected to Okta for login, then get redirected back to original ACAS url https://example.com/acas

**Actual Results**
Okta sign-in works, but user is sent to https://example.com/ which then redirects to LD homepage
If you then go to https://example.com/acas it works since you are logged in

**Extra Information**
Clicking the relevant ACAS app icon in Okta results in a smooth sign-in that takes you to the ACAS homepage.

### Description of fix
 - Direct login changes
   - Fixed the general issue above by not storing the redirect url in the session
   - Added redirect_login parameter to login post from login jade file
   - use general `exports.getRedirectUrl(req)` for determining redirect login url to set on login page
   - Added redirect notice to home page when redirecting a user to a page other than the home page
<img width="1364" alt="Screen Shot 2022-07-19 at 9 33 54 AM" src="https://user-images.githubusercontent.com/868119/179809227-7f23ab76-d74e-4d19-9bf5-16b741d8363d.png">

   - Added host check to redirect_url
   - Added external link page if redirect_url somehow gets set to external host
<img width="745" alt="Screen Shot 2022-07-19 at 9 48 11 AM" src="https://user-images.githubusercontent.com/868119/179808780-8e3c49eb-ad0b-428a-9dde-3d3586f178d5.png">
  
 - SSO login page changes
   - Refactored anonymous functions to named functions
   - Use same general `exports.getRedirectUrl(req)` function for determining relay state

## Related Issue
ACAS-346


## How Has This Been Tested?
- Ran redirect tests on localhost with ACAS login configuration where `client.basePath=/`
- Ran redirect tests on localhost with SAML login configuration where `client.basePath=/`
- Ran redirect tests on remote host with ACAS login configuration where `client.basePath=/acas`
- Ran redirect tests on remote host with SAML login configuration where `client.basePath=/acas`
