### PR TITLE
ACAS-412: Partial work on rendering data column values within Experiment

### DIFF
--- a/modules/ServerAPI/conf/ProtocolConfJSON.coffee
+++ b/modules/ServerAPI/conf/ProtocolConfJSON.coffee
@@ -247,6 +247,18 @@
 			,
 				typeName: "data column"
 				kindName: "column type"
+			,
+				typeName: "data column"
+				kindName: "column units"
+			,
+				typeName: "data column"
+				kindName: "column name"
+			,
+				typeName: "data column"
+				kindName: "column conc units"
+			,
+				typeName: "data column"
+				kindName: "column time units"
 			]
 
 		codetables:

--- a/modules/ServerAPI/conf/ProtocolConfJSON.coffee
+++ b/modules/ServerAPI/conf/ProtocolConfJSON.coffee
@@ -175,6 +175,8 @@
 				typeName: "analysis parameter"
 			,
 				typeName: "protocol metadata"
+			,
+				typeName: "data column"
 
 			]
 
@@ -242,6 +244,9 @@
 			,
 				typeName: "model fit"
 				kindName: "transformation units"
+			,
+				typeName: "data column"
+				kindName: "column type"
 			]
 
 		codetables:
@@ -478,6 +483,34 @@
 				codeOrigin: "ACAS DDICT"
 				code: "%"
 				name: "%"
+				ignored: false
+			,
+				codeType: "data column"
+				codeKind: "column type"
+				codeOrigin: "ACAS DDICT"
+				code: "stringValue"
+				name: "Text"
+				ignored: false
+			,
+				codeType: "data column"
+				codeKind: "column type"
+				codeOrigin: "ACAS DDICT"
+				code: "numericValue"
+				name: "Number"
+				ignored: false
+			,
+				codeType: "data column"
+				codeKind: "column type"
+				codeOrigin: "ACAS DDICT"
+				code: "dateValue"
+				name: "Date"
+				ignored: false
+			,
+				codeType: "data column"
+				codeKind: "column type"
+				codeOrigin: "ACAS DDICT"
+				code: "inlineFileValue"
+				name: "Image File"
 				ignored: false
 			]
 

--- a/modules/ServerAPI/src/client/Experiment.coffee
+++ b/modules/ServerAPI/src/client/Experiment.coffee
@@ -449,6 +449,10 @@ class ExperimentBaseController extends BaseEntityController
 			@setupProjectSelect()
 		@setupAttachFileListController()
 		@setupCustomExperimentMetadataController()
+		# Parse "data column order" states and setup controllers
+		# TODO uncomment
+		# if @readOnly
+		@setupEndpointsController()
 		@render()
 		@listenTo @model, 'sync', @modelSyncCallback.bind(@)
 		@listenTo @model, 'change', @modelChangeCallback.bind(@)
@@ -782,3 +786,12 @@ class ExperimentBaseController extends BaseEntityController
 	displayInReadOnlyMode: =>
 		super()
 		@$('.bv_openInQueryToolWrapper').hide()
+	
+	setupEndpointsController: =>
+		# Parse data column order states
+		endpointStates = @model.get("lsStates").getStatesByTypeAndKind "metadata", "data column order"
+		@endpointListController = new EndpointListController
+			el: @$('.bv_endpointTable')
+			collection: endpointStates
+
+		@endpointListController.render()

--- a/modules/ServerAPI/src/client/Experiment.coffee
+++ b/modules/ServerAPI/src/client/Experiment.coffee
@@ -793,5 +793,6 @@ class ExperimentBaseController extends BaseEntityController
 		@endpointListController = new EndpointListController
 			el: @$('.bv_endpointTable')
 			collection: endpointStates
+			model: @model
 
 		@endpointListController.render()

--- a/modules/ServerAPI/src/client/Experiment.html
+++ b/modules/ServerAPI/src/client/Experiment.html
@@ -90,6 +90,7 @@
         </div>
 
     </div>
+    <div class="bv_endpointTable"></div>
 
     <div class="span12 bv_group_shortDescription" style="margin-left:0px;">
         <div style="margin-bottom:5px;">Short Description</div>

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -575,6 +575,14 @@ class EndpointController extends AbstractFormController
 
 	initialize: (options) =>
 		@endpointData = options.endpointData
