### PR TITLE
Add bulk download button to Experiment Browser

### DIFF
--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -426,13 +426,6 @@ class ExperimentBrowserController extends Backbone.View
 				@serviceReturn = null
 			dataType: 'json'
 
-
-
-
-		
-
-
-
 	setupExperimentSummaryTable: (experiments) =>
 		@destroyExperimentSummaryTable()
 

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -156,207 +156,10 @@ class ExperimentSimpleSearchController extends AbstractFormController
 	events:
 		'keyup .bv_experimentSearchTerm': 'updateExperimentSearchTerm'
 		'click .bv_doSearch': 'handleDoSearchClicked'
-		'click .bv_downloadFiles': 'downloadFiles'
 
 	render: =>
 		$(@el).empty()
 		$(@el).html @template()
-	
-	downloadFiles: =>
-		#extract the current search term in the experiment browser
-		experimentSearchTerm = $.trim(@$(".bv_experimentSearchTerm").val())
-		
-		#get the text value in the filter input text field
-		filterSearchTerm = $(".dataTables_filter input").val()
-
-		#replace "-" in filterSearchTerm with spaces (for filtering later on)
-		filterSearchTerm = filterSearchTerm.replaceAll("-", " ")
-
-		#create an array to store all experiment files
-		allExperimentFiles = []
-
-		#search for experiments
-		$.ajax
-			type: 'GET'
-			url: "/api/experiments/genericSearch/#{experimentSearchTerm}"
-			dataType: "json"
-			data:
-				testMode: false
-				fullObject: true
-			success: (response) =>
-				#Here we extract all of the file attachments in all the experiments that pass filtering
-				#Then we send the file urls to a route in the backend that makes and returns a zip
-
-				#helper function for handling competing metadata values
-				findMostRecentValue =(dates,values) ->
-					#if there are multiple competing values, it finds the most recent and returns it
-					if values.length == 0
-						return ""
-					else if values.length == 1
-						return values[0]
-					else
-						#if there are multiple values, find the index position of the highest date
-						mostRecentDatePosition = 0 #start at the initial position
-						for x in [0...dates.length]
-							if dates[x] > dates[mostRecentDatePosition]
-								mostRecentDatePosition = x
-						#select the value based on that index
-						return values[mostRecentDatePosition]
-
-				for experimentData in response
-					try
-						#create an array to store all the experiment's files
-						experimentFiles = []
-
-						#In addition to extracting each experiment's files...
-						#...we want to parse out the 9 metadata variables in the experiment browser to match filtering in the browser:
-						#Code, Name, Protocol Code, Protocol Name, Project, Scientist, Date, Status, Analysis Status
-
-						#extract the more easily accessible experiment metadata values
-						experimentCode = experimentData.codeName
-						experimentName = experimentData.lsLabels[0].labelText
-						experimentProtocolCode = experimentData.protocol.codeName
-						experimentProtocolName = experimentData.protocol.lsLabels[0].labelText
-
-						#Extract the more difficult to access experiment values
-						#Given the way some of the metadata is stored, its possible for an experiment to still have older values if an experiment has been modified...
-						#...so we need to keep track of all values and dates, then pick the most recent for these specific metadata values
-						experimentAnalysisStatusDates = []
-						experimentAnalysisStatusValues = []
-
-						experimentScientistDates = []
-						experimentScientistValues = []
-
-						experimentExperimentStatusDates = []
-						experimentExperimentStatusValues = []
-
-						for experimentLsState in experimentData.lsStates
-							if experimentLsState.lsKind == "experiment metadata"
-								for experimentLsValue in experimentLsState.lsValues
-									#extract the analysis status
-									if experimentLsValue.lsKind == "analysis status"
-										experimentAnalysisStatusValues.push experimentLsValue.codeValue
-										experimentAnalysisStatusDates.push experimentLsValue.recordedDate
-										
-									#extract the experiment scientist
-									if experimentLsValue.lsKind == "scientist"
-										experimentScientistValues.push experimentLsValue.codeValue
-										experimentScientistDates.push experimentLsValue.recordedDate
-
-									#extract the experiment status
-									if experimentLsValue.lsKind == "experiment status"
-										experimentExperimentStatusValues.push experimentLsValue.codeValue
-										experimentExperimentStatusDates.push experimentLsValue.recordedDate
-
-									#extract the experiment's date
-									if experimentLsValue.dateValue
-										experimentDate = new Date(experimentLsValue.dateValue)
-										#convert experimentDate into YYYY-MM-DD format
-										dd = experimentDate.getDate()
-										mm = experimentDate.getMonth() + 1 #need to add 1 to correct stored format being one month behind?
-										yyyy = experimentDate.getFullYear()
-										if dd < 10
-											dd = '0' + dd
-										if mm < 10
-											mm = '0' + mm
-										experimentDate = yyyy + " " + mm + " " + dd #We replace dashes with spaces for regex purposes
-
-									#extract any attachments for the experiment
-									if experimentLsValue.fileValue
-										#Keeping track of dates and values isn't necessary for files since they are all stored in separate lsValues (no duplicates)
-										experimentFiles.push "dataFiles/" + experimentLsValue.fileValue
-						
-						#Given the dates and corresponding values, find the most recent value
-						experimentAnalysisStatus = findMostRecentValue(experimentAnalysisStatusDates, experimentAnalysisStatusValues)
-						experimentExperimentStatus = findMostRecentValue(experimentExperimentStatusDates, experimentExperimentStatusValues)
-						experimentScientist = findMostRecentValue(experimentScientistDates, experimentScientistValues)
-
-						#if the experiment has been deleted, automatically fail filtering, don't include files in the download
-						if experimentExperimentStatus == "deleted"
-							passFiltering = false
-						#if there is no search term, automatically pass filtering
-						else if filterSearchTerm == "" 
-							passFiltering = true 
-						#if there is a search term, run checks for filtering
-						else
-							#create a large string containing all the experiment metadata of interest, run one search on it
-							experimentMetadataStr = experimentCode + " " +  experimentName + 
-							" " + experimentProtocolCode + " " + experimentProtocolName + 
-							" " + experimentScientist  + " " + experimentDate + " " + 
-							experimentAnalysisStatus + " " + experimentScientist + " " + 
-							experimentExperimentStatus
-							
-							#filterSearchTerm needs to be split into separate terms by spaces and checked individually
-							filterSearchTerms = filterSearchTerm.split(" ")
-
-							#all sub-terms need to be found in order to pass filtering, so if one is not found we set passFiltering to false
-							passFiltering = true 
-							for subSearchTerm in filterSearchTerms
-								#convert filterSearchTerm to case-insensitive regular expression
-								re = new RegExp(subSearchTerm, "i")
-
-								#if the term is not present, the experiment fails the filtering step, end the loop
-								if experimentMetadataStr.search(re) == -1
-									passFiltering = false
-									break
-																
-						#if the experiment passes the filtering criteria, append experiment files to total expeirment files
-						if passFiltering
-							for experimentFile in experimentFiles
-								allExperimentFiles.push experimentFile
-					catch error
-						console.log "There was an error parsing experiment metadata:" + error
-
-				#Get today's date to timestamp any experiment file exports
-				today = new Date
-				dd = today.getDate()
-				mm = today.getMonth() + 1
-				yyyy = today.getFullYear()
-				if dd < 10
-					dd = '0' + dd
-				if mm < 10
-					mm = '0' + mm
-				today = '_' + mm + '_' + dd + '_' + yyyy
-
-				#construct request
-				dataToPost =
-					fileName: "experiment_files" + today
-					mappings: JSON.parse(JSON.stringify(allExperimentFiles))
-					userName: window.AppLaunchParams.loginUser.username 
-
-				#send all experiment filenames to backend to zip up
-				$.ajax
-					type: 'POST'
-					url: "/api/exportExperimentFiles"
-					data: dataToPost
-					timeout: 6000000
-					success: (response) =>
-						#Since we can't directly send the .zip file to download it...
-						#...we create a hidden link with the download path and automatically click on it
-						a = document.createElement('a');
-						a.style.display = 'none';
-						a.href = "dataFiles/" + response;
-						document.body.appendChild(a);
-						a.click();
-
-						#Update GUI to indicate succesful download
-						$(".bv_downloadWarning").hide()
-						$(".bv_downloadSuccess").show()
-
-					error: (err) =>
-						console.log "Could not download files" + err
-
-						#Update GUI to indicate files could not be downloaded
-						$(".bv_downloadSuccess").hide()
-						$(".bv_downloadWarning").show()
-						@serviceReturn = null
-					dataType: 'json'
-			error: (err) =>
-				console.log "Could not search for experiments" + err
-				$(".bv_downloadSuccess").hide()
-				$(".bv_downloadWarning").show()
-
-
 
 
 	updateExperimentSearchTerm: (e) =>
