### PR TITLE
SSO login map group attributes to ACAS roles

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -363,7 +363,7 @@ server.security.saml.entryPoint=https://<organization>.okta.com/app/<appName>/<i
 server.security.saml.issuer=http://www.okta.com/<issuerID>
 # Embedded cert needs \\n in string to escape properly
 server.security.saml.cert=-----BEGIN CERTIFICATE-----\\nABC\\nXYZ\\n-----END CERTIFICATE-----
-server.security.saml.groupAttribute=group
+server.security.saml.profileAttributeToSystemRoles=[{"ssoName":"ACASUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"ssoName":"ACASAdmin","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"ssoName":"CmpdRegUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"ssoName":"CmpdRegAdmin","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"ssoName":"CmpdRegReadOnlyUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"ssoName":"ACASCrossProjectLoaderUser","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]
 server.security.saml.userNameAttribute=nameID
 server.security.saml.firstNameAttribute=firstName
 server.security.saml.lastNameAttribute=lastName
@@ -379,7 +379,7 @@ client.security.syncLdapAuthRoles=${server.security.syncLdapAuthRoles}
 client.scientistCodeOrigin=ACAS authors
 client.molecularTargetCodeOrigin=ACAS DDICT
 
-client.roles.loginRole=ROLE_ACAS-USERS,ROLE_CMPDREG-USERS
+client.roles.loginRole=ROLE_ACAS-USERS,ROLE_CMPDREG-USERS,ROLE_CMPDREG-READONLY
 client.roles.cmpdreg.chemistRole=ROLE_CMPDREG-USERS
 client.roles.cmpdreg.adminRole=ROLE_CMPDREG-ADMINS
 client.roles.acas.userRole=ROLE_ACAS-USERS


### PR DESCRIPTION
## Description
 - Switch to mapping specific group attributes to ls role configs which map the SSO group attribute to a system role
 - Add `ROLE_CMPDREG-READONLY` to users able to login (can search creg but nothing else)
 
<img width="483" alt="Screen Shot 2022-08-10 at 7 52 26 PM" src="https://user-images.githubusercontent.com/868119/184042347-099bcff4-15ee-4627-b878-14bca838188f.png">


## Related Issue
ACAS-394

## How Has This Been Tested?
Verified features of ACAS were added or removed by adding roles to a user one by one.
 - Added user to acas-users group and verified they could login and see acas-user module menus but not admin or creg
 - Added user to acas-admins group and verified they could see the addition acas admin module menus but not creg 
 - Added user to cmpdreg-users and verified they could see creg but not creg admin
 - Added user to cmpdreg-admins and verified they could see cmpd reg admin modules and bulk load admin purge app
 - Revoked all roles except cmpdreg-readonly and verified I could login but not see any acas user, admin or creg admin modules but could search creg.
 - Verified that cross project loader role was given when assigned but didn't actually test the role functionality.

Verified as I added or removed user from groups, that the SQL below yielded the correct roles in the ACAS DB when they hit the login endpoint which synched their roles:

e.g.
```
SELECT a.user_name, r.ls_kind, r.role_name
FROM author a
join author_role ar on a.id=ar.author_id
join ls_role r on ar.lsrole_id=r.id
WHERE r.ls_type='System'
and a.user_name = 'brian.bolt@boltengineered.com';
```

Full access to all:
```
           user_name           | ls_kind |           role_name            
———————————————+————+————————————————
 brian.bolt@boltengineered.com | ACAS    | ROLE_ACAS-ADMINS
 brian.bolt@boltengineered.com | ACAS    | ROLE_ACAS-CROSS-PROJECT-LOADER
 brian.bolt@boltengineered.com | ACAS    | ROLE_ACAS-USERS
 brian.bolt@boltengineered.com | CmpdReg | ROLE_CMPDREG-ADMINS
 brian.bolt@boltengineered.com | CmpdReg | ROLE_CMPDREG-READONLY
 brian.bolt@boltengineered.com | CmpdReg | ROLE_CMPDREG-USERS
(6 rows)
```