### PR TITLE
Reparent lot workflow editor ACAS-216-reparent-lot

### DIFF
--- a/modules/CmpdReg/src/client/CmpdReg.jade
+++ b/modules/CmpdReg/src/client/CmpdReg.jade
@@ -10,6 +10,7 @@ html#CmpdRegView
 		//link(rel="stylesheet", href="/stylesheets/CmpdReg/github.css")
 
 		include ../public/html/CmpdReg/DeleteLotView.html
+		include ../public/html/CmpdReg/ReparentLotView.html
 
 		script(type='text/javascript', src="/CmpdReg/client/lib/jquery-1.7.2.min.js")
 		script(type='text/javascript', src="/CmpdReg/client/lib/json2.js")
@@ -63,6 +64,7 @@ html#CmpdRegView
 		script(type='text/javascript', src="/CmpdReg/client/src/EditParent.js")
 
 		script(type='text/javascript', src="/CmpdReg/client/custom/Lot_Custom.js")
+		script(type='text/javascript', src="/javascripts/src/CmpdReg/ReparentLot.js")
 
 
 

--- a/modules/CmpdReg/src/client/Dockerfile
+++ b/modules/CmpdReg/src/client/Dockerfile
@@ -1,6 +1,0 @@
-FROM mcneilco/tomcat-maven
-WORKDIR /src
-ENV CATALINA_HOME /usr/local/tomcat
-ENV PATH $CATALINA_HOME/bin:$PATH
-RUN		mkdir -p $CATALINA_HOME/webapps/cmpdreg/client
-ADD		. $CATALINA_HOME/webapps/cmpdreg/client

--- a/modules/CmpdReg/src/client/ReparentLot.coffee
+++ b/modules/CmpdReg/src/client/ReparentLot.coffee
@@ -156,14 +156,15 @@ class ReparentLotController extends Backbone.View
 		changesToLotSummary += "</ul>"
 
 		errorSummary = "<h3>Errors</h3><ul>"
-		@$('.reparentLotButton').show()
+		# Currently we don't have any error cases so we alway show the reparent lot button on successful service call.
+		@$('.reparentLotButton').show();
 		errorSummary += "<li>None</li>"
 		errorSummary += "</ul>"
 
 		warningSummary = "<h3>Warnings</h3><ul>"
 		if dependencies.linkedLots? && dependencies.linkedLots.length == 0
 			parentCorpName = dependencies.lot.parent.corpName
-			warningSummary += "<li>This is the only lot on the parent compound #{parentCorpName}. Reparening this #{@lotLabel.toLowerCase()} will delete #{parentCorpName}.</li>"
+			warningSummary += "<li>This is the only lot on the parent compound #{parentCorpName}. Reparenting this #{@lotLabel.toLowerCase()} will delete #{parentCorpName}.</li>"
 		else
 			warningSummary += "<li>None</li>"
 		warningSummary += "</ul>"