@@ -541,6 +344,7 @@ class ExperimentBrowserController extends Backbone.View
 		"click .bv_duplicateExperiment": "handleDuplicateExperimentClicked"
 		"click .bv_confirmDeleteExperimentButton": "handleConfirmDeleteExperimentClicked"
 		"click .bv_cancelDelete": "handleCancelDeleteClicked"
+		'click .bv_downloadFiles': 'downloadFiles'
 
 	initialize: ->
 		template = _.template( $("#ExperimentBrowserView").html(),  {includeDuplicateAndEdit: @includeDuplicateAndEdit} );
@@ -552,6 +356,82 @@ class ExperimentBrowserController extends Backbone.View
 			includeDuplicateAndEdit: @includeDuplicateAndEdit
 		@searchController.render()
 		@searchController.on "searchReturned", @setupExperimentSummaryTable.bind(@)
+
+	downloadFiles: =>
+		#extract the experiment data from the summary table
+		experimentMetadata = @experimentSummaryTable.collection.models
+		#console.log experimentMetadata
+		#console.log JSON.stringify(experimentMetadata)
+
+		#collect the codes of the experiments that are currently shown
+		table = $(".bv_experimentTableController .dataTables_wrapper .table").dataTable()
+		filteredExperimentCodes = []
+		for filteredExperiments in table._('tr', {'filter': 'applied'})
+			filteredExperimentCodes.push filteredExperiments[0]
+		
+		#create an array to store all the experiment's files
+		experimentFiles = []
+		for experimentData in experimentMetadata
+			#if the experiment code is in the filtered codes, search for associated files
+			if experimentData.attributes.codeName in filteredExperimentCodes
+				for experimentLsState in experimentData.attributes.lsStates.models
+					if experimentLsState.attributes.lsKind == "experiment metadata"
+						for experimentLsValue in experimentLsState.attributes.lsValues.models
+							if experimentLsValue.attributes.fileValue
+								#add files to experimentFiles
+								experimentFiles.push "dataFiles/" + experimentLsValue.attributes.fileValue
+
+		#Get today's date to timestamp any experiment file exports
+		today = new Date
+		dd = today.getDate()
+		mm = today.getMonth() + 1
+		yyyy = today.getFullYear()
+		if dd < 10
+			dd = '0' + dd
+		if mm < 10
+			mm = '0' + mm
+		today = '_' + mm + '_' + dd + '_' + yyyy
+
+		#construct request
+		dataToPost =
+			fileName: "experiment_files" + today
+			mappings: JSON.parse(JSON.stringify(experimentFiles))
+			userName: window.AppLaunchParams.loginUser.username 
+
+		#send all experiment filenames to backend to zip up
+		$.ajax
+			type: 'POST'
+			url: "/api/exportExperimentFiles"
+			data: dataToPost
+			timeout: 6000000
+			success: (response) =>
+				#Since we can't directly send the .zip file to download it...
+				#...we create a hidden link with the download path and automatically click on it
+				a = document.createElement('a');
+				a.style.display = 'none';
+				a.href = "dataFiles/" + response;
+				document.body.appendChild(a);
+				a.click();
+
+				#Update GUI to indicate succesful download
+				$(".bv_downloadWarning").hide()
+				$(".bv_downloadSuccess").show()
+
+			error: (err) =>
+				console.log "Could not download files" + err
+
+				#Update GUI to indicate files could not be downloaded
+				$(".bv_downloadSuccess").hide()
+				$(".bv_downloadWarning").show()
+				@serviceReturn = null
+			dataType: 'json'
+
+
+
+
+		
+
+
 
 	setupExperimentSummaryTable: (experiments) =>
 		@destroyExperimentSummaryTable()

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -360,9 +360,7 @@ class ExperimentBrowserController extends Backbone.View
 	downloadFiles: =>
 		#extract the experiment data from the summary table
 		experimentMetadata = @experimentSummaryTable.collection.models
