### PR TITLE
ACAS-424: Fix Open In LiveDesign button on Experiment Editor

### DIFF
--- a/modules/ServerAPI/src/server/routes/OpenExptWithQueryTool.coffee
+++ b/modules/ServerAPI/src/server/routes/OpenExptWithQueryTool.coffee
@@ -16,7 +16,10 @@ exports.redirectToQueryToolForExperiment = (req, resp) ->
 #resp.redirect '/api/redirectToNewLiveDesignLiveReportForExperiment/' + req.query.experiment
 		getLdUrl = require './CreateLiveDesignLiveReportForACAS.js'
 		username = req.session.passport.user.username
-		getLdUrl.getUrlForNewLiveDesignLiveReportForExperimentInternal req.query.experiment, username, (url) ->
+		getLdUrl.getUrlForNewLiveDesignLiveReportForExperimentInternal req.query.experiment, username, (statusCode, url) ->
+			if statusCode != 200
+				resp.statusCode = statusCode
+				resp.end url
 			url = url.replace /(\r\n|\n|\r)/gm,""
 			console.log "redirecting to #{url}"
 			resp.redirect url


### PR DESCRIPTION
## Summary of Changes
I updated the function return signature of getUrlForNewLiveDesignLiveReportForExperimentInternal, and updated all but one location where the function is used.

This PR fixes the last usage to comply with the new function outputs.

## Testing Done
Patched this in as javascript onto an instance demonstrating the issue, and confirmed it fixes the issue.