--- a/modules/CmpdReg/src/client/ReparentLot.coffee
+++ b/modules/CmpdReg/src/client/ReparentLot.coffee
@@ -1,0 +1,231 @@
+class ReparentLotController extends Backbone.View
+	template: _.template($("#ReparentLotView").html())
+
+	events:
+		"click .cancelReparentLotButton": "handleCancelButtonClicked"
+		"click .reparentLotButton": "handleDeleteButtonClicked"
+		"click .downloadLotButton": "downloadLot"
+		"click .bv_backToCreg": "handleBackToCregButtonClicked"
+
+
+	initialize: ->
+		_.bindAll(@, 'handleCancelButtonClicked', 'handleDeleteButtonClicked', 'checkDependencies', 'dependencyCheckReturn', 'dependencyCheckError', 'deleteLotError', 'deleteLotReturn', 'downloadLot', 'handleBackToCregButtonClicked');
+		# $(@el).empty()
+		$(@el).html @template()
+
+		@lotLabel = if window.configuration.metaLot.lotCalledBatch == true then "Batch" else "Lot"
+		@.corpName = @.options.corpName;
+		@.newParentCorpName = @.options.parentCorpName;
+		@$(".bv_title").html("Re-parent #{@lotLabel} #{@.corpName} on to compound #{@.newParentCorpName}: Review Dependencies")
+		@.eNotiList = @.options.errorNotifList;
+		@.bind('notifyError', @.eNotiList.add);
+		@.bind('clearErrors', @.eNotiList.removeMessagesForOwner);
+		@checkDependencies()
+
+
+	handleCancelButtonClicked: ->
+		window.location.reload();
+
+	handleDeleteButtonClicked: ->
+		@.trigger('clearErrors', "ReparentLotController");
+		@.trigger('notifyError', {
+			owner: 'ReparentLotController',
+			errorLevel: 'warning',
+			message: "Reparenting #{@lotLabel}..."
+		});
+		url = window.configuration.serverConnection.baseServerURL+"metalots/corpName/"+@.corpName;
+
+		$.ajax({
+			type: "DELETE",
+			url: url,
+			success: @.deleteLotReturn,
+			error: @.deleteLotError
+		});
+
+	checkDependencies: ->
+		@.trigger('notifyError', {
+			owner: 'DeleteLotController',
+			errorLevel: 'warning',
+			message: 'Checking dependencies...'
+		});
+		url = window.configuration.serverConnection.baseServerURL+"metalots/checkDependencies/corpName/"+@.corpName;
+		
+		# @delegateEvents({}); # stop listening to buttons
+		$.ajax({
+			type: "GET",
+			url: url,
+			success: @.dependencyCheckReturn,
+			error: @.dependencyCheckError
+		});
+		
+	downloadLot: ->
+		window.open("/cmpdReg/export/corpName/"+@.corpName)
+
+	dependencyCheckReturn: (data) ->
+		@.trigger('clearErrors', "DeleteLotController");
+
+		# Get summary of dependencies
+		dependencySummary = @summarizeDependencyCheckResults(data);
+		
+		# Display summary of dependencies
+		@$(".bv_dependencySummary").html(dependencySummary);
+
+		# Show the summary
+		@$(".bv_dependencySummary").show();
+		
+	handleBackToCregButtonClicked: ->
+		window.location.href = 	window.configuration.serverConnection.baseServerURL
+		
+	getUlFromCodeArray: (codeArray, link) ->
+		ul = "<ul>";
+		_.each(codeArray, (code) ->
+			descriptionText = ""
+			if code.description?
+				descriptionText = ": #{code.description}"
+			if link?
+				# target blank
+				if code.code == code.name
+					# target blank a tag with a href to link with code
+					ul += "<li><a href='#{link+code.code}' target='_blank'>#{code.code}#{descriptionText}</a></li>"
+				else
+					# target blank a tag with a href to link with code
+					ul += "<li><a href='#{link+code.code}' target='_blank'>#{code.code} \"#{code.name}\"</a>#{descriptionText}</li>"
+			else 
+				if code.name == code.code
+					ul += "<li>#{code.code}#{descriptionText}</li>"
+				else
+					ul += "<li>#{code.code} \"#{code.name}\"#{descriptionText}" + "</li>"	
+		);
+		ul += "</ul>";
+		return ul;
+		
+	
+	summarizeDependencyCheckResults: (data) ->
+		# Returns html string with summary of dependency check results
+		
+		# Get linked experiments summary
+		experimentSummary = ""
+		linkedExperiments = data.linkedExperiments? && data.linkedExperiments.length > 0
+		if linkedExperiments
+			linkedExperiments = _.sortBy(data.linkedExperiments, (experiment) -> experiment.code)
+
+			experimentSummaryText = "Dependent Experimental Results"
+			experimentSummary += "<h3>#{experimentSummaryText}</h3><ul>"
+			modifableExperimentSummary = "<li>Which you have access to delete:"
+			unmodifableExperimentSummary = "<li>Which are not modifable by you:"
+			unreadableExperimentSummary = "<li>Which are not readable by you:"
+
+			modifableExperiments = linkedExperiments.filter((experiment) -> experiment.acls.delete)
+			unmodifableExperiments = linkedExperiments.filter((experiment) -> experiment.acls.read && !experiment.acls.delete)
+			unreadableExperimentsCount = linkedExperiments.filter((experiment) -> !experiment.acls.read).length
+			
+
+			if modifableExperiments.length > 0
+				modifableExperimentSummary += @getUlFromCodeArray(modifableExperiments, "/entity/edit/codeName/")
+				experimentSummary += modifableExperimentSummary + "</li>"
+
+			if unmodifableExperiments.length > 0
+				unmodifableExperimentSummary += @getUlFromCodeArray(unmodifableExperiments, "/entity/edit/codeName/")
+				experimentSummary += unmodifableExperimentSummary + "</li>"
+
+			if unreadableExperimentsCount > 0
+				unreadableExperimentSummary += " #{unreadableExperimentsCount}"
+				experimentSummary += unreadableExperimentSummary + "</li>"
+			experimentSummary += "</ul>"
+
+		# Get linked lots summary
+		lotSummary = ""
+		linkedLots =  (data.linkedLots? && data.linkedLots.length > 0)
+		if linkedLots
+			linkedLots = _.sortBy(data.linkedLots, (lot) -> lot.code)
+
+			lotSummaryText = "Remaining Lots On Parent"
+			lotSummary += "<h3>#{lotSummaryText}</h3><ul>"
+			readableLotSummary = "<li>Which are readable by you:"
+			unreadableLotSummary = "<li>Which are not readable by you:"
+
+			readableLots = linkedLots.filter((lot) -> lot.acls.read)
+			unreadableLotsCount = linkedLots.filter((lot) -> !lot.acls.read).length
+
+			if readableLots.length > 0
+				readableLotSummary += @getUlFromCodeArray(readableLots, "#lot/")
+				lotSummary += readableLotSummary + "</li>"
+
+			if unreadableLotsCount > 0
+				unreadableLotSummary += " #{unreadableLotsCount}"
+				lotSummary += unreadableLotSummary + "</li>"
+			lotSummary += "</ul>"
+			
+			## Add the lot summary as a global to the controller so it can be displayed again after delete
+			@lotSummary = lotSummary
+
+		errorSummary = "<h3>Errors</h3><ul>"
+		if linkedExperiments && (unreadableExperimentsCount > 0 || unmodifableExperiments.length > 0)
+			@$('.reparentLotButton').hide()
+			errorSummary += "<li>You do not have the necessary permissions to edit associated experimental results. Please contact your Administrator for assistance.</li>"
+		else
+			@$('.reparentLotButton').show()
+			errorSummary += "<li>None</li>"
+		errorSummary += "</ul>"
+
+		warningSummary = "<h3>Warnings</h3><ul>"
+		modifableExperiments = (linkedExperiments && modifableExperiments.length > 0)
+		if modifableExperiments || !linkedLots
+			if modifableExperiments
+				warningSummary += "<li>Reparenting this #{@lotLabel.toLowerCase()} will update dependent experimental results to reference the new #{@lotLabel} Corp Name. This will cause the database to diverge from the original experiment upload file.</li>"
+			if !linkedLots
+				parentCorpName = data.lot.parent.corpName
+				warningSummary += "<li>This is the only lot on the parent compound #{parentCorpName}. Reparening this #{@lotLabel.toLowerCase()} will delete #{parentCorpName}.</li>"
+		else
+			warningSummary += "<li>None</li>"
+		warningSummary += "</ul>"
+		return experimentSummary + lotSummary + errorSummary + warningSummary;
+
+	showOne:  (className) ->
+		classes = ["bv_deleteLotError", "bv_dependencySummary", "bv_dependencyCheckError", "bv_deleteLotSuccess"]
+		me = this
+		_.each(classes, (c) ->
+			if c == className
+				me.$("." + c).show()
+			else
+				me.$("." + c).hide()
+		)
+	
+	dependencyCheckError:  (data) ->
+		@.trigger('clearErrors', "DeleteLotController");
+		@trigger('notifyError', {
+			owner: 'DeleteLotController',
+			errorLevel: 'error',
+			message: 'Error checking dependencies'
+		})
+		@showOne('bv_dependencySummary')
+
+	deleteLotReturn: (data) ->
+		@.trigger('clearErrors', "DeleteLotController");
+		@trigger('notifyError', {
+			owner: 'DeleteLotController',
+			errorLevel: 'info',
+			message: "Successfully deleted #{@lotLabel}"
+		})
+		# Get summary of dependencies
+		@$(".bv_remainingLotsOnParentLinks").html(@lotSummary)
+
+		# Hide all buttons
+		@$(".reparentLotButtons").hide()
+
+		# Hide form title
+		@$(".bv_deleteLotTitle").hide()
+
+		# Show success message
+		@showOne('bv_deleteLotSuccess')
+
+		
+
+	deleteLotError:  (data) ->
+		@.trigger('clearErrors', "DeleteLotController");
+		@trigger('notifyError', {
+			owner: 'DeleteLotController',
+			errorLevel: 'error',
+			message: "Error deleting #{@lotLabel}"
+		})
+		@showOne('bv_deleteLotError')