-		#console.log experimentMetadata
-		#console.log JSON.stringify(experimentMetadata)
-
+		
 		#collect the codes of the experiments that are currently shown
 		table = $(".bv_experimentTableController .dataTables_wrapper .table").dataTable()
 		filteredExperimentCodes = []

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
@@ -53,6 +53,7 @@
 							<i class="icon-search bv_doSearchIcon"></i>
 							<i class="icon-remove bv_clearSearchIcon hide"></i>
 						</button>
+						<button class="btn bv_downloadFiles" style="float: right; margin-top: auto; margin-bottom: auto;">Download All</button>
 					</div>
 				</div>
 			<!-- </form> -->

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
@@ -54,6 +54,10 @@
 							<i class="icon-remove bv_clearSearchIcon hide"></i>
 						</button>
 						<button class="btn bv_downloadFiles" style="float: right; margin-top: auto; margin-bottom: auto;">Download All Files</button>
+						<br/>
+						<div class="bv_downloadWarning hide" style="color: red; font-size: 12px; text-align: right;">Could not download files</div>
+						<div class="bv_downloadSuccess hide" style="color: green; font-size: 12px; text-align: right;">Downloaded successfully</div>
+
 					</div>
 				</div>
 			<!-- </form> -->

--- a/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowserView.html
@@ -53,7 +53,7 @@
 							<i class="icon-search bv_doSearchIcon"></i>
 							<i class="icon-remove bv_clearSearchIcon hide"></i>
 						</button>
