### PR TITLE
ACAS-6: Fix Maestro sketcher implementation

### DIFF
--- a/modules/BuildUtilities/src/server/routes/RequiredClientScripts_template.js
+++ b/modules/BuildUtilities/src/server/routes/RequiredClientScripts_template.js
@@ -31,6 +31,8 @@ exports.requiredScripts = [
 	// '/CmpdReg/marvinjs/gui/lib/promise-1.0.0.min.js',
 	// '/CmpdReg/marvinjs/js/marvinjslauncher.js',
 	// '/CmpdReg/client/custom/marvinStructureTemplate.js',
+	// The following line is for the Maestro sketcher
+	'/CmpdReg/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js',
 	'/socket.io/socket.io.js',
 	'/lib/blockUI.js'
 ];

--- a/modules/ChemStructure/src/server/routes/ChemStructureRoutes.coffee
+++ b/modules/ChemStructure/src/server/routes/ChemStructureRoutes.coffee
@@ -206,7 +206,7 @@ exports.renderMolStructureBase64 = (req, resp) ->
 			else
 				console.log '--- line 153:   got ajax error trying to render molStructure'
 				console.log error
-				console.log json
+				console.log output
 				console.log response
 				resp.statusCode = 500
 				resp.end JSON.stringify "render molStructure failed"

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -57,6 +57,7 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.get '/cmpdReg/parentLot/getAllAuthorizedLots', loginRoutes.ensureAuthenticated, exports.getAllAuthorizedLots
 	app.get '/cmpdReg/allowCmpdRegistration', loginRoutes.ensureAuthenticated, exports.allowCmpdRegistration
 	app.get '/cmpdReg/export/corpName/:lotCorpName', loginRoutes.ensureAuthenticated, exports.exportLotToSDF
+	app.post '/api/cmpdReg/renderMolStructureBase64', loginRoutes.ensureAuthenticated, exports.renderMolStructureBase64CmpdReg
 
 _ = require 'underscore'
 request = require 'request'
@@ -1143,3 +1144,31 @@ exports.allowCmpdRegistration = (req, resp) ->
 					allowCmpdRegistration: allowCmpdRegistration
 					message: message
 				resp.json response
+
+exports.renderMolStructureBase64CmpdReg = (req, resp) ->
+	molecule = req.body.molStructure
+	height = 200
+	width = 200
+	format = "png"
+	if req.body.height?
+		height = req.body.height
+	if req.body.width?
+		width = req.body.width
+	config = require '../conf/compiled/conf.js'
+	baseurl = config.all.client.service.cmpdReg.persistence.fullpath+"structureimage/convertMol/base64?hsize=#{height}&wsize=#{width}&format=#{format}"
+	request = require 'request'
+	request(
+		method: 'POST'
+		url: baseurl
+		body: molecule
+		json: true
+	, (error, response, output) =>
+		if !error && response.statusCode == 200
+			resp.end output
+		else
+			console.log error
+			console.log output
+			console.log response
+			resp.statusCode = 500
+			resp.end JSON.stringify "render molStructure base64 CmpdReg failed"
+	)

--- a/modules/Components/src/client/ACASFormChemicalStructure.coffee
+++ b/modules/Components/src/client/ACASFormChemicalStructure.coffee
@@ -75,33 +75,25 @@ class MaestroChemicalStructureController extends Backbone.View
 		$(@el).empty()
 		$(@el).html @template()
 
-		@$('.bv_sketcherIFrame').on 'load', @startSketcher
-
-		searchFrameURL = "/components/ACASFormChemicalRegStructure"
-		if @options?
-			if @options.searchMode?
-				if @options.searchMode
-					searchFrameURL = "/components/ACASFormChemicalSearchStructure"
-
+		searchFrameURL = "/CmpdReg/maestrosketcher/wasm_shell.html"
+		@maestroIFrameID = "maestroSketcher_" + new Date().getMilliseconds()
+		@$('.bv_sketcherIFrame').attr 'id', @maestroIFrameID
 		@$('.bv_sketcherIFrame').attr 'src', searchFrameURL
+		@$('.bv_sketcherIFrame').on 'load', @startSketcher
 
 		@
 
 	startSketcher: =>
-		@windowObj = @$('.bv_sketcherIFrame')[0].contentWindow
-		@trigger 'sketcherLoaded'
+		MaestroJSUtil.getSketcher("##{@maestroIFrameID}").then (maestro) =>
+			@maestro = maestro
+			@trigger 'sketcherLoaded'
+		
 
 	getMol: ->
-		mol = @windowObj.sketcher.getMolecule();
-		@windowObj.ChemDoodle.writeMOL(mol)
+		@maestro.sketcherExportMolBlock()
 
 	setMol: (molStr) ->
-		molStruct = @windowObj.ChemDoodle.readMOL molStr
-		@windowObj.sketcher.loadMolecule(molStruct);
-
-	getChemDoodleJSON: ->
-		mol = @windowObj.sketcher.getMolecule();
-		@windowObj.ChemDoodle.writeJSON([mol],[])
+		@maestro.sketcherImportText molStr
 
 
 #TODO Why is it making a call to WebHQ outside our server, and make it stop