--- a/modules/CmpdReg/src/client/ReparentLot.coffee
+++ b/modules/CmpdReg/src/client/ReparentLot.coffee
@@ -4,12 +4,12 @@ class ReparentLotController extends Backbone.View
 	events:
 		"click .cancelReparentLotButton": "handleCancelButtonClicked"
 		"click .reparentLotButton": "handleReparentButtonClicked"
-		"click .downloadLotButton": "downloadLot"
+		"click .backFromReparentLotButton": "back"
 		"click .bv_backToCreg": "handleBackToCregButtonClicked"
 
 
 	initialize: ->
-		_.bindAll(@, 'handleCancelButtonClicked', 'handleReparentButtonClicked', 'checkDependencies', 'dependencyCheckReturn', 'dependencyCheckError', 'reparentLotError', 'reparentLotReturn', 'downloadLot', 'handleBackToCregButtonClicked');
+		_.bindAll(@, 'handleCancelButtonClicked', 'handleReparentButtonClicked', 'checkDependencies', 'dependencyCheckReturn', 'dependencyCheckError', 'reparentLotError', 'reparentLotReturn', 'back', 'handleBackToCregButtonClicked');
 		# $(@el).empty()
 		$(@el).html @template()
 
@@ -62,8 +62,16 @@ class ReparentLotController extends Backbone.View
 			error: @.dependencyCheckError
 		});
 		
