### PR TITLE
Fixed error downloading summary files for some .sdfs 

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -954,7 +954,6 @@ class FileRowSummaryController extends Backbone.View
 			loadUser: @model.get('recordedBy')
 			currentFileLink: "/api/cmpdRegBulkLoader/getSDFFromBulkLoadFileID/" + reportID
 			currentFileName: currentFileName
-			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + fileName
 			reportName: reportName
 			#remove special characters from the links to prevent errors, but not from the displayed names
 			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(fileName)

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -956,7 +956,9 @@ class FileRowSummaryController extends Backbone.View
 			currentFileName: currentFileName
 			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + fileName
 			reportName: reportName
-			reportLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + reportName
+			#remove special characters from the links to prevent errors, but not from the displayed names
+			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(fileName)
+			reportLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(reportName)
 		$(@el).html(@template(toDisplay))
 
 		#Check whether lots in the bulk file have been updated since they were registered
@@ -1188,13 +1190,13 @@ class CmpdRegBulkLoaderAppController extends Backbone.View
 			@$('.bv_bulkValSummary').hide()
 			@$('.bv_bulkRegSummary').show()
 			@setupBulkRegCmpdsSummaryController(summary[0])
-			downloadUrl = window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" +summary[1]
+			downloadUrl = window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(summary[1])
 			@$('.bv_downloadSummary').attr "href", downloadUrl
 		@regCmpdsController.on 'validateComplete', (summary) =>
 			@$('.bv_bulkReg').hide()
 			@$('.bv_bulkValSummary').show()
 			@setupBulkValCmpdsSummaryController(summary[0])
-			downloadUrl = window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" +summary[1]
+			downloadUrl = window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(summary[1])
 			@$('.bv_downloadSummary').attr "href", downloadUrl
 
 	setupBulkRegCmpdsSummaryController: (summary) ->


### PR DESCRIPTION
**Please review ACAS-301 before this PR**

## Description
There was an issue in the CReg bulk loader where summary files for some .sdfs (with special characters) could not be downloaded before and after registration. Added URI encoding in file download links to fix. 

## How Has This Been Tested?
Tested using an .sdf file with special characters (model 310522#1 (1).sdf), was able to download summary files before and after registration. Also was able to download original .sdf, current .sdf, and summary files from the Purge Files page in the CReg bulk loader. 