### PR TITLE
ACAS-343: CI change to use corresponding acasclient version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,7 +35,7 @@ jobs:
       # If main or release branch, run tests using matching release branch of acasclient
       - name: Set ACAS_CLIENT_REF to the current branch ${{ github.ref }}
         run: |
-          echo "ACAS_CLIENT_REF=${{ github.ref }}" >> $GITHUB_ENV
+          echo "ACAS_CLIENT_REF=$(echo ${{ github.ref }} | sed 's/refs\/heads\///g')" >> $GITHUB_ENV
         if: github.event_name == 'push'
       # If a PR, run tests on acasclient branch matching destination of PR
       - name: Set ACAS_CLIENT_REF to the PR destination branch ${{ github.base_ref }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["master", "release/*"]
+  pull_request:
+    types: [opened, synchronize]
   create:
     tags: "**"
 jobs:
@@ -29,15 +31,35 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # The following few steps figure out what version of acasclient to test with
+      # If main or release branch, run tests using matching release branch of acasclient
+      - name: Set ACAS_CLIENT_REF to the current branch ${{ github.ref }}
+        run: |
+          echo "ACAS_CLIENT_REF=${{ github.ref }}" >> $GITHUB_ENV
+        if: github.event_name == 'push'
+      # If a PR, run tests on acasclient branch matching destination of PR
+      - name: Set ACAS_CLIENT_REF to the PR destination branch ${{ github.base_ref }}
+        run: |
+          echo "ACAS_CLIENT_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+       # If a tag, run tests on acasclient branch by the same tag
+      - name: Set ACAS_CLIENT_REF to tag extracted from ${{ github.ref }}
+        run: |
+          ACAS_CLIENT_REF=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')
+          echo "ACAS_CLIENT_REF=$ACAS_CLIENT_REF" >> $GITHUB_ENV
+        if: github.event_name == 'create'
+      # If on the "master" branch, run tests on the "main" branch of acasclient
+      - name: Override ACAS_CLIENT_REF if branch is "master"
+        run: |
+          echo "ACAS_CLIENT_REF=main" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
       - name: Checkout acasclient
         uses: actions/checkout@v3
         with:
           repository: mcneilco/acasclient
           path: acasclient
-          # Below checks out the same revision name as ACAS but skipping now
-          # because we don't want to keep acasclient version in sync with ACAS version
-          # at the moment.
-          # ref: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          # Check out the branch specified by ACAS_CLIENT_REF
+          ref: ${{ env.ACAS_CLIENT_REF }}
       - name: Build (no push)
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
## Description
- Switch from building every commit to branch to now only building on commits to `master` + `release/*` plus building on commits to PRs

## Related Issue

## How Has This Been Tested?
Pushing to release branches: Will be tested after this is merged
Pull requests: Testing via this PR. See successful tests within "checks" on this PR.
Tags: Created tag 0.0.dev344 on acasclient and acas repos. See build: https://github.com/mcneilco/acas/runs/7528166639?check_suite_focus=true