### PR TITLE
CReg Bulk Loader: Fixed sorting bug on "Has File Been Updated" column

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -955,20 +955,12 @@ class FileRowSummaryController extends Backbone.View
 			currentFileLink: "/api/cmpdRegBulkLoader/getSDFFromBulkLoadFileID/" + reportID
 			currentFileName: currentFileName
 			reportName: reportName
+			bulkFileUpdated: @model.get('bulkFileUpdated')
 			#remove special characters from the links to prevent errors, but not from the displayed names
 			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(fileName)
 			reportLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(reportName)
 		$(@el).html(@template(toDisplay))
 
-		#Check whether lots in the bulk file have been updated since they were registered
-		$.ajax
-			type: 'GET'
-			url: "/api/cmpdRegBulkLoader/checkForBulkLoadFileModifications/" + reportID
-			dataType: "json"
-			success: (response) =>
-				@$('.bv_bulkFileUpdated').html response
-			error: (err) =>
-				@$('.bv_bulkFileUpdated').html "N/A"
 		@
 
 class FileSummaryTableController extends Backbone.View

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -265,7 +265,7 @@
     <td class='bv_loadDate'><%-loadDate%></td>
     <td class='bv_loadUser'><%-loadUser%></td>
     <td class="bv_currentSDF"><a href=<%-currentFileLink%> download="<%-currentFileName%>">Download</a></td>
-    <td class="bv_bulkFileUpdated"></td>
+    <td class="bv_bulkFileUpdated"><%-bulkFileUpdated%></td>
     <td class='bv_Report'><a href='<%-reportLink%>'><%-reportName%></a></td>
 </script>
 

--- a/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
+++ b/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
@@ -7,7 +7,6 @@ exports.setupAPIRoutes = (app, loginRoutes) ->
 	app.get '/api/cmpdRegBulkLoader/getFilesToPurge', exports.getFilesToPurge
 	app.post '/api/cmpdRegBulkLoader/purgeFile', exports.purgeFile
 	app.get '/api/cmpdRegBulkLoader/getSDFFromBulkLoadFileId/:bulkFileID', exports.getSDFFromBulkLoadFileId
-	app.get '/api/cmpdRegBulkLoader/checkForBulkLoadFileModifications/:bulkFileID', exports.checkForBulkLoadFileModifications
 
 
 
@@ -22,7 +21,6 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/api/cmpdRegBulkLoader/checkFileDependencies', loginRoutes.ensureAuthenticated, exports.checkFileDependencies
 	app.post '/api/cmpdRegBulkLoader/purgeFile', loginRoutes.ensureAuthenticated, exports.purgeFile
 	app.get '/api/cmpdRegBulkLoader/getSDFFromBulkLoadFileId/:bulkFileID', loginRoutes.ensureAuthenticated, exports.getSDFFromBulkLoadFileId
-	app.get '/api/cmpdRegBulkLoader/checkForBulkLoadFileModifications/:bulkFileID', loginRoutes.ensureAuthenticated, exports.checkForBulkLoadFileModifications
 
 exports.cmpdRegBulkLoaderIndex = (req, res) ->
 	scriptPaths = require './RequiredClientScripts.js'
@@ -71,8 +69,60 @@ exports.getFilesToPurge = (req, resp) ->
 		config = require '../conf/compiled/conf.js'
 		serverUtilityFunctions = require './ServerUtilityFunctions.js'
 		baseurl = config.all.client.service.cmpdReg.persistence.fullpath+"bulkload/files"
