### PR TITLE
Logout redirect to base path

### DIFF
--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -114,18 +114,20 @@ exports.changePost = (req, res) ->
 
 exports.logout = (req, res) ->
 	req.logout =>
+		# If using saml then redirect to the specified logout url
 		if config.all.server.security.saml.use == true && config.all.server.security.saml.logoutRedirectURL?
 			redirectMatch = config.all.server.security.saml.logoutRedirectURL
 		else 
+			# If the original url is e.g. /logout/cmpdreg then attempt to redirect to /cmpdreg
 			redirectMatch = req.originalUrl.match(/^\/logout\/(.*)\/?$/i)
 			if redirectMatch?
-				redirectMatch = redirectMatch[1]
+				redirectMatch = "/#{redirectMatch[1]}"
 			else
+				# If the url is just /logout then redirect to the base path
 				if config.all.client.basePath?
 					redirectMatch = config.all.client.basePath
 				else
 					redirectMatch = '/'
-				redirectMatch = "/"
 		res.redirect redirectMatch
 
 exports.ssoLogin = (req, res, next) ->


### PR DESCRIPTION
## Description
 - /logout should redirect users to the configured base path, currently it's just redirecting to "/" which is LD
 - Going to /logout/cmpdreg should redirect users to /cmpdreg
    -  This is a feature added a long time ago to make links to /logout/cmpdreg easy to create
    - The only known use case is for the excel apps we created which call /logout/excelApps when logging users out but its still a use case.

## Related Issue
ACAS-390

## How Has This Been Tested?
Ran on Kubernetes instance of ACAS where login is /acas and verified logout takes you back to /acas
Ran on local instance of ACAS where login is / and verified logout takes you back to /
Ran /logout/cmpdreg on both K8s and local instance and verified login page is rendered with `After login you will be redirected to /cmpdreg` and you are then redirected back to K8s after login