### PR TITLE
Generating Link Bar Overflows on Screen When Copy Link Button is Visible 

### DIFF
--- a/modules/Components/src/client/OpenExperimentInQueryTool.coffee
+++ b/modules/Components/src/client/OpenExperimentInQueryTool.coffee
@@ -57,6 +57,7 @@ class OpenExperimentInQueryToolController extends Backbone.View
                 @$('.bv_generatingLink').hide()
                 @$('.bv_getLinkResults').show()
                 @$('.bv_exptLink').val(response)
+                @$('.bv_getLinkQueryToolButton').attr("disabled", true)
             error: (err) =>
                 # Take Away Generating Progress Mask 
                 @$('.bv_generatingLink').hide()


### PR DESCRIPTION
**Original Steps to Reproduce**

- Upload an SEL file using the Experiment Loader.
- Click Generate Link
- Click Generate Link Again When Copy Link Button is Present 

**Original Observed Results**

The blue loading bar would extend beyond the grey summary box and would be aesthetically displeasing 

**Expected results:**

The blue loading bar should not extend beyond the grey summary box.

**Changed Behavior**

The Generate Link button is disabled after the first time the system successfully generates a link. This prevents the original UI bug from occurring since the loading bar should not be visible to the user for an extended period of time while the Copy Link button is also visible.