### PR TITLE
ACAS-343: Set acasclient version based on ACAS branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["master", "release/*"]
+  pull_request:
+    types: [opened, synchronize]
   create:
     tags: "**"
 jobs:
@@ -29,6 +31,22 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # The following few steps figure out what version of acasclient to test with
+      # If main or release branch, run tests using matching release branch of acasclient
+      - name: Set ACAS_CLIENT_REF to the current branch ${{ github.ref }}
+        run: |
+          echo "ACAS_CLIENT_REF=${{ github.ref }}" >> $GITHUB_ENV
+        if: github.event_name == 'push'
+      # If a PR, run tests on acasclient branch matching destination of PR
+      - name: Set ACAS_CLIENT_REF to the PR destination branch ${{ github.base_ref }}
+        run: |
+          echo "ACAS_CLIENT_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+       # If a tag, run tests on acasclient branch by the same tag
+      - name: Set ACAS_CLIENT_REF to tag ${{ github.ref##*/ }}
+        run: |
+          echo "ACAS_CLIENT_REF=${{ github.ref##*/ }}" >> $GITHUB_ENV
+        if: github.event_name == 'tag'
       - name: Checkout acasclient
         uses: actions/checkout@v3
         with:
@@ -37,7 +55,7 @@ jobs:
           # Below checks out the same revision name as ACAS but skipping now
           # because we don't want to keep acasclient version in sync with ACAS version
           # at the moment.
-          # ref: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          ref: ${{ env.ACAS_CLIENT_REF }}
       - name: Build (no push)
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,7 +43,7 @@ jobs:
           echo "ACAS_CLIENT_REF=${{ github.base_ref }}" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
        # If a tag, run tests on acasclient branch by the same tag
-      - name: Set ACAS_CLIENT_REF to tag ${{ github.ref##*/ }}
+      - name: Set ACAS_CLIENT_REF to tag extracted from ${{ github.ref }}
         run: |
           ACAS_CLIENT_REF=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')
           echo "ACAS_CLIENT_REF=$ACAS_CLIENT_REF" >> $GITHUB_ENV

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,7 +45,8 @@ jobs:
        # If a tag, run tests on acasclient branch by the same tag
       - name: Set ACAS_CLIENT_REF to tag ${{ github.ref##*/ }}
         run: |
-          echo "ACAS_CLIENT_REF=${{ github.ref##*/ }}" >> $GITHUB_ENV
+          ACAS_CLIENT_REF=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')
+          echo "ACAS_CLIENT_REF=$ACAS_CLIENT_REF" >> $GITHUB_ENV
         if: github.event_name == 'tag'
       - name: Checkout acasclient
         uses: actions/checkout@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           ACAS_CLIENT_REF=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')
           echo "ACAS_CLIENT_REF=$ACAS_CLIENT_REF" >> $GITHUB_ENV
-        if: github.event_name == 'tag'
+        if: github.event_name == 'create'
       - name: Checkout acasclient
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,9 +53,7 @@ jobs:
         with:
           repository: mcneilco/acasclient
           path: acasclient
-          # Below checks out the same revision name as ACAS but skipping now
-          # because we don't want to keep acasclient version in sync with ACAS version
-          # at the moment.
+          # Check out the branch specified by ACAS_CLIENT_REF
           ref: ${{ env.ACAS_CLIENT_REF }}
       - name: Build (no push)
         uses: docker/build-push-action@v2


### PR DESCRIPTION
## Description
Make ACAS run acasclient tests appropriate for the ACAS branch.
- Switched from building on every branch to only building on `master` & `release/*` branches, and on PRs
- Use acasclient version based on ACAS version: 
- for `release/*` branches, check out same `release/*` branch of acasclient
- For PRs, check out the acasclient branch matching the ACAS PR target branch
- For tags, check out the same tag (this will require us to change our tagging scheme for acasclient)

## Related Issue

## How Has This Been Tested?
Pushing to release branches: Will be tested after this is merged
Pull requests: Testing via this PR. See successful tests within "checks" on this PR.
Tags: Created tag `0.0.dev344` on acasclient and acas repos. See build: https://github.com/mcneilco/acas/runs/7528166639?check_suite_focus=true