### PR TITLE
Open url utility function which workaround safari pop up blocker

### DIFF
--- a/modules/Components/src/client/OpenExperimentInQueryTool.coffee
+++ b/modules/Components/src/client/OpenExperimentInQueryTool.coffee
@@ -33,7 +33,7 @@ class OpenExperimentInQueryToolController extends Backbone.View
                 success: (response) => 
                     # Take Away Generating Progress Mask 
                     @$('.bv_generatingLink').hide()
-                    window.open(response,'_blank')
+                    UtilityFunctions::openURL(response)
                 error: (err) =>
                     # Take Away Generating Progress Mask 
                     @$('.bv_generatingLink').hide()

--- a/modules/Components/src/client/UtilityFunctions.coffee
+++ b/modules/Components/src/client/UtilityFunctions.coffee
@@ -128,3 +128,4 @@ class UtilityFunctions
 		a.href = url;
 		document.body.appendChild a
 		a.click()
+		document.body.removeChild(a);

--- a/modules/Components/src/client/UtilityFunctions.coffee
+++ b/modules/Components/src/client/UtilityFunctions.coffee
@@ -120,3 +120,11 @@ class UtilityFunctions
 			console.log "can't find entry in pickLists hash for: "+value.get('lsKind')
 			console.dir pickLists
 			return "not found"
+
+	openURL: (url) ->
+		a = document.createElement 'a'
+		a.style.display = 'none'
+		a.target = '_blank'
+		a.href = url;
+		document.body.appendChild a
+		a.click()

--- a/modules/Components/src/client/UtilityFunctions.coffee
+++ b/modules/Components/src/client/UtilityFunctions.coffee
@@ -128,4 +128,4 @@ class UtilityFunctions
 		a.href = url;
 		document.body.appendChild a
 		a.click()
-		document.body.removeChild(a);
+		document.body.removeChild a


### PR DESCRIPTION
## Description
Added utility function to workaround Safari pop up blocker and used it in open experiment in query tool component.  This was technique being used in a few places but in slightly different ways:
https://github.com/mcneilco/acas/blob/ebc5cb75accb8f09ca249252685f76809b8d5696/modules/Standardization/src/client/Standardization.coffee#L75
https://github.com/mcneilco/acas/blob/65e0cdd4dc6a3fe920903c9a0652dcbfe79e1852/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee#L412
https://github.com/mcneilco/acas/blob/ebc5cb75accb8f09ca249252685f76809b8d5696/modules/Standardization/src/client/Standardization.coffee#L75
## Related Issue
ACAS-426

## How Has This Been Tested?
Click the open in live design button in both chrome and safari and made sure pop ups weren't blocked.
This does not make it so you can repeatedly click the open in live design button, it just makes the button work in Safari where it is currently getting blocked.