+		# Parse out endpointData
+		@lsState = @endpointData
+		@dataTypeValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column type"
+		@columnNameValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column name"
+		@unitsValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column units"
+		console.log "dataType: #{@dataTypeValue.get("stringValue")}"
+		console.log "columnName: #{@columnNameValue.get("stringValue")}"
+		console.log "units: #{@unitsValue.get("stringValue")}"
 		super()
 
 
@@ -591,7 +599,7 @@ class EndpointController extends AbstractFormController
 		@editablePickListController3 = new EditablePickListSelect2Controller
 			el: @$('.bv_dataTypePickListParent')
 			collection: @editablePickListList
-			selectedCode: "unassigned"
+			selectedCode: @dataTypeValue.get("stringValue")
 			parameter: "projects"
 			codeType: "protocolMetadata"
 			codeKind: "projects"

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -592,13 +592,16 @@ class EndpointController extends AbstractFormController
 		$(@el).empty()
 		$(@el).html @template()
 
+		@setupDataTypeController()
+
 		@editablePickListList = new PickListList()
+		
 		# @editablePickListList.url = "/api/projects"
 
 		#Try to render an editable pick list for testing
 		# FIXME: We should make editable picklists for Result Type and Units, but Data Type should be non-editable
 		@editablePickListController3 = new EditablePickListSelect2Controller
-			el: @$('.bv_dataTypePickListParent')
+			el: @$('.bv_unitsPickList')
 			collection: @editablePickListList
 			selectedCode: @dataTypeValue.get("stringValue")
 			parameter: "projects"
@@ -609,6 +612,19 @@ class EndpointController extends AbstractFormController
 		@editablePickListController3.render()
 
 		@
+	
+	setupDataTypeController: =>
+		codeType = "data column"
+		codeKind = "column type"
+		@dataTypePickListList = new PickListList()
+		@dataTypePickListList.url = "/api/codetables/#{codeType}/#{codeKind}"
+		@dataTypeController = new PickListSelectController
+			el: @$('.bv_dataTypePickList')
+			collection: @dataTypePickListList
+			selectedCode: @dataTypeValue.get("stringValue")
+		
+		@dataTypeController.render()
+
 	
 	removeRow: =>
 		@el.remove()

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -294,12 +294,14 @@ class ProtocolBaseController extends BaseEntityController
 			el: @$('.bv_endpointTableExample')
 		@endpointListControllerExample.render()
 
-
+		# Mocking up the states list for now
+		endpointStates = @model.get("lsStates").getStatesByTypeAndKind "metadata", "data column order"
 
 		@endpointListController = new EndpointListController
 			el: @$('.bv_endpointTable')
-			collection: ["one", "two", "three", "four"]
-			#collection: ["one"]
+			#collection: ["one", "two", "three", "four"]
+			collection: endpointStates
+			model: @model
 
 		@endpointListController.render()
 
@@ -574,9 +576,8 @@ class EndpointController extends AbstractFormController
 
 
 	initialize: (options) =>
-		@endpointData = options.endpointData
+		@lsState = options.lsState
 		# Parse out endpointData
-		@lsState = @endpointData
 		@dataTypeValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column type"
 		@columnNameValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column name"
 		@unitsValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column units"
@@ -592,7 +593,7 @@ class EndpointController extends AbstractFormController
 		$(@el).html @template()
 
 		@editablePickListList = new PickListList()
-		@editablePickListList.url = "/api/projects"
+		# @editablePickListList.url = "/api/projects"
 
 		#Try to render an editable pick list for testing
 		# FIXME: We should make editable picklists for Result Type and Units, but Data Type should be non-editable
@@ -623,7 +624,10 @@ class EndpointListController extends AbstractFormController
 	template: _.template($("#EndpointListView").html())
 
 	events:
-		"click .bv_addEndpoint": "addOne"
+		"click .bv_addEndpoint": "handleAddEndpointPressed"
+	
+	initialize: (options) =>
+		@model = options.model
 
 	render: => 
 		$(@el).empty()
@@ -632,11 +636,11 @@ class EndpointListController extends AbstractFormController
 		#Placeholder until we update the protocol data structure
 		# Create a list to hold the endpoint controllers in, so we can iterate through them later
 		@endpointControllers = []
