### PR TITLE
ACAS-362: automate dev build tagging

### DIFF
--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -1,13 +1,6 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Tag ACAS Repos
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push events but only for the "release/2022.1.x" branch
-  #push:
-  #  branches: [ "release/2022.1.x" ]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -20,14 +13,12 @@ on:
        required: true
        type: string
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   apply-tags:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         acas-repo: [ acas, acasclient, racas, acas-roo-server ]
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Set ACAS_REF to the current to input branch or github.ref
         run: |

--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -1,4 +1,4 @@
-name: Trigger Tag
+name: Trigger Dev Tag
 
 on:
   # Trigger on new commits to release branches

--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -1,0 +1,42 @@
+name: Trigger Tag
+
+on:
+  # Trigger on new commits to release branches
+  push:
+   branches: [ "release/**" ]
+
+jobs:
+  trigger-tag:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout this repo
+      - name: Checkout
+        uses: actions/checkout@v3
+      # Get branch name
+      - name: Set BRANCH_NAME to the current branch ${{ github.ref }}
+        run: |
+          echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed 's/refs\/heads\///g')" >> $GITHUB_ENV
+      # Get next dev tag name on this branch
+      # First command lists all tags on the branch, filters to those containing '.dev', then grabs the last one
+      # Second command increments the final digit after dev, so 2022.1.1.dev1 will become 2022.1.1.dev2
+      # and 2022.1.1.dev9 will become 2022.1.1.dev10
+      - name: Get next dev tag name
+        run: |
+          LAST_TAG=$(git tag --merged ${{ env.BRANCH_NAME }} | grep '.dev' | tail -1)
+          echo "NEXT_TAG=$(echo $LAST_TAG | awk -F.dev -v OFS=.dev '{$NF += 1 ; print}')" >> $GITHUB_ENV
+      # Trigger the build
+      - name: Trigger the tagger workflow with branch ${{env.BRANCH_NAME}} and tag ${{ env.NEXT_TAG }}
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.ACAS_WORKFLOWS_TOKEN }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: "mcneilco",
+              repo: "acas",
+              workflow_id: "tagger.yml",
+              ref: "${{env.BRANCH_NAME}}",
+              inputs: {
+                branch-name: "${{env.BRANCH_NAME}}",
+                tag-name: "${{env.NEXT_TAG"
+              }
+            });


### PR DESCRIPTION
## Description
This adds a second workflow "Trigger Dev Tag" that will figure out the next ".dev" tag, then call the "Tag ACAS Repos" workflow. The idea is to put this "Trigger Dev Tag" workflow onto every acas repo, so a commit to a release branch on any repo will trigger a new tag on every repo.

## Related Issue

## How Has This Been Tested?
Not tested yet, need to merge to test.