-	downloadLot: ->
-		window.open("/cmpdReg/export/corpName/"+@.corpName)
+	back: ->
+		this.hide()
+		@.trigger("back")
+
+
+	hide: ->
+		$(this.el).hide()
+
+	show: ->
+		$(this.el).show()
 
 	dependencyCheckReturn: (data) ->
 		@.trigger('clearErrors', "ReparentLotController");

--- a/modules/CmpdReg/src/client/ReparentLotView.html
+++ b/modules/CmpdReg/src/client/ReparentLotView.html
@@ -7,8 +7,6 @@
 		<h1>Failed to reparent lot. Please contact your administrator.</h1>
 	</div>
 	<div class="bv_reparentLotSuccess hide" style="">
-		<h1>Lot reparented successfully.
-		</h1>
 		<div class="bv_reparentLotSuccessSummary"></div>
 		<div class="MetaLotViewButtons buttons">
 			<input type=button class="button cregBtn bv_backToCreg small" style="margin-left:20px;float:left;" value="Back Home">

--- a/modules/CmpdReg/src/client/ReparentLotView.html
+++ b/modules/CmpdReg/src/client/ReparentLotView.html
@@ -16,7 +16,7 @@
 	<div class="bv_dependencySummary hide" style=""></div>
 	<div class="MetaLotViewButtons buttons reparentLotButtons">
 		<input type=button class="button cregBtn reparentLotButton hide" value="Reparent">
-		<input type=button class="button cregBtn downloadLotButton" value="Back">
 		<input type=button class="button cancelReparentLotButton" />