-		serverUtilityFunctions.getFromACASServer(baseurl, resp)
+		request = require 'request'
+		#in the first request, get all the file data
+		request(
+			method: 'GET'
+			url: baseurl
+			json: true
+		, (error, response, json) =>
+			if !error && response.statusCode == 200
+				resp.statusCode = response.statusCode
 
+				#after getting the file data, we need to check if the each file has been updated or not
+				for fileData in json
+					try
+						#get all lots associated with each file
+						baseurl = config.all.client.service.cmpdReg.persistence.fullpath+"bulkload/getLotsByBulkLoadFileID?bulkLoadFileID=" + fileData.id 
+						response = await fetch(baseurl, method: 'GET')
+						checkStatus response
+						lotCorpNames = await response.json()
+
+						#If one of the lots has been modified, we say the bulkFile has been updated
+						bulkFileUpdated = "No"
+
+						#run a loop to find out if each lot has been modified, and if so who/when
+						for lotName in lotCorpNames
+							baseurl = config.all.client.service.cmpdReg.persistence.fullpath + "/metalots/corpName/" + lotName
+							response = await fetch(baseurl, method: 'GET')
+
+							checkStatus response
+							lotMetadata = await response.json()
+							lotModifiedBy = lotMetadata.lot.modifiedBy
+							# TODO - Add sorting for who last modified the bulk file, and when it was last modified
+							# TODO - When you edit a lot in ACAS, it doesn't seem to record the modified date 
+							#lotModifiedDate = lotMetadata.lot.modifiedDate
+
+							#if there is a user who modified one of the lots, we know that the lots in file have been udpated and end the loop
+							if lotModifiedBy != null
+								bulkFileUpdated = "Yes"
+								break
+
+						#Update whether the file has been updated or not
+						fileData.bulkFileUpdated = bulkFileUpdated
+				
+					catch err
+						fileData.bulkFileUpdated = "N/A" 
+						console.log "Error checking for if file has been modified: " + err
+			
+				resp.json json
+			else
+				console.log 'got ajax error'
+				console.log error
+				console.log json
+				callback 500, {error: true, message:error}
+		)
+			
 exports.cmpdRegBulkLoaderReadSdf = (req, resp) ->
 	if req.query.testMode or global.specRunnerTestmode
 		cmpdRegBulkLoaderTestJSON = require '../public/javascripts/spec/testFixtures/CmpdRegBulkLoaderServiceTestJSON.js'
@@ -392,54 +442,6 @@ exports.getSDFFromBulkLoadFileId = (req, resp) ->
 			console.log 'got ajax error trying to retrieve lots from bulk file ID'
 			console.log error
 			console.log json
-			console.log response
-			resp.end JSON.stringify "Error"
-	)
-
-exports.checkForBulkLoadFileModifications = (req, resp) ->
-	req.setTimeout 86400000
-	config = require '../conf/compiled/conf.js'
-	baseurl = config.all.client.service.cmpdReg.persistence.fullpath+"bulkload/getLotsByBulkLoadFileID?bulkLoadFileID=" +req.params.bulkFileID
-	request = require 'request'
-	request(
-		method: 'GET'
-		url: baseurl
-		json: true
-	, (error, response, lotCorpNames) =>
-		if !error && response.statusCode == 200
-			try
-				#If one of the lots has been modified, we say the bulkFile has been updated
-				bulkFileUpdated = "No"
-
-				#run a loop to find out if each lot has been modified, and if so who/when
-				for lotName in lotCorpNames
-					baseurl = config.all.client.service.cmpdReg.persistence.fullpath + "/metalots/corpName/" + lotName
-					response = await fetch(baseurl, method: 'GET')
-
-					checkStatus response
-					lotMetadata = await response.json()
-					lotModifiedBy = lotMetadata.lot.modifiedBy
-					# TODO - Add sorting for who last modified the bulk file, and when it was last modified
-					# TODO - When you edit a lot in ACAS, it doesn't seem to record the modified date 
-					#lotModifiedDate = lotMetadata.lot.modifiedDate
-
-					#if there is a user who modified one of the lots, we know that the lots in file have been udpated and end the loop
-					if lotModifiedBy != null
-						bulkFileUpdated = "Yes"
-						break
-
-				resp.end JSON.stringify bulkFileUpdated
-
-		
-			catch err
-				console.log "Error calling service: " + err
-				resp.statusCode = 500
-				resp.json err			
-
-		else
-			console.log 'got ajax error trying to retrieve lots from bulk file ID'
-			console.log error
-			console.log lotCorpNames
 			console.log response
 			resp.end JSON.stringify "Error"
 	)


### PR DESCRIPTION
## Description
There was a bug where you could not sort "Has File Been Updated" on the purge files page in the CReg Bulk Loader. This was because the logic for checking for whether the file was updated or not was done and added to the HTML after the dataTable was already generated. 

To fix the bug, the checkForBulkLoadFileModifications() route for checking whether a file has already been updated or not was moved into the getFilesToPurge() route. As a result, the bulkFile data object contained data on whether the file had been modified earlier on, and there was no need to run a separate request to check and update the table after it had already been generated. 

## How Has This Been Tested?
<img width="674" alt="Screen Shot 2022-08-11 at 4 51 19 PM" src="https://user-images.githubusercontent.com/107148842/184239955-f83011c4-3e06-43b6-b806-2ff1bce6f657.png">
<img width="682" alt="Screen Shot 2022-08-11 at 4 51 14 PM" src="https://user-images.githubusercontent.com/107148842/184239976-f8d42537-ca07-4dbe-8406-67345d34dd28.png">

Tested with local data. 