### PR TITLE
Fix issue with detection of failed login for applications that require 302 and location

### DIFF
--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -189,6 +189,11 @@ exports.ensureAuthenticated = (req, res, next) ->
 			exports.ssoRelayStateRedirect(req, res, next)
 	else
 		# If Authentication strategy is not SAML then redirect to the login page
+		# If this is a failed login attempt we send the location because
+		# this is a redirect and some dependent systems require a location to detect
+		# failed login attempts.
+		res.statusCode = 302
+		res.location('/login')
 		exports.loginPage(req, res, next)
 
 exports.ensureCmpdRegAdmin = (req, res, next) ->


### PR DESCRIPTION
## Description
 - Some applications require 302 status and a location header set to /login when failing to login to ACAS, a change to the login routes returned 200 and did not set the location header

## Related Issue
ACAS-389

## How Has This Been Tested?
Tested against and application that requires 302 and location header set and verified this fixed the issue of detecting a failed authentication.
Verified that normal UI login worked as expected.