### PR TITLE
Add disableDeleteMyLots which dissallows anyone but cmpd reg users from deleting a lot

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -697,6 +697,7 @@ client.cmpdreg.metaLot.showTareWeight=false
 client.cmpdreg.metaLot.showTotalAmountStored=false
 client.cmpdreg.metaLot.disableAliasEdit=false
 client.cmpdreg.metaLot.showLotInventory=false
+client.cmpdreg.metaLot.disableDeleteMyLots=true
 client.cmpdreg.metaLot.disableEditMyLots=false
 client.cmpdreg.metaLot.disableEditMyParents=true
 client.cmpdreg.metaLot.requireLotNumber=false

--- a/modules/CmpdReg/src/client/DeleteLot.coffee
+++ b/modules/CmpdReg/src/client/DeleteLot.coffee
@@ -70,6 +70,12 @@ class DeleteLotController extends Backbone.View
 
 		# Show the summary
 		@$(".bv_dependencySummary").show();
+
+		# Show the delete button if user can delete
+		if data.lot?.acls?.delete
+			@$('.deleteLotButton').show()
+		else
+			@$('.deleteLotButton').hide()
 		
 	handleBackToCregButtonClicked: ->
 		window.location.href = 	window.configuration.serverConnection.baseServerURL
@@ -171,12 +177,13 @@ class DeleteLotController extends Backbone.View
 			containerSummary += "</ul>"
 
 		errorSummary = "<h3>Errors</h3><ul>"
-		if linkedExperiments && (unreadableExperimentsCount > 0 || undeletableExperiments.length > 0)
-			@$('.deleteLotButton').hide()
-			errorSummary += "<li>You do not have the necessary permissions to delete associated experimental results. Please contact your Administrator for assistance.</li>"
-		else
-			@$('.deleteLotButton').show()
+		if data.lot?.acls?.delete
 			errorSummary += "<li>None</li>"
+		else
+			errorSummary += "<li>You do not have the permissions to delete this lot. Please contact your Administrator for assistance.</li>"
+			if linkedExperiments && (unreadableExperimentsCount > 0 || undeletableExperiments.length > 0)
+				errorSummary += "<li>You do not have the permissions to delete associated experimental results.</li>"
+
 		errorSummary += "</ul>"
 
 		warningSummary = "<h3>Warnings</h3><ul>"

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -240,7 +240,9 @@ $(function() {
 			    }
 			    if (!this.model.get('lot').get("acls").write) {
 				    this.$('.saveButton').hide();
-				    this.$('.deleteButton').hide();
+				}
+				if (!this.model.get('lot').get("acls").delete) {
+					this.$('.deleteButton').hide();
 			    } else {
 					this.$('.deleteButton').html(lisb ? 'Delete Batch...' : 'Delete Lot...');
 			    }

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -240,11 +240,9 @@ $(function() {
 			    }
 			    if (!this.model.get('lot').get("acls").write) {
 				    this.$('.saveButton').hide();
-			    }
-			    if (!this.model.get('lot').get("acls").delete) {
 				    this.$('.deleteButton').hide();
 			    } else {
-				    this.$('.deleteButton').html(lisb ? 'Delete Batch...' : 'Delete Lot...');
+					this.$('.deleteButton').html(lisb ? 'Delete Batch...' : 'Delete Lot...');
 			    }
 			    console.log("about to load inventory");
 			    console.log(window.configuration.metaLot.showLotInventory);

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -240,11 +240,11 @@ $(function() {
 			    }
 			    if (!this.model.get('lot').get("acls").write) {
 				    this.$('.saveButton').hide();
-				}
-				if (!this.model.get('lot').get("acls").delete) {
-					this.$('.deleteButton').hide();
+			    }
+			    if (!this.model.get('lot').get("acls").delete) {
+				    this.$('.deleteButton').hide();
 			    } else {
-					this.$('.deleteButton').html(lisb ? 'Delete Batch...' : 'Delete Lot...');
+				    this.$('.deleteButton').html(lisb ? 'Delete Batch...' : 'Delete Lot...');
 			    }
 			    console.log("about to load inventory");
 			    console.log(window.configuration.metaLot.showLotInventory);

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -242,7 +242,7 @@ exports.getMetaLotDependencies = (req, resp, next) ->
 		return
 
 	# Get the meta lot
-	[err, metaLot, statusCode] = await exports.getMetaLotInternal(req.params.lotCorpName, req.user, allowedProjects, getDeleteAcl=false)
+	[err, metaLot, statusCode] = await exports.getMetaLotInternal(req.params.lotCorpName, req.user, allowedProjects, getDeleteAcl=true)
 	if err?
 		console.log "User #{req.user.username} does not have permission to check dependencies for lot #{req.params.lotCorpName}"
 		resp.statusCode = statusCode


### PR DESCRIPTION
## Description
Add new default config `client.cmpdreg.metaLot.disableDeleteMyLots` = `true` which disables deleting lots if the user is not a CregAdmin

## Related Issue
ACAS-408

## How Has This Been Tested?
Ran acas client tests
Verified with setting on true, creg user who owned the lot could not see delete button
Verified with setting on false, creg user who owned the lot could see the delete and use the delete button
Verified with either setting a creg admin could see the delete and use the delete button