### PR TITLE
Updating/Fixing Error Message if No Salt Structure Provided

### DIFF
--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -270,7 +270,9 @@ class SaltBrowserController extends Backbone.View
 			console.log(saltName)
 			console.log(saltStruct)
 			# Need to Alert User of Empty Fields Somehow 
-			alert('Please fill in name, abbrev, and structure fields!')
+			@$('.bv_createNotifications').show()
+			@createNotificationController.clearAllNotificiations()
+			@createNotificationController.addNotifications(@errorOwnerName, [{"errorLevel": "error", "message": "Please fill in structure, name, and abbrev fields!" }])
 		if (fieldsFilled)
 			saltDict = 
 			{
@@ -296,6 +298,10 @@ class SaltBrowserController extends Backbone.View
 						@createNotificationController.clearAllNotificiations()
 						for feedback in result
 							@createNotificationController.addNotifications(@errorOwnerName, [{"errorLevel": feedback.level, "message":feedback.message}])
+					else if result["formula"] == ""
+						@$('.bv_createNotifications').show()
+						@createNotificationController.clearAllNotificiations()
+						@createNotificationController.addNotifications(@errorOwnerName, [{"errorLevel": "error", "message": "No salt structure provided!" }])
 					else 
 						@$('.bv_createNotifications').hide()
 						# Need to Parse Result Values Into Form Fields 


### PR DESCRIPTION
**Steps to reproduce:**

Try to register a salt without a structure.

**Prior to Bug Fix Results:**

The current workflow just abruptly ends after you click save with no notification of whether the salt registration is successful or not.
No error is displayed to the user about the structure being absent.

**Fixed Results:**

When you register a new salt without a structure, the UI should display an error that adding a structure is mandatory for registering the salt.