### PR TITLE
Fix issue with scoping button between deleteLot and metalot

### DIFF
--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -322,7 +322,7 @@ $(function() {
 	    deleteLotRequest: function () {
 		    this.trigger('clearErrors', "MetaLotController");
 		    this.trigger('clearErrors', "LotController");
-			this.delegateEvents({}); // stop listening to buttons
+		    this.delegateEvents({}); // stop listening to buttons
 		    $(this.el).empty();
 		    this.deleteLotController = new DeleteLotController({
 			    el: $(this.el),

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -111,7 +111,7 @@ $(function() {
 		    'click .cancelButton': 'close',
 		    'click .newLotButton': 'newLot',
 		    'click .deleteButton': 'deleteLotRequest',
-		    'click .downloadLotButton': 'downloadLot'
+		    'click .downloadMetaLotButton': 'downloadLot'
 	    },
 
 	    initialize: function () {
@@ -199,7 +199,7 @@ $(function() {
 		    var lisb = window.configuration.metaLot.lotCalledBatch;
 		    if (this.model.get('lot').isNew()) {
 			    this.$('.newLotButton').hide();
-			    this.$('.downloadLotButton').hide();
+			    this.$('.downloadMetaLotButton').hide();
 			    this.$('.deleteButton').hide();
 			    this.$('.saveButton').addClass('saveImage');
 			    this.$('.saveButton').removeClass('updateImage');

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -111,7 +111,7 @@ $(function() {
 		    'click .cancelButton': 'close',
 		    'click .newLotButton': 'newLot',
 		    'click .deleteButton': 'deleteLotRequest',
-		    'click .downloadMetaLotButton': 'downloadLot'
+		    'click .downloadLotButton': 'downloadLot'
 	    },
 
 	    initialize: function () {
@@ -199,7 +199,7 @@ $(function() {
 		    var lisb = window.configuration.metaLot.lotCalledBatch;
 		    if (this.model.get('lot').isNew()) {
 			    this.$('.newLotButton').hide();
-			    this.$('.downloadMetaLotButton').hide();
+			    this.$('.downloadLotButton').hide();
 			    this.$('.deleteButton').hide();
 			    this.$('.saveButton').addClass('saveImage');
 			    this.$('.saveButton').removeClass('updateImage');
@@ -322,6 +322,7 @@ $(function() {
 	    deleteLotRequest: function () {
 		    this.trigger('clearErrors', "MetaLotController");
 		    this.trigger('clearErrors', "LotController");
+			this.delegateEvents({}); // stop listening to buttons
 		    $(this.el).empty();
 		    this.deleteLotController = new DeleteLotController({
 			    el: $(this.el),

--- a/modules/CmpdReg/src/client/templates/LotForm/MetaLotView.inc
+++ b/modules/CmpdReg/src/client/templates/LotForm/MetaLotView.inc
@@ -9,7 +9,7 @@
 		<a class="button cancelButton" href="#" onclick="this.blur(); return false;"></a>
 		<a class="button backButton" href="#" onclick="this.blur(); return false;"></a>
         <a class="button newLotButton" href="#" onclick="this.blur(); return false;"></a>
-		<a class="button cregBtn downloadLotButton small" href="#" onclick="this.blur(); return false;">Download SDF</a>
+		<a class="button cregBtn downloadMetaLotButton small" href="#" onclick="this.blur(); return false;">Download SDF</a>
 		<a class="button cregBtn deleteButton" href="#" onclick="this.blur(); return false;">Delete...</a>
 	</div>
     <div class="floatingPanel NewLotSuccessView"></div>

--- a/modules/CmpdReg/src/client/templates/LotForm/MetaLotView.inc
+++ b/modules/CmpdReg/src/client/templates/LotForm/MetaLotView.inc
@@ -9,7 +9,7 @@
 		<a class="button cancelButton" href="#" onclick="this.blur(); return false;"></a>
 		<a class="button backButton" href="#" onclick="this.blur(); return false;"></a>
         <a class="button newLotButton" href="#" onclick="this.blur(); return false;"></a>
-		<a class="button cregBtn downloadMetaLotButton small" href="#" onclick="this.blur(); return false;">Download SDF</a>
+		<a class="button cregBtn downloadLotButton small" href="#" onclick="this.blur(); return false;">Download SDF</a>
 		<a class="button cregBtn deleteButton" href="#" onclick="this.blur(); return false;">Delete...</a>
 	</div>
     <div class="floatingPanel NewLotSuccessView"></div>


### PR DESCRIPTION
## Description
 - When re-using the same element like we do in meta lot, we need to stop listing to buttons events especially if we are listing for clicks old the same class name.
 - This stop listing to any metalot events when creating the delete lot controller.
  
## Related Issue
ACAS-393

## How Has This Been Tested?
With web inspector, verified that meta lot "downloadLot" function is no longer called when clicking "downloadLotButton" in Delete Lot view. Verified that DeleteLot controller "downloadLot" was called and that the sdf downloaded properly.