+		<input type=button class="button cregBtn backFromReparentLotButton" value="Back">
 	</div>
 </script>

--- a/modules/CmpdReg/src/client/ReparentLotView.html
+++ b/modules/CmpdReg/src/client/ReparentLotView.html
@@ -1,14 +1,15 @@
 <script type="text/template" id="ReparentLotView" xmlns="http://www.w3.org/1999/html">
-    <h2 class="form_title bv_title bv_deleteLotTitle"></h2>
+    <h2 class="form_title bv_title bv_reparentLotTitle"></h2>
 	<div class="bv_dependencyCheckError hide" style="">
 		<h1>Failed to check dependencies.</h1>
 	</div>
-	<div class="bv_deleteLotError hide" style="">
-		<h1>Failed to delete lot. Please contact your administrator.</h1>
+	<div class="bv_reparentLotError hide" style="">
+		<h1>Failed to reparent lot. Please contact your administrator.</h1>
 	</div>
-	<div class="bv_deleteLotSuccess hide" style="">
-		<h1>Lot deleted successfully.
+	<div class="bv_reparentLotSuccess hide" style="">
+		<h1>Lot reparented successfully.
 		</h1>
+		<div class="bv_reparentLotSuccessSummary"></div>
 		<div class="MetaLotViewButtons buttons">
 			<input type=button class="button cregBtn bv_backToCreg small" style="margin-left:20px;float:left;" value="Back Home">
 		</div>

--- a/modules/CmpdReg/src/client/ReparentLotView.html
+++ b/modules/CmpdReg/src/client/ReparentLotView.html
@@ -1,0 +1,23 @@
+<script type="text/template" id="ReparentLotView" xmlns="http://www.w3.org/1999/html">
+    <h2 class="form_title bv_title bv_deleteLotTitle"></h2>
+	<div class="bv_dependencyCheckError hide" style="">
+		<h1>Failed to check dependencies.</h1>
+	</div>
+	<div class="bv_deleteLotError hide" style="">
+		<h1>Failed to delete lot. Please contact your administrator.</h1>
+	</div>
+	<div class="bv_deleteLotSuccess hide" style="">
+		<h1>Lot deleted successfully.
+		</h1>
+		<div class="MetaLotViewButtons buttons">
+			<input type=button class="button cregBtn bv_backToCreg small" style="margin-left:20px;float:left;" value="Back Home">
+		</div>
+		<div class= "bv_remainingLotsOnParentLinks"></div>
+	</div>
+	<div class="bv_dependencySummary hide" style=""></div>
+	<div class="MetaLotViewButtons buttons reparentLotButtons">
+		<input type=button class="button cregBtn reparentLotButton hide" value="Reparent">
+		<input type=button class="button cregBtn downloadLotButton" value="Back">
+		<input type=button class="button cancelReparentLotButton" />
+	</div>
+</script>

--- a/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
+++ b/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
@@ -264,7 +264,7 @@ div {
     padding: 10px 5px 0px 5px;
     border: none;
 }
