### PR TITLE
Removed all "has file been updated?" parts of CReg Bulk Loader

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -958,17 +958,7 @@ class FileRowSummaryController extends Backbone.View
 			#remove special characters from the links to prevent errors, but not from the displayed names
 			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(fileName)
 			reportLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(reportName)
-		$(@el).html(@template(toDisplay))
-
-		#Check whether lots in the bulk file have been updated since they were registered
-		$.ajax
-			type: 'GET'
-			url: "/api/cmpdRegBulkLoader/checkForBulkLoadFileModifications/" + reportID
-			dataType: "json"
-			success: (response) =>
-				@$('.bv_bulkFileUpdated').html response
-			error: (err) =>
-				@$('.bv_bulkFileUpdated').html "N/A"
+		$(@el).html(@template(toDisplay))		
 		@
 
 class FileSummaryTableController extends Backbone.View

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -265,7 +265,6 @@
     <td class='bv_loadDate'><%-loadDate%></td>
     <td class='bv_loadUser'><%-loadUser%></td>
     <td class="bv_currentSDF"><a href=<%-currentFileLink%> download="<%-currentFileName%>">Download</a></td>
-    <td class="bv_bulkFileUpdated"></td>
     <td class='bv_Report'><a href='<%-reportLink%>'><%-reportName%></a></td>
 </script>
 
@@ -277,7 +276,6 @@
                 <th>Load Date</th>
                 <th>Load User</th>
                 <th>Current File</th>
-                <th>Has File Been Updated?</th>
                 <th>Summary Files</th>
             </tr>
         </thead>

--- a/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
+++ b/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
@@ -7,7 +7,6 @@ exports.setupAPIRoutes = (app, loginRoutes) ->
 	app.get '/api/cmpdRegBulkLoader/getFilesToPurge', exports.getFilesToPurge
 	app.post '/api/cmpdRegBulkLoader/purgeFile', exports.purgeFile
 	app.get '/api/cmpdRegBulkLoader/getSDFFromBulkLoadFileId/:bulkFileID', exports.getSDFFromBulkLoadFileId
-	app.get '/api/cmpdRegBulkLoader/checkForBulkLoadFileModifications/:bulkFileID', exports.checkForBulkLoadFileModifications
 
 
 
@@ -22,7 +21,6 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/api/cmpdRegBulkLoader/checkFileDependencies', loginRoutes.ensureAuthenticated, exports.checkFileDependencies
 	app.post '/api/cmpdRegBulkLoader/purgeFile', loginRoutes.ensureAuthenticated, exports.purgeFile
 	app.get '/api/cmpdRegBulkLoader/getSDFFromBulkLoadFileId/:bulkFileID', loginRoutes.ensureAuthenticated, exports.getSDFFromBulkLoadFileId
-	app.get '/api/cmpdRegBulkLoader/checkForBulkLoadFileModifications/:bulkFileID', loginRoutes.ensureAuthenticated, exports.checkForBulkLoadFileModifications
 
 exports.cmpdRegBulkLoaderIndex = (req, res) ->
 	scriptPaths = require './RequiredClientScripts.js'
@@ -396,50 +394,3 @@ exports.getSDFFromBulkLoadFileId = (req, resp) ->
 			resp.end JSON.stringify "Error"
 	)
 
-exports.checkForBulkLoadFileModifications = (req, resp) ->
-	req.setTimeout 86400000
-	config = require '../conf/compiled/conf.js'
-	baseurl = config.all.client.service.cmpdReg.persistence.fullpath+"bulkload/getLotsByBulkLoadFileID?bulkLoadFileID=" +req.params.bulkFileID
-	request = require 'request'
-	request(
-		method: 'GET'
-		url: baseurl
-		json: true
-	, (error, response, lotCorpNames) =>
-		if !error && response.statusCode == 200
-			try
-				#If one of the lots has been modified, we say the bulkFile has been updated
-				bulkFileUpdated = "No"
-
-				#run a loop to find out if each lot has been modified, and if so who/when
-				for lotName in lotCorpNames
-					baseurl = config.all.client.service.cmpdReg.persistence.fullpath + "/metalots/corpName/" + lotName
-					response = await fetch(baseurl, method: 'GET')
-
-					checkStatus response
-					lotMetadata = await response.json()
-					lotModifiedBy = lotMetadata.lot.modifiedBy
-					# TODO - Add sorting for who last modified the bulk file, and when it was last modified
-					# TODO - When you edit a lot in ACAS, it doesn't seem to record the modified date 
-					#lotModifiedDate = lotMetadata.lot.modifiedDate
-
-					#if there is a user who modified one of the lots, we know that the lots in file have been udpated and end the loop
-					if lotModifiedBy != null
-						bulkFileUpdated = "Yes"
-						break
-
-				resp.end JSON.stringify bulkFileUpdated
-
-		
-			catch err
-				console.log "Error calling service: " + err
-				resp.statusCode = 500
-				resp.json err			
-
-		else
-			console.log 'got ajax error trying to retrieve lots from bulk file ID'
-			console.log error
-			console.log lotCorpNames
-			console.log response
-			resp.end JSON.stringify "Error"
-	)


### PR DESCRIPTION
## Description
The "Has File Been Updated" column on the Purge Files window of the CReg Bulk Loader was loading to slowly. When moving this logic into another route, this caused the window to load slowly instead. The decision was made to hold off on adding this feature for the time being. 

## How Has This Been Tested?
Purge file window loads quickly without issue after removing "Has File Been Updated?" parts. 

<img width="903" alt="Screen Shot 2022-08-12 at 2 06 47 PM" src="https://user-images.githubusercontent.com/107148842/184418044-40eacf47-fe74-453d-a024-145fd87a5079.png">
