### PR TITLE
ACAS-427: add uri encoding for datafiles urls

### DIFF
--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -867,9 +867,9 @@ class ACASFormLSFileValueFieldController extends ACASFormAbstractFieldController
 			if !displayText?
 				displayText = fileValue
 			if @displayInline
-				@$('.bv_file').html '<img src="'+window.conf.datafiles.downloadurl.prefix+fileValue+'" alt="'+ displayText+'">'
+				@$('.bv_file').html '<img src="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'" alt="'+ displayText+'">'
 			else
-				@$('.bv_file').html '<a href="'+window.conf.datafiles.downloadurl.prefix+fileValue+'">'+displayText+'</a>'
+				@$('.bv_file').html '<a href="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'">'+displayText+'</a>'
 			@$('.bv_deleteSavedFile').show()
 
 	createNewFileChooser: ->

--- a/modules/ServerAPI/src/client/AttachFile.coffee
+++ b/modules/ServerAPI/src/client/AttachFile.coffee
@@ -107,9 +107,9 @@ class BasicFileController extends AbstractFormController
 			@createNewFileChooser()
 		else
 			if urlValue?
-				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+ urlValue+'">'+urlValue+'</a></div>'
+				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+ encodeURI(urlValue)+'">'+urlValue+'</a></div>'
 			else
-				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+window.conf.datafiles.downloadurl.prefix+fileValue+'">'+@model.escape('comments')+'</a></div>'
+				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'">'+@model.escape('comments')+'</a></div>'
 			@$('.bv_recordedBy').html @model.escape("recordedBy")
 			@$('.bv_recordedDate').html UtilityFunctions::convertMSToYMDDate @model.get("recordedDate")
 		@
@@ -249,7 +249,7 @@ class AttachFileController extends BasicFileController
 		if fileValue is null or fileValue is "" or fileValue is undefined
 			@createNewFileChooser()
 		else
-			@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+window.conf.datafiles.downloadurl.prefix+fileValue+'" target="_blank">'+@model.get('comments')+'</a></div>'
+			@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'" target="_blank">'+@model.get('comments')+'</a></div>'
 
 		uneditableFileTypes = window.conf.experiment.uneditableFileTypes
 		unless uneditableFileTypes?


### PR DESCRIPTION
## Summary
We have a few places that we're serving up URLs based on a filename, and we're not properly URI encoding, so the links are broken if the filenames have special characters like %.

This fixes it.

## Testing performed
Patched this change in as javascript on a server demonstrating the issue, and confirmed it fixed the experiment file download link.