### PR TITLE
Set status code 401 when user is not authenticated and send the login page

### DIFF
--- a/modules/Login/src/server/routes/loginRoutes.coffee
+++ b/modules/Login/src/server/routes/loginRoutes.coffee
@@ -188,7 +188,9 @@ exports.ensureAuthenticated = (req, res, next) ->
 	if config.all.server.security.saml.use == true
 			exports.ssoRelayStateRedirect(req, res, next)
 	else
-		# If Authentication strategy is not SAML then redirect to the login page
+		# If Authentication strategy is not SAML then send the login page
+		# And set the status code to 401
+		res.statusCode = 401
 		exports.loginPage(req, res, next)
 
 exports.ensureCmpdRegAdmin = (req, res, next) ->


### PR DESCRIPTION
## Description
 - Applications using the ACAS api need a way to detect a failed login.  Instead of setting 302 and location /login. We should respond with a 401 and the login page.

## Related Issue
ACAS-389

## How Has This Been Tested?
Verified that normal UI login worked as expected.
Verified that requesting /cmpdreg when logged out rendered `After login you will be redirected to /cmpdreg` and that after successful login, the user was redirected to /cmpdreg.
Verified logout worked as expected.