### PR TITLE
Add route to swap two parent structures.

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -859,27 +859,31 @@ exports.updateParent = (req, resp) ->
 	)
 
 exports.swapParentStructures = (req, resp) ->
-	console.log "exports.swapParentStructures"
-
-	# TODO: Do we need to keep track of who swapped the parent structure.
 	cmpdRegCall = config.all.client.service.cmpdReg.persistence.fullpath + '/parents/swapParentStructures'
+
+	username = req.session.passport?.user.username
+	if !username
+		resp.statusCode = 401
+		resp.end "No user name specified"
+		return
+	req.body['username'] = username
 	request(
 		method: 'POST'
 		url: cmpdRegCall
-		body: req.body
+		body: JSON.stringify req.body
 		json: true
 		timeout: 6000000
 	, (error, response, data) =>
-		if error
+		if !error
+			resp.statusCode = response.statusCode
+			resp.end data
+		else
 			console.log 'got ajax error trying to swap parent structures'
 			console.log error
 			console.log json
 			console.log response
 			resp.statusCode = 500
 			resp.end "Error trying to swap parent structures: " + error
-		else
-			resp.statusCode = response.statusCode
-			resp.end data
 	)
 
 exports.updateLotMetadata = (req, resp) ->

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -860,13 +860,7 @@ exports.updateParent = (req, resp) ->
 
 exports.swapParentStructures = (req, resp) ->
 	cmpdRegCall = config.all.client.service.cmpdReg.persistence.fullpath + '/parents/swapParentStructures'
-
-	username = req.session.passport?.user.username
-	if !username
-		resp.statusCode = 401
-		resp.end "No user name specified"
-		return
-	req.body['username'] = username
+	req.body['username'] = req.session.passport.user.username
 	request(
 		method: 'POST'
 		url: cmpdRegCall

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -43,7 +43,7 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/cmpdReg/export/searchResults', loginRoutes.ensureAuthenticated, exports.exportSearchResults
 	app.post '/cmpdReg/validateParent', loginRoutes.ensureAuthenticated, exports.validateParent
 	app.post '/cmpdReg/updateParent', loginRoutes.ensureAuthenticated, exports.updateParent
-	app.post '/cmpdReg/swapParentStructures', exports.swapParentStructures  # TODO: Ensure the user is authenticated.
+	app.post '/cmpdReg/swapParentStructures', loginRoutes.ensureAuthenticated, exports.swapParentStructures
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata', loginRoutes.ensureAuthenticated, exports.updateLotMetadata
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata/jsonArray', loginRoutes.ensureAuthenticated, exports.updateLotsMetadata
 	app.post '/cmpdReg/api/v1/parentServices/update/parent/metadata', loginRoutes.ensureAuthenticated, exports.updateParentMetadata
@@ -860,7 +860,7 @@ exports.updateParent = (req, resp) ->
 
 exports.swapParentStructures = (req, resp) ->
 	console.log "exports.swapParentStructures"
-	
+
 	# TODO: Do we need to keep track of who swapped the parent structure.
 	cmpdRegCall = config.all.client.service.cmpdReg.persistence.fullpath + '/parents/swapParentStructures'
 	request(
@@ -869,17 +869,17 @@ exports.swapParentStructures = (req, resp) ->
 		body: req.body
 		json: true
 		timeout: 6000000
-	, (error, response, json) =>
-		if !error
-			resp.setHeader('Content-Type', 'plain/text')
-			resp.json json
-		else
+	, (error, response, data) =>
+		if error
 			console.log 'got ajax error trying to swap parent structures'
 			console.log error
 			console.log json
 			console.log response
 			resp.statusCode = 500
 			resp.end "Error trying to swap parent structures: " + error
+		else
+			resp.statusCode = response.statusCode
+			resp.end data
 	)
 
 exports.updateLotMetadata = (req, resp) ->

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -43,6 +43,7 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/cmpdReg/export/searchResults', loginRoutes.ensureAuthenticated, exports.exportSearchResults
 	app.post '/cmpdReg/validateParent', loginRoutes.ensureAuthenticated, exports.validateParent
 	app.post '/cmpdReg/updateParent', loginRoutes.ensureAuthenticated, exports.updateParent
+	app.post '/cmpdReg/swapParentStructures', exports.swapParentStructures  # TODO: Ensure the user is authenticated.
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata', loginRoutes.ensureAuthenticated, exports.updateLotMetadata
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata/jsonArray', loginRoutes.ensureAuthenticated, exports.updateLotsMetadata
 	app.post '/cmpdReg/api/v1/parentServices/update/parent/metadata', loginRoutes.ensureAuthenticated, exports.updateParentMetadata
@@ -856,8 +857,31 @@ exports.updateParent = (req, resp) ->
 			resp.statusCode = 500
 			resp.end "Error trying to update parent: " + error;
 	)
+
+exports.swapParentStructures = (req, resp) ->
+	console.log "exports.swapParentStructures"
 	
-	
+	# TODO: Do we need to keep track of who swapped the parent structure.
+	cmpdRegCall = config.all.client.service.cmpdReg.persistence.fullpath + '/parents/swapParentStructures'
+	request(
+		method: 'POST'
+		url: cmpdRegCall
+		body: req.body
+		json: true
+		timeout: 6000000
+	, (error, response, json) =>
+		if !error
+			resp.setHeader('Content-Type', 'plain/text')
+			resp.json json
+		else
+			console.log 'got ajax error trying to swap parent structures'
+			console.log error
+			console.log json
+			console.log response
+			resp.statusCode = 500
+			resp.end "Error trying to swap parent structures: " + error
+	)
+
 exports.updateLotMetadata = (req, resp) ->
 	request = require 'request'
 	config = require '../conf/compiled/conf.js'

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -876,7 +876,7 @@ exports.swapParentStructures = (req, resp) ->
 	, (error, response, data) =>
 		if !error
 			resp.statusCode = response.statusCode
-			resp.end data
+			resp.json data
 		else
 			console.log 'got ajax error trying to swap parent structures'
 			console.log error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add route to swap two parent structures. 

## Description
<!--- Describe your changes in detail -->
Route to interact with the roo layer.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-286](https://jira.schrodinger.com/browse/ACAS-286).
[acas-roo-server](https://github.com/mcneilco/acas-roo-server/pull/342) PR.

## How Has This Been Tested?
<!--- Describe how this has been tested -->
I used curl requests to check the API,
```
curl -X POST http://localhost:3000/cmpdreg/swapParentStructures -H 'Content-Type: application/json' --data-raw '{"corpName1": "CMPD-0000001", "corpName2": "CMPD-0000002"}'
```
## TODO:
~In cases duplicate parents exist for a compound, it's still going ahead with the swapping even though duplicates should have been marked. See [acas-roo-server](https://github.com/mcneilco/acas-roo-server/pull/342) PR.~