-.cancelNewSaltButton, .cancelDeleteLotButton {
+.cancelNewSaltButton, .cancelDeleteLotButton, .cancelReparentLotButton {
     background: no-repeat url('../images/cancel.png');
     float:right;
     height: 27px;

--- a/modules/CmpdReg/src/client/src/EditParent.js
+++ b/modules/CmpdReg/src/client/src/EditParent.js
@@ -195,11 +195,12 @@ $(function () {
             'click .nextButton': 'next',
             'click .cancelEditButton': 'cancel',
             'click .isVirtual': 'toggleParentsVisible',
-            'click .backToSearchButton': 'back'
+            'click .backToSearchButton': 'back',
+            'click .reparentLotPick': 'reparentLotPick'
         },
 
         initialize: function(){
-            _.bindAll(this, 'toggleParentsVisible', 'next');
+            _.bindAll(this, 'toggleParentsVisible', 'next', 'back', 'reparentLotPick');
             this.sketcherLoaded = false;
             this.hide();
             this.parentModel = this.options.parentModel;
@@ -282,6 +283,21 @@ $(function () {
         back: function() {
             this.trigger('searchResultsBack');
             this.hide();
+        },
+
+        reparentLotPick: function(e) {
+            el = $(e.target)
+            newSelectedParentCorpName = el.val()
+            if(typeof(this.reparentCorpNamePick) != 'undefined' && this.reparentCorpNamePick != null) {
+                if(this.reparentCorpNamePick == newSelectedParentCorpName) {
+                    el.prop('checked', false);
+                    this.reparentCorpNamePick = null;
+                } else {
+                    this.reparentCorpNamePick = newSelectedParentCorpName;
+                }
+            } else {
+                this.reparentCorpNamePick = newSelectedParentCorpName
+            }
         },
 
         next: function() {
@@ -506,6 +522,10 @@ $(function () {
         },
 
         editParentSearchResultsToReparentLotStep: function(selection, reparentLotSelection) {
+            // Edit parent workflow
+            if( this.reparentLotController !=null ) {
+                this.deleteReparentLotController();
+            }
 		    this.reparentLotController = new ReparentLotController({
                 el: this.$('.ReparentLotView'),
                 buttons: this.$('.ParentView .buttons'),
@@ -514,6 +534,9 @@ $(function () {
 			    errorNotifList: this.options.errorNotifList,
 			    user: this.user
 		    });
+            this.reparentLotController.show();
+            this.reparentLotController.bind('back', this.updateParentBack);
+
         },
 
         parentUpdated: function(ajaxReturn){
@@ -560,6 +583,12 @@ $(function () {
             this.parentController.delegateEvents({});
             this.parentController = null;
             this.$('.ParentView').html('');
+        },
+
+        deleteReparentLotController: function() {
+            this.reparentLotController.delegateEvents({});
+            this.reparentLotController = null;
+            this.$('.ReparentLotView').html('');
         },
 
         render: function () {

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -340,7 +340,8 @@ $(function() {
 			    corpName: this.model.get('corpName'),
 			    errorNotifList: this.options.errorNotifList,
 			    user: this.user,
-			    parentModel: parent
+			    parentModel: parent,
+				lotModel: this.model.get('lot')
 		    });
 	    },
 

--- a/modules/CmpdReg/src/client/src/Parent.js
+++ b/modules/CmpdReg/src/client/src/Parent.js
@@ -523,11 +523,13 @@ $(function() {
 		render: function() {
 			RegParentController.__super__.render.call(this);
 			this.$('.editParentButtonWrapper').hide();
+            this.$('.reparentLotWrapper').show();
 			return this;
 		},
 
         setupForRegSelect: function(saltForms) {
             this.$('.regPick').val(this.model.get('corpName'));
+            this.$('.reparentLotPick').val(this.model.get('corpName'));
             this.$('.corpName').html(this.model.get('corpName'));
             var lisb = window.configuration.metaLot.lotCalledBatch;
             this.$('.lotOrBatch').html(lisb?'batch':'lot');

--- a/modules/CmpdReg/src/client/src/Parent.js
+++ b/modules/CmpdReg/src/client/src/Parent.js
@@ -533,7 +533,7 @@ $(function() {
 			RegParentController.__super__.render.call(this);
 			this.$('.editParentButtonWrapper').hide();
 			if(this.showReparentLot){
-            	this.$('.reparentLotWrapper').show();
+				this.$('.reparentLotWrapper').show();
 			} else {
 				this.$('.reparentLotWrapper').hide();
 			}

--- a/modules/CmpdReg/src/client/src/Parent.js
+++ b/modules/CmpdReg/src/client/src/Parent.js
@@ -520,10 +520,23 @@ $(function() {
 
     window.RegParentController = ParentController.extend({
 
+		initialize: function() {
+			RegParentController.__super__.render.call(this);
+			if(typeof(this.options.showReparentLot) != "undefined" && this.options.showReparentLot == true){
+				this.showReparentLot = this.options.showReparentLot;
+			} else {
+				this.showReparentLot = false;
+			}
+		},
+
 		render: function() {
 			RegParentController.__super__.render.call(this);
 			this.$('.editParentButtonWrapper').hide();
-            this.$('.reparentLotWrapper').show();
+			if(this.showReparentLot){
+            	this.$('.reparentLotWrapper').show();
+			} else {
+				this.$('.reparentLotWrapper').hide();
+			}
 			return this;
 		},
 

--- a/modules/CmpdReg/src/client/src/ParentList.js
+++ b/modules/CmpdReg/src/client/src/ParentList.js
@@ -17,6 +17,11 @@ $(function() {
             var sfListCont;
             var js = this.options.json;
 
+            this.showReparentLot = false;
+            if(this.options.showReparentLot) {
+                this.showReparentLot = true;
+            }
+
 			_.each(js, function(pc){
                 parentController = self.setupParentController(pc);
 				$(self.el).append(parentController.render().el);
@@ -45,7 +50,8 @@ $(function() {
                 className: 'RegSearchResults_ParentView',
                 model: parent,
                 readMode: true,
-                step: 'regSearchResults'
+                step: 'regSearchResults',
+                showReparentLot: this.showReparentLot
             });
             return parentController;
 

--- a/modules/CmpdReg/src/client/templates/EditParentSearchResultsView.inc
+++ b/modules/CmpdReg/src/client/templates/EditParentSearchResultsView.inc
@@ -29,6 +29,10 @@
 		<div class="errorNotification_warning">
 			<span>The following matching structures were found. To be unique, the parent compound you are editing must be saved with a distinct Stereo Category/Stereo Comment combination.</span>
 		</div>
+		<div class="errorNotification_warning">
+			<span>Or if you want to move this Lot onto one of the parents below, toggle the "Reparent Lot onto this compound" checkbox on the desired parent structure below.</span>
+		</div>
+
 	</div>
 
 	<div class="EditParentSearchResults_ParentListView"></div>

--- a/modules/CmpdReg/src/client/templates/EditParentSearchResultsView.inc
+++ b/modules/CmpdReg/src/client/templates/EditParentSearchResultsView.inc
@@ -30,7 +30,7 @@
 			<span>The following matching structures were found. To be unique, the parent compound you are editing must be saved with a distinct Stereo Category/Stereo Comment combination.</span>
 		</div>
 		<div class="errorNotification_warning">
-			<span>Or if you want to move this Lot onto one of the parents below, toggle the "Reparent Lot onto this compound" checkbox on the desired parent structure below.</span>
+			<span>Or if you want to move this Lot onto one of the parents below, toggle the "Reparent lot to" radio on the desired parent structure below.</span>
 		</div>
 
 	</div>

--- a/modules/CmpdReg/src/client/templates/EditParentSearchView.inc
+++ b/modules/CmpdReg/src/client/templates/EditParentSearchView.inc
@@ -5,7 +5,11 @@
 	<div class="marvinWrapper"> <!--dependent? change name...-->
 		<iframe id="editParentMarvinSketch" class="sketcher-frame"></iframe>
 	</div>
-
+		<div class="corpNameInput">
+			<label>Or enter compound ID </label>
+			<input type=text class="corpName" />
+			</div>
+		</div>
 	<div class="buttons">
 		<a class="nextButton" href="#" onclick="this.blur(); return false;"><span></span></a>
 		<a class="cancelEditButton" href="#" onclick="this.blur(); return false;"><span></span></a>

--- a/modules/CmpdReg/src/client/templates/EditParentView.inc
+++ b/modules/CmpdReg/src/client/templates/EditParentView.inc
@@ -4,6 +4,7 @@
     <div class="EditParentSearchView"></div>
     <div class="EditParentSearchResultsView"></div>
     <div class="ParentView"></div>
+    <div class="ReparentLotView"></div>
 
 
 </script>

--- a/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
+++ b/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
@@ -1,14 +1,13 @@
 <script type="text/template" id="LotForm_ParentView_template">
 
     <div class="radioWrapper">
-        <input id="newLot" type="radio" name="regPick" class="regPick" ></input>
-        <label for="newLot">New <span class="lotOrBatch"></span> <span class="corpName"></span></label>
+        <label><input id="newLot" type="radio" name="regPick" class="regPick" ></input>New <span class="lotOrBatch"></span> <span class="corpName"></span></label>
+        
         <select class="FormInput saltFormCorpNames"></select>
     </div>
 
 	<div class="reparentLotWrapper hide">
-        <input id="reparentLot" type="radio" name="reparentLotPick" class="reparentLotPick" ></input>
-        <label for="reparentLot">Reparent <span class="lotOrBatch"></span> to <span class="corpName"></span></label>
+        <label><input id="reparentLot" type="radio" name="reparentLotPick" class="reparentLotPick" ></input>Reparent <span class="lotOrBatch"></span> to <span class="corpName"></span></label>
 	</div>
 
 	<div><h2>Parent Structure:</h2></div>

--- a/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
+++ b/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
@@ -6,6 +6,11 @@
         <select class="FormInput saltFormCorpNames"></select>
     </div>
 
+	<div class="reparentLotWrapper hide">
+        <input id="reparentLot" type="radio" name="reparentLotPick" class="reparentLotPick" ></input>
+        <label for="reparentLot">Reparent <span class="lotOrBatch"></span> to <span class="corpName"></span></label>
+	</div>
+
 	<div><h2>Parent Structure:</h2></div>
 
   <div class="parentImageWrapper">
@@ -82,6 +87,12 @@
 		<a class="button bv_saveUpdateParentButton saveUpdateParentButtonOn" href="#" onclick="this.blur(); return false;"></a>
 		<a class="button bv_cancelUpdateParentButton cancelUpdateParentButtonOn" href="#" onclick="this.blur(); return false;"></a>
 		<a class="button bv_backUpdateParentButton backUpdateParentButtonOn" href="#" onclick="this.blur(); return false;"></a>
+	</div>
+
+	<div class="ReparentLotButtons buttons hide">
+		<a class="button bv_saveReparentLotButton saveReparentLotButtonOn" href="#" onclick="this.blur(); return false;"></a>
+		<a class="button bv_cancelReparentLotButton cancelReparentLotButtonOn" href="#" onclick="this.blur(); return false;"></a>
+		<a class="button bv_backReparentLotButton backReparentLotButtonOn" href="#" onclick="this.blur(); return false;"></a>
 	</div>
 
 	<div class="ValidateParentErrorsPanel hide"></div>

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -264,6 +264,11 @@ exports.getMetaLotDependencies = (req, resp, next) ->
 		resp.statusCode = 500
 		resp.json {error: err}
 
+exports.getLotDependenciesByCorpNameInternal = (lotCorpName, user, allowedProjects, includeLinkedLots=true) ->
+	[err, metaLot, statusCode] = await exports.getMetaLotInternal(lotCorpName, user, allowedProjects, getDeleteAcl=false)
+	dependencies = await exports.getLotDependenciesInternal(metaLot.lot, user, allowedProjects, includeLinkedLots)
+	return dependencies
+
 exports.getLotDependenciesInternal = (lot, user, allowedProjects, includeLinkedLots=true) ->
 	console.log "Checking lot dependencies for lot #{lot.corpName} with user #{user.username}"
 


### PR DESCRIPTION
## Description
 - Added reparent lot workflow to edit parent workflow for compound reg admins only
 - If a structure is found by either the mol structure entered or by lot corp name an optional radio button is shown next to returned structures which allows the user to select the parent for reparenting.
 - If a structure is selected, and alternative step 3 is shown to the user which shows the expected changes to the user including:
   - Changed lot corp name
   - Changed lot corp number
   - Whether or not the parent is orphaned and will be deleted or not
   - The experimental results which will by modified by the change
   - The inventory results which will be modified by the change

## Related Issue
ACAS-216

## How Has This Been Tested?
acas client tests
Ran manual tests via the UI
Verified that lots over the max auto lot threshold maintain their lot number on reparenting and fail if the reparenting would cause a collision with lot corp names which may have that high lot number already.