--- a/modules/Components/src/client/ACASFormChemicalStructureView.html
+++ b/modules/Components/src/client/ACASFormChemicalStructureView.html
@@ -7,7 +7,7 @@
 
 
 <script type="text/template" id="MaestroChemicalStructureControllerView" xmlns="http://www.w3.org/1999/html">
-    <iframe class="bv_sketcherIFrame"  style="width:520px; height:390px;">sketcher should load here</iframe>
+    <iframe class="bv_sketcherIFrame"  style="width:600px; height:500px;">sketcher should load here</iframe>
 </script>
 
 <script type="text/template" id="KetcherChemicalStructureControllerView" xmlns="http://www.w3.org/1999/html">

--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -230,7 +230,7 @@ class SaltBrowserController extends Backbone.View
 
 		# Want to Clear Form Fields Here 
 		@$('.bv_abbrevName').val ""
-		@$('.bv_saltName').val ""
+		@$('.bv_saltNameCreate').val ""
 
 		@$('.bv_saltBrowserCoreContainer').hide()
 		@$('bv_saltBrowserCore').hide()
@@ -256,7 +256,7 @@ class SaltBrowserController extends Backbone.View
 		if (saltAbbrev == "" || saltAbbrev == null)
 			fieldsFilled = false
 
-		saltName = UtilityFunctions::getTrimmedInput @$('.bv_saltName')
+		saltName = UtilityFunctions::getTrimmedInput @$('.bv_saltNameCreate')
 		if (saltName == "" || saltName == null)
 			fieldsFilled = false
 

--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -199,7 +199,7 @@ class SaltBrowserController extends Backbone.View
 
 		$.ajax(
 			type: 'POST'
-			url: "/api/chemStructure/renderMolStructureBase64"
+			url: "/api/cmpdReg/renderMolStructureBase64"
 			contentType: 'application/json'
 			dataType: 'text'
 
@@ -319,7 +319,7 @@ class SaltBrowserController extends Backbone.View
 						# Render Image
 						$.ajax(
 							type: 'POST'
-							url: "/api/chemStructure/renderMolStructureBase64"
+							url: "/api/cmpdReg/renderMolStructureBase64"
 							contentType: 'application/json'
 							dataType: 'text'
 							data: JSON.stringify(requestJSON)
@@ -565,7 +565,7 @@ class SaltBrowserController extends Backbone.View
 						# AJAX Call to Generate Picture of New Structure
 						$.ajax(
 							type: 'POST'
-							url: "/api/chemStructure/renderMolStructureBase64"
+							url: "/api/cmpdReg/renderMolStructureBase64"
 							contentType: 'application/json'
 							dataType: 'text'
 							data: JSON.stringify(requestJSON)

--- a/modules/ServerAPI/src/client/SaltBrowser.html
+++ b/modules/ServerAPI/src/client/SaltBrowser.html
@@ -124,7 +124,7 @@
             <label for="abbrevName">Abbreviation: </label><br>
             <input type="text" id="abbrevName" name="abbrevName" class="bv_abbrevName"><br>
             <label for="saltName">Name:</label><br>
-            <input type="text" id="saltName" name="saltName" class="bv_saltName">
+            <input type="text" id="saltName" name="saltName" class="bv_saltNameCreate">
             <br>
             <div class='bv_createNotifications row span7' style="padding: 10px;"></div>
         </div>


### PR DESCRIPTION
## Description
Switch Salt Browser sketcher to actually use Maestro sketcher when client.cmpdreg.sketcher = 'maestro', then fix a couple issues with instantiating the sketcher and getting & setting mols.

## Related Issue

## How Has This Been Tested?
Tested locally by coping maestro sketcher code into dev environment, then ran with maestro sketcher configured. Confirmed I could register a salt, got the correct molecular weight and formula, could render the images, and the "edit salt" workflow started with the correct structure loaded in the sketcher.

In this local dev setup, I did observe an issue where the structure image wouldn't render during the "preview" phase before save. This appears to be a MOL V3000 issue with the indigo / cdk rendering code in Roo. 
```
acas-roo-1  | 06 Sep 2022 18:39:55 72605 [http-nio-8080-exec-3] ERROR com.labsynch.labseer.api.ApiStructureController [] - Caught exception in renderMolStructure
acas-roo-1  | org.openscience.cdk.exception.CDKException: This file must be read with the MDLV3000Reader.
acas-roo-1  |   at org.openscience.cdk.io.MDLV2000Reader.readAtomContainer(MDLV2000Reader.java:370) ~[cdk-io-1.5.13.jar:1.5.13]
acas-roo-1  |   at org.openscience.cdk.io.MDLV2000Reader.read(MDLV2000Reader.java:229) ~[cdk-io-1.5.13.jar:1.5.13]
acas-roo-1  |   at com.labsynch.labseer.service.StructureServiceImpl.readMolStructure(StructureServiceImpl.java:151) ~[classes/:?]
acas-roo-1  |   at com.labsynch.labseer.service.StructureServiceImpl.renderMolStructureBase64_aroundBody2(StructureServiceImpl.java:89) ~[classes/:?]
```
We may want to switch this to using CReg, or need to figure out how to send a V2000 MOL to the rendering service.