-		for endpointData in @collection
-			@.addOne(endpointData)
+		for lsState in @collection
+			@.addOne(lsState)
 		@
 	
-	addOne: (endpointData) =>
+	addOne: (lsState) =>
 		# create a new table row
 		tr = document.createElement('tr')
 		# Add that row into the table
@@ -645,11 +649,15 @@ class EndpointListController extends AbstractFormController
 		# Pass the row we just created for the EndpointController to render into
 		rowController = new EndpointController
 			el: tr
-			endpointData: endpointData
+			lsState: lsState
 		rowController.render()
 		# Add this controller to our list so we can access it later
 		@endpointControllers.push rowController
 
+	handleAddEndpointPressed: =>
+		# Create a new LsState
+		lsState = @model.get("lsStates").createStateByTypeAndKind "metadata", "data column order"
+		@.addOne(lsState)
 
 			
 

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -593,25 +593,27 @@ class EndpointController extends AbstractFormController
 		$(@el).html @template()
 
 		@setupDataTypeController()
-
-		@editablePickListList = new PickListList()
-		
-		# @editablePickListList.url = "/api/projects"
-
-		#Try to render an editable pick list for testing
-		# FIXME: We should make editable picklists for Result Type and Units, but Data Type should be non-editable
-		@editablePickListController3 = new EditablePickListSelect2Controller
-			el: @$('.bv_unitsPickList')
-			collection: @editablePickListList
-			selectedCode: @dataTypeValue.get("stringValue")
-			parameter: "projects"
-			codeType: "protocolMetadata"
-			codeKind: "projects"
-			roles: [window.conf.roles.acas.userRole]
-
-		@editablePickListController3.render()
+		@setupUnitsController()
 
 		@
+	
+	setupUnitsController: =>
+		codeType = "data column"
+		codeKind = "column units"
+		@unitsPickListList = new PickListList()
+		@unitsPickListList.url = "/api/codetables/#{codeType}/#{codeKind}"
+		@unitsController = new EditablePickListSelect2Controller
+			el: @$('.bv_unitsPickList')
+			collection: @unitsPickListList
+			selectedCode: @unitsValue.get("stringValue")
+			parameter: "units"
+			codeType: codeType
+			codeKind: codeKind
+			autoSave: true
+			roles = [window.conf.roles.acas.userRole]
+		
+		@unitsController.render()
+
 	
 	setupDataTypeController: =>
 		codeType = "data column"

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -622,6 +622,9 @@ class EndpointController extends AbstractFormController
 			el: @$('.bv_dataTypePickList')
 			collection: @dataTypePickListList
 			selectedCode: @dataTypeValue.get("stringValue")
+			insertFirstOption: new PickList
+				code: "unassigned"
+				name: "Select Data Type"
 		
 		@dataTypeController.render()
 

--- a/modules/ServerAPI/src/client/Protocol.html
+++ b/modules/ServerAPI/src/client/Protocol.html
@@ -297,7 +297,7 @@
         <div class="bv_unitsPickList">Placeholder</div>
     </td>
     <td style="vertical-align:middle;" class="bv_dataTypePickListParent">
-        <div class="bv_dataTypePickList"></div>
+        <select class="bv_dataTypePickList"></select>
     </td>
     <td style="text-align:center;vertical-align:middle;"><input class= "" type="checkbox" id="" name=""></td>
     <td style="text-align:center;vertical-align:middle;"><input class= "" type="checkbox" id="" name=""></td>


### PR DESCRIPTION
## Description
I started to work on the rendering piece, and made some progress. I wanted to give you a chance to review this before shoving it all into your branch. I think this would be good to merge in tomorrow morning so we can build on top of it.

## Related Issue

## How Has This Been Tested?
Tested locally that the "Add Endpoint" button in Protocol Editor still works
Tested viewing experiments both in Experiment Browser and Protocol Browser.

There's a known issue that the "units" dropdown starts out empty. I tested that I could use the "editable picklist" to add values to the database, and then they'd be correctly rendered when viewing saved experiments. But long term we'll need to change the backend logic to save these during the data loading, so it's OK to ignore this for now.