### PR TITLE
Removing Unnecessary Spacing in Salt Edit Panel 

### DIFF
--- a/modules/ServerAPI/src/client/SaltBrowser.html
+++ b/modules/ServerAPI/src/client/SaltBrowser.html
@@ -197,10 +197,9 @@
             </div>
             <p><i>Use the sketcher to sepcify the molecular structure of the salt. Pay close attention to charges as they will be used in calculating Lot Molecular Weight. Use the + and - buttons to add positive or negative charges</i></p>
             <br>
-            <br>
-            <label for="abbrevName">Abbreviation: </label><br>
+            <label for="abbrevName">Abbreviation: </label>
             <input type="text" id="abbrevNameEdit" name="abbrevNameEdit" class="bv_abbrevNameEdit"><br>
-            <label for="saltName">Name:</label><br>
+            <label for="saltName">Name:</label>
             <input type="text" id="saltNameEdit" name="saltNameEdit" class="bv_saltNameEdit">
             <br>
         </div>


### PR DESCRIPTION
**Steps to reproduce:**

As a CReg admin, navigate to the CmpdRed Salts panel, pick any salt from the table and edit it.

**Previous:**

Too much line spacing between the sketcher and the fields beneath it. 

**Changed:**

Even spacing across the panel with not too much real estate occupied.