-						<button class="btn bv_downloadFiles" style="float: right; margin-top: auto; margin-bottom: auto;">Download All</button>
+						<button class="btn bv_downloadFiles" style="float: right; margin-top: auto; margin-bottom: auto;">Download All Files</button>
 					</div>
 				</div>
 			<!-- </form> -->

--- a/modules/ExperimentBrowser/src/server/routes/ExperimentBrowserRoutes.coffee
+++ b/modules/ExperimentBrowser/src/server/routes/ExperimentBrowserRoutes.coffee
@@ -5,8 +5,6 @@ Add this line to public/src/modules/ModuleMenus/src/client/ModuleMenusConfigurat
 
 ###
 
-path = require 'path'
-
 
 exports.setupRoutes = (app, loginRoutes) ->
 	app.get '/api/experimentsForProtocol/:protocolCode', loginRoutes.ensureAuthenticated, exports.experimentsForProtocol


### PR DESCRIPTION
## Description
Made download button that given a current search and filter term, creates and downloads a zip for all files for matching experiments. 
* Created /exportExperimentFiles in ExperimentBrowserRoutes.coffee that takes an array of file names, creates a .zip file from them, and returns the .zip file name
- Created downloadFiles function in ExperimentBrowser.coffee that extracts all current experiments that pass filtering in the table sends array of their associated files to /exportExperimentFiles, downloads a .zip of the file and notifies user 

## How Has This Been Tested?
Created several experiments with different attachments, and attributes. Also deleted experiments to make sure that deleted experiment files weren't being included in the downloaded files. 

<img width="1444" alt="Screen Shot 2022-08-02 at 4 47 21 PM" src="https://user-images.githubusercontent.com/107148842/182470406-41f62560-0f5b-4615-b788-46310008ef3b.png">

<img width="1021" alt="Screen Shot 2022-08-02 at 5 00 24 PM" src="https://user-images.githubusercontent.com/107148842/182472458-8a6bc143-63f8-4492-943d-c395dbf0ed5f.png">

