### PR TITLE
ACAS-304: Bugfix for saving issue

### DIFF
--- a/modules/BuildUtilities/src/server/routes/RequiredClientScripts_template.js
+++ b/modules/BuildUtilities/src/server/routes/RequiredClientScripts_template.js
@@ -43,6 +43,8 @@ exports.applicationScripts = [
 	'/javascripts/src/Components/LSErrorNotification.js',
 	'/javascripts/src/Components/AbstractFormController.js',
 	'/javascripts/src/Components/AbstractParserFormController.js',
+	'/javascripts/src/Components/ACASFormFields.js',
+	'/javascripts/src/Components/ACASFormStateTable.js',
 	'/javascripts/src/Components/BasicFileValidateAndSave.js',
 	'/javascripts/src/Components/BasicFileValidateReviewAndSave.js',
 	'/javascripts/src/Components/ACASThingBrowser.js',

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -38,7 +38,7 @@ class ACASFormAbstractFieldController extends Backbone.View
 		@$('.label-tooltip').tooltip()
 
 	getModel: ->
-		if @thingRef instanceof Thing
+		if @thingRef instanceof Thing or @thingRef instanceof BaseEntity
 			return @thingRef.get @modelKey
 		else
 			return @thingRef

--- a/modules/Components/src/client/ACASFormStateTable.coffee
+++ b/modules/Components/src/client/ACASFormStateTable.coffee
@@ -809,12 +809,17 @@ class ACASFormStateTableFormController extends Backbone.View
 				firstSelectText: field.fieldSettings.firstSelectText
 				modelDefaults: field.modelDefaults
 				allowedFileTypes: field.fieldSettings.allowedFileTypes
+				maxFileSize: field.fieldSettings.maxFileSize
+				displayInline: field.fieldSettings.displayInline
 				extendedLabel: field.fieldSettings.extendedLabel
 				sorter: field.fieldSettings.sorter
 				tabIndex: field.fieldSettings.tabIndex
 				toFixed: field.fieldSettings.toFixed
 				pickList: field.fieldSettings.pickList
 				showDescription: field.fieldSettings.showDescription
+				editablePicklist: field.fieldSettings.editablePicklist
+				editablePicklistRoles: field.fieldSettings.editablePicklistRoles
+				# Additional opts specific to StateTables
 				rowNumber: @rowNumber
 				rowNumberKind: @rowNumberKind
 				stateType: @stateType

--- a/modules/Components/src/client/PickList.coffee
+++ b/modules/Components/src/client/PickList.coffee
@@ -673,20 +673,24 @@ class EditablePickListSelectController extends Backbone.View
 
 class EditablePickListSelect2Controller extends EditablePickListSelectController
 	setupEditablePickList: ->
-		parameterNameWithSpaces = @options.parameter.replace /([A-Z])/g,' $1'
-		pascalCaseParameterName = (parameterNameWithSpaces).charAt(0).toUpperCase() + (parameterNameWithSpaces).slice(1)
-
+		plOptions =
+			el: @$('.bv_parameterSelectList')
+			collection: @collection
+			selectedCode: @options.selectedCode
+			filters: filters
+		if @options.insertFirstOption
+			plOptions.insertFirstOption = @options.insertFirstOption
+		else if @options.parameter?
+			# The parameter field gives a default first option based on the model key
+			parameterNameWithSpaces = @options.parameter.replace /([A-Z])/g,' $1'
+			pascalCaseParameterName = (parameterNameWithSpaces).charAt(0).toUpperCase() + (parameterNameWithSpaces).slice(1)
+			plOptions.insertFirstOption = new PickList
+				code: "unassigned"
+				name: "Select "+pascalCaseParameterName
 		if @pickListController?
 			filters = @pickListController.filters
 			@pickListController.remove()
-		@pickListController = new PickListSelect2Controller
-			el: @$('.bv_parameterSelectList')
-			collection: @collection
-			insertFirstOption: new PickList
-				code: "unassigned"
-				name: "Select "+pascalCaseParameterName
-			selectedCode: @options.selectedCode
-			filters: filters
+		@pickListController = new PickListSelect2Controller plOptions
 
 class ThingLabelComboBoxController extends PickListSelect2Controller
 

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -623,6 +623,7 @@ class EndpointListController extends AbstractFormController
 
 	events:
 		"click .bv_addEndpoint": "handleAddEndpointPressed"
+		"rowRemoved": "handleRowRemoved"
 	
 	rowNumberKind: "column order"
 	
@@ -656,11 +657,11 @@ class EndpointListController extends AbstractFormController
 		# Create a new EndpointController, which manages a row
 		# We get the row number from the state which was passed in
 		rowNumber = @getRowNumberForState(state)
-		# TODO uncomment if the rest of this starts working
-		# if @stateTableFormControllersCollection[rowNumber]?
-		# 	@stateTableFormControllersCollection[rowNumber].remove()
-		# 	@stateTableFormControllersCollection[rowNumber].unbind()
-		rowController = new ACASFormStateTableFormController
+		# Start tracking the controllers based on their row numbers
+		if @endpointControllers[rowNumber]?
+			@endpointControllers[rowNumber].remove()
+			@endpointControllers[rowNumber].unbind()
+		rowController = new EndpointController
 			el: tr
 			thingRef: @model
 			valueDefs: EndpointsValuesConf
@@ -668,9 +669,8 @@ class EndpointListController extends AbstractFormController
 			stateKind: 'data column order'
 			rowNumber: rowNumber
 			rowNumberKind: @rowNumberKind
-		#rowController.render()
-		# Add this controller to our list so we can access it later
-		@endpointControllers.push rowController
+		# Add this controller to our tracking dictionary so we can access it later
+		@endpointControllers[rowNumber] = rowController
 	
 	getRowNumberForState: (state) =>
 		rowValues = state.getValuesByTypeAndKind 'numericValue', @rowNumberKind
@@ -696,6 +696,12 @@ class EndpointListController extends AbstractFormController
 		# Add the state to the collection
 		@collection.push lsState
 		@.addOne(lsState)
+	
+	handleRowRemoved: (rowNumber) =>
+		if @endpointControllers[rowNumber]?
+			@endpointControllers[rowNumber].remove()
+			@endpointControllers[rowNumber].unbind()
+			@endpointControllers[rowNumber].el.remove()
 
 			
 class EndpointListControllerReadOnly extends EndpointListController

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -289,6 +289,8 @@ class ProtocolBaseController extends BaseEntityController
 		@model.getStatus().on 'change', @updateEditable.bind(@)
 #		@trigger 'amClean' #so that module starts off clean when initialized
 
+		# Hack to see if we can get this working with Thing-based ACASFormStateTable
+		@model.lsProperties = {'defaultValues': []}
 
 		# Mocking up the states list for now
 		endpointStates = @model.get("lsStates").getStatesByTypeAndKind "metadata", "data column order"
@@ -716,7 +718,63 @@ class EndpointController extends AbstractFormController
 		# TODO figure out how to remove this controller from the parent controller's "endpointControllers"
 
 				
-
+# Protocol Endpoints definition
+EndpointsValuesConf = [
+	key: 'column name'
+	modelDefaults:
+		type: 'stringValue'
+		kind: 'column name'
+		codeType: 'data column'
+		codeKind: 'column name'
+		codeOrigin: 'ACAS DDict'
+		value: null
+	fieldSettings:
+		fieldType: 'codeValue'
+		formLabel: ''
+		fieldWrapper: 'bv_columnNamePickList'
+		insertUnassigned: true
+		firstSelectText: "Select Column Name"
+		required: false
+		editablePicklist: true
+		autoSavePickListItem: true
+		editablePicklistRoles: [window.conf.roles.acas.userRole]
+,
+	key: 'column units'
+	modelDefaults:
+		type: 'stringValue'
+		kind: 'column units'
+		codeType: 'data column'
+		codeKind: 'column units'
+		codeOrigin: 'ACAS DDict'
+		value: null
+	fieldSettings:
+		fieldType: 'codeValue'
+		formLabel: ''
+		fieldWrapper: 'bv_unitsPickList'
+		insertUnassigned: true
+		firstSelectText: "Select Column Units"
+		required: false
+		editablePicklist: true
+		autoSavePickListItem: true
+		editablePicklistRoles: [window.conf.roles.acas.userRole]
+,
+	key: 'column type'
+	modelDefaults:
+		type: 'stringValue'
+		kind: 'column type'
+		codeType: 'data column'
+		codeKind: 'column type'
+		codeOrigin: 'ACAS DDict'
+		value: null
+	fieldSettings:
+		fieldType: 'codeValue'
+		formLabel: ''
+		fieldWrapper: 'bv_dataTypePickList'
+		insertUnassigned: true
+		firstSelectText: ""
+		required: false
+		editablePicklist: false
+]
 		
 
 
@@ -751,17 +809,34 @@ class EndpointListController extends AbstractFormController
 			@.addOne(lsState)
 		@
 	
-	addOne: (lsState) =>
+	addOne: (state) =>
 		# create a new table row
 		tr = document.createElement('tr')
 		# Add that row into the table
 		@$('.bv_endpointRows').append tr
+		# Hack to render template into the tr
+		#tr.empty()
+		template = $("#EndpointRowView2").html()
+		tr.innerHTML = template
 		# Create a new EndpointController, which manages a row
 		# Pass the row we just created for the EndpointController to render into
-		rowController = new EndpointController
+		# rowController = new EndpointController
+		# 	el: tr
+		# 	lsState: lsState
+		rowNumber = @getRowNumberForState(state)
+		# TODO uncomment if the rest of this starts working
+		# if @stateTableFormControllersCollection[rowNumber]?
+		# 	@stateTableFormControllersCollection[rowNumber].remove()
+		# 	@stateTableFormControllersCollection[rowNumber].unbind()
+		rowController = new ACASFormStateTableFormController
 			el: tr
-			lsState: lsState
-		rowController.render()
+			thingRef: @model
+			valueDefs: EndpointsValuesConf
+			stateType: 'metadata'
+			stateKind: 'data column order'
+			rowNumber: rowNumber
+			rowNumberKind: @rowNumberKind
+		#rowController.render()
 		# Add this controller to our list so we can access it later
 		@endpointControllers.push rowController
 	

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -529,7 +529,7 @@ class ProtocolBaseController extends BaseEntityController
 		@handleValueChanged "StrictEndpointMatching", value
 
 
-class EndpointController extends AbstractFormController
+class EndpointController extends ACASFormStateTableFormController
 	template: _.template($("#EndpointRowView2").html())
 
 	events:
@@ -537,184 +537,23 @@ class EndpointController extends AbstractFormController
 
 
 	initialize: (options) =>
-		@lsState = options.lsState
-		# Parse out endpointData
-		@dataTypeValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column type"
-		@columnNameValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column name"
-		@unitsValue = @lsState.getOrCreateValueByTypeAndKind "stringValue", "column units"
-		@dataTypeValue.set "value", @dataTypeValue.get "stringValue"
-		@columnNameValue.set "value", @columnNameValue.get "stringValue"
-		@unitsValue.set "value", @unitsValue.get "stringValue"
-		console.log "dataType: #{@dataTypeValue.get("stringValue")}"
-		console.log "columnName: #{@columnNameValue.get("stringValue")}"
-		console.log "units: #{@unitsValue.get("stringValue")}"
-		# TODO remaining values
-		super()
-
-
-	#TODO - based on AssignedPropertyController in CmpdRegBulkLoader.coffee (line 223)
-	render: =>
 		$(@el).empty()
 		$(@el).html @template()
-
-		@setupDataTypeController()
-		@setupUnitsController()
-		@setupColumnNameController()
-
-		@
-	
-	setupColumnNameController: =>
-		codeType = "data column"
-		codeKind = "column name"
-		opts =
-				modelKey: "name"
-				# inputClass: field.fieldSettings.inputClass
-				formLabel: ''
-				# formLabelOrientation: field.fieldSettings.formLabelOrientation
-				# formLabelTooltip: field.fieldSettings.formLabelTooltip
-				# placeholder: field.fieldSettings.placeholder
-				# required: field.fieldSettings.required
-				url: "/api/codetables/#{codeType}/#{codeKind}"
-				thingRef: @columnNameValue
-				# insertUnassigned: field.fieldSettings.insertUnassigned
-				# firstSelectText: field.fieldSettings.firstSelectText
-				# modelDefaults: field.modelDefaults
-				# allowedFileTypes: field.fieldSettings.allowedFileTypes
-				# maxFileSize: field.fieldSettings.maxFileSize
-				# displayInline: field.fieldSettings.displayInline
-				# extendedLabel: field.fieldSettings.extendedLabel
-				# sorter: field.fieldSettings.sorter
-				# tabIndex: field.fieldSettings.tabIndex
-				# toFixed: field.fieldSettings.toFixed
-				# pickList: field.fieldSettings.pickList
-				# showDescription: field.fieldSettings.showDescription
-				editablePicklist: true
-				autoSavePickListItem: true
-				editablePicklistRoles: [window.conf.roles.acas.userRole]
-
-		@columnNameController = new ACASFormLSCodeValueFieldController opts
-
-		@$(".bv_columnNamePickList").append @columnNameController.render().el
-		@columnNameController.renderModelContent()
-
-		#--- (Start): Previous Code for Column Name Controller --- 
-		#@columnNamePickListList = new PickListList()
-		#@columnNamePickListList.url = "/api/codetables/#{codeType}/#{codeKind}"
-		#@columnNameController = new EditablePickListSelect2Controller
-		#	el: @$('.bv_columnNamePickList')
-		#	collection: @columnNamePickListList
-		#	selectedCode: @columnNameValue.get("stringValue")
-		#	parameter: "column name"
-		#	codeType: codeType
-		#	codeKind: codeKind
-		#	autoSave: true
-		#	roles = [window.conf.roles.acas.userRole]
-		#@columnNameController.render()
-		#--- (End) --- 
-
-
-		
-
-	setupUnitsController: =>
-		codeType = "data column"
-		codeKind = "column units"
-		opts =
-				modelKey: "units"
-				# inputClass: field.fieldSettings.inputClass
-				formLabel: ''
-				# formLabelOrientation: field.fieldSettings.formLabelOrientation
-				# formLabelTooltip: field.fieldSettings.formLabelTooltip
-				# placeholder: field.fieldSettings.placeholder
-				# required: field.fieldSettings.required
-				url: "/api/codetables/#{codeType}/#{codeKind}"
-				thingRef: @unitsValue
-				# insertUnassigned: field.fieldSettings.insertUnassigned
-				# firstSelectText: field.fieldSettings.firstSelectText
-				# modelDefaults: field.modelDefaults
-				# allowedFileTypes: field.fieldSettings.allowedFileTypes
-				# maxFileSize: field.fieldSettings.maxFileSize
-				# displayInline: field.fieldSettings.displayInline
-				# extendedLabel: field.fieldSettings.extendedLabel
-				# sorter: field.fieldSettings.sorter
-				# tabIndex: field.fieldSettings.tabIndex
-				# toFixed: field.fieldSettings.toFixed
-				# pickList: field.fieldSettings.pickList
-				# showDescription: field.fieldSettings.showDescription
-				editablePicklist: true
-				autoSavePickListItem: true
-				editablePicklistRoles: [window.conf.roles.acas.userRole]
-		
-		@unitsController = new ACASFormLSCodeValueFieldController opts
-
-		@$(".bv_unitsPickList").append @unitsController.render().el
-		@unitsController.renderModelContent()
-
-		#--- (Start): Previous Code for Units Pick List --- 
-		# @unitsPickListList = new PickListList()
-		# @unitsPickListList.url = "/api/codetables/#{codeType}/#{codeKind}"
-		# @unitsController = new EditablePickListSelect2Controller
-		# 	el: @$('.bv_unitsPickList')
-		# 	collection: @unitsPickListList
-		# 	selectedCode: @unitsValue.get("stringValue")
-		# 	parameter: "units"
-		# 	codeType: codeType
-		# 	codeKind: codeKind
-		# 	autoSave: true
-		# 	roles = [window.conf.roles.acas.userRole]
-		# @unitsController.render()
-		#--- (End) --- 
-
-
-	
-	setupDataTypeController: =>
-		codeType = "data column"
-		codeKind = "column type"
-		opts =
-				modelKey: "type"
-				# inputClass: field.fieldSettings.inputClass
-				formLabel: ''
-				# formLabelOrientation: field.fieldSettings.formLabelOrientation
-				# formLabelTooltip: field.fieldSettings.formLabelTooltip
-				# placeholder: field.fieldSettings.placeholder
-				# required: field.fieldSettings.required
-				url: "/api/codetables/#{codeType}/#{codeKind}"
-				thingRef: @dataTypeValue
-				# insertUnassigned: field.fieldSettings.insertUnassigned
-				# firstSelectText: field.fieldSettings.firstSelectText
-				# modelDefaults: field.modelDefaults
-				# allowedFileTypes: field.fieldSettings.allowedFileTypes
-				# maxFileSize: field.fieldSettings.maxFileSize
-				# displayInline: field.fieldSettings.displayInline
-				# extendedLabel: field.fieldSettings.extendedLabel
-				# sorter: field.fieldSettings.sorter
-				# tabIndex: field.fieldSettings.tabIndex
-				# toFixed: field.fieldSettings.toFixed
-				# pickList: field.fieldSettings.pickList
-				# showDescription: field.fieldSettings.showDescription
-				editablePicklist: false
-				autoSavePickListItem: true
-				editablePicklistRoles: [window.conf.roles.acas.userRole]
-		@dataTypeController = new ACASFormLSCodeValueFieldController opts
-		@$(".bv_dataTypePickList").append @dataTypeController.render().el
-		@dataTypeController.renderModelContent()
-
-		#--- (Start): Previous Code for Data Type Pick List --- 
-		#@dataTypePickListList = new PickListList()
-		#@dataTypePickListList.url = "/api/codetables/#{codeType}/#{codeKind}"
-		#@dataTypeController = new PickListSelectController
-		#	el: @$('.bv_dataTypePickList')
-		#	collection: @dataTypePickListList
-		#	selectedCode: @dataTypeValue.get("stringValue")
-		#	insertFirstOption: new PickList
-		#		code: "unassigned"
-		#		name: "Select Data Type"
-		
-		#@dataTypeController.render()
-		#--- (End) ---
-
+		# TODO remaining values
+		super(options)
 	
 	removeRow: =>
+		# Remove UI element
 		@el.remove()
+		# Ignore the state
+		state = @getStateForRow()
+		state.set 
+			ignored: true
+			modifiedBy: window.AppLaunchParams.loginUser.username
+			modifiedDate: new Date().getTime()
+			isDirty: true
+		# Alert the parent controller to destroy this controller
+		@trigger 'rowRemoved', @rowNumber
 		# TODO figure out how to remove this controller from the parent controller's "endpointControllers"
 
 				
@@ -814,15 +653,8 @@ class EndpointListController extends AbstractFormController
 		tr = document.createElement('tr')
 		# Add that row into the table
 		@$('.bv_endpointRows').append tr
-		# Hack to render template into the tr
-		#tr.empty()
-		template = $("#EndpointRowView2").html()
-		tr.innerHTML = template
 		# Create a new EndpointController, which manages a row
-		# Pass the row we just created for the EndpointController to render into
-		# rowController = new EndpointController
-		# 	el: tr
-		# 	lsState: lsState
+		# We get the row number from the state which was passed in
 		rowNumber = @getRowNumberForState(state)
 		# TODO uncomment if the rest of this starts working
 		# if @stateTableFormControllersCollection[rowNumber]?

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -591,7 +591,7 @@ EndpointsValuesConf = [
 		formLabel: ''
 		fieldWrapper: 'bv_unitsPickList'
 		insertUnassigned: true
-		firstSelectText: "Select Column Units"
+		firstSelectText: "(unitless)"
 		required: false
 		editablePicklist: true
 		autoSavePickListItem: true
@@ -610,7 +610,7 @@ EndpointsValuesConf = [
 		formLabel: ''
 		fieldWrapper: 'bv_dataTypePickList'
 		insertUnassigned: true
-		firstSelectText: ""
+		firstSelectText: "Select Column Type"
 		required: false
 		editablePicklist: false
 ]

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -573,7 +573,7 @@ EndpointsValuesConf = [
 		fieldWrapper: 'bv_columnNamePickList'
 		insertUnassigned: true
 		firstSelectText: "Select Column Name"
-		required: false
+		required: true
 		editablePicklist: true
 		autoSavePickListItem: true
 		editablePicklistRoles: [window.conf.roles.acas.userRole]
@@ -611,7 +611,7 @@ EndpointsValuesConf = [
 		fieldWrapper: 'bv_dataTypePickList'
 		insertUnassigned: true
 		firstSelectText: "Select Column Type"
-		required: false
+		required: true
 		editablePicklist: false
 ]
 		


### PR DESCRIPTION
## Description
I took a sortof extreme approach to this, and tried to alter the EndpointController to use the ACASFormStateTableFormController, which was built to create a non-tabular layout, but still save values to a StateTable data structure.

It took a bunch of troubleshooting, but I was able to get that working with some minor tweaks to ACASFormFields and ACASFormStateTable and Protocol. With that, I was able to shift from our bespoke controllers into a more "LsThing-like" mode where we can configure `EndpointsValuesConf` and derive the fields from there.

The big advantage here is that we can then take advantage of pre-existing code that works properly for saving these values. I briefly had an issue where I was saving _two_ new values every time I made an edit, but I was able to track that down to there being multiple listeners, which counterintuitively I was able to fix by stopping calling "render". This is ultimately because the `ACASFormStateTableFormController` class has some overlap between its `initialize` and `render` functions, and they shouldn't both be called.

## Related Issue

## How Has This Been Tested?
Local dev environment testing. Confirmed I'm able to
- Add new values to the dropdowns
- Save new rows
- Render back saved rows
- Edit empty rows and save values on the first try