### PR TITLE
ACAS-460 LsThingBrowser use flat advanced search results, fix hiding/showing of messages

### DIFF
--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -19,13 +19,13 @@ jobs:
         run: |
           echo "BRANCH_NAME=$(echo ${{ github.ref }} | sed 's/refs\/heads\///g')" >> $GITHUB_ENV
       # Get next dev tag name on this branch
-      # First command lists all tags on the branch, filters to those containing '.dev', then grabs the last one
-      # Second command increments the final digit after dev, so 2022.1.1.dev1 will become 2022.1.1.dev2
-      # and 2022.1.1.dev9 will become 2022.1.1.dev10
+      # First command lists all tags on the branch, filters to those containing '-dev', then grabs the last one
+      # Second command increments the final digit after dev, so 2022.1.1-dev1 will become 2022.1.1-dev2
+      # and 2022.1.1-dev9 will become 2022.1.1-dev10
       - name: Get next dev tag name
         run: |
-          LAST_TAG=$(git tag --sort=committerdate --merged ${{ env.BRANCH_NAME }} | grep '.dev' | tail -1)
-          echo "NEXT_TAG=$(echo $LAST_TAG | awk -F.dev -v OFS=.dev '{$NF += 1 ; print}')" >> $GITHUB_ENV
+          LAST_TAG=$(git tag --sort=committerdate --merged ${{ env.BRANCH_NAME }} | grep -e '-dev' | tail -1)
+          echo "NEXT_TAG=$(echo $LAST_TAG | awk -F-dev -v OFS=-dev '{$NF += 1 ; print}')" >> $GITHUB_ENV
       # Trigger the build
       - name: Trigger the tagger workflow with branch ${{env.BRANCH_NAME}} and tag ${{ env.NEXT_TAG }}
         uses: actions/github-script@v5

--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -410,9 +410,9 @@ class ACASThingBrowserController extends Backbone.View
 		if response.maxResults <= response.numberOfResults
 			msg = "Browser results were limited to the first " + response.maxResults + " entries out of " + response.numberOfResults + " results"
 			@$('.bv_maxThingBrowserSearchResultsReached').html msg
-			@$("bv_maxThingBrowserSearchResultsReached").removeClass("hide")
+			@$(".bv_maxThingBrowserSearchResultsReached").removeClass("hide")
 		else 
-			@$("bv_maxSearchResultsLimited").addClass("hide")
+			@$(".bv_maxThingBrowserSearchResultsReached").addClass("hide")
 
 		if results is null
 			@showOne("bv_errorOccurredPerformingSearch")

--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -446,7 +446,7 @@ class ACASThingBrowserController extends Backbone.View
 				el: @$('.bv_thingController')
 			@renderController()
 		else
-			c = new @modelClass(thing.attributes)
+			c = new @modelClass(thing)
 			c.fetch
 				success: (model, response, options) =>
 					@thingController = new @controllerClass

--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -50,7 +50,7 @@ class ThingSimpleSearchController extends AbstractFormController
 			defaultQueryTerms =
 				queryString: "#{thingSearchTerm}"
 				queryDTO:
-					maxResults: 1000000000
+					maxResults: @options.maxResults
 					lsType: @model.get("lsType")
 					lsKind: @model.get("lsKind")
 					recordedBy: "#{thingSearchTerm}"
@@ -255,6 +255,7 @@ class ThingSummaryTableController extends Backbone.View
 	initialize: (options)->
 		@configs = options.configs
 		@columnFilters = options.columnFilters
+		@maxResults = options.maxResults
 
 	selectedRowChanged: (row) =>
 		@trigger "selectedRowUpdated", row
@@ -379,6 +380,7 @@ class ACASThingBrowserController extends Backbone.View
 			model: thingModel
 			query: @query
 			configs: @configs
+			maxResults: @maxResults
 			el: @$('.bv_thingSearchController')
 		@searchController.render()
 		@searchController.on "searchReturned", @setupThingSummaryTable.bind(@)
@@ -426,6 +428,7 @@ class ACASThingBrowserController extends Backbone.View
 				thingModelClass: @modelClass
 				configs: @configs
 				columnFilters: @columnFilters
+				maxResults: @maxResults
 
 			@thingSummaryTable.on "selectedRowUpdated", @selectedThingUpdated
 			@$(".bv_thingTableController").html @thingSummaryTable.render().el

--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -442,6 +442,7 @@ class ACASThingBrowserController extends Backbone.View
 			@thingController = new @controllerClass
 				model: thing
 				configs: @configs
+				readOnly: true
 				el: @$('.bv_thingController')
 			@renderController()
 		else
@@ -451,6 +452,7 @@ class ACASThingBrowserController extends Backbone.View
 					@thingController = new @controllerClass
 						model: model
 						configs: @configs
+						readOnly: true
 						el: @$('.bv_thingController')
 					@renderController()
 				error: (model, response, options) =>

--- a/modules/Components/src/client/ACASThingBrowserView.html
+++ b/modules/Components/src/client/ACASThingBrowserView.html
@@ -71,14 +71,15 @@
                                 <div class="bar" style="width: 100%; margin: auto;"></div>
                             </div>
                         </div>
+                        <h5 class="bv_maxThingBrowserSearchResultsReached hide"></h5>
                     </td>
                 </tr>
                 </tbody>
                 </tbody>
             </table>
         </div>
-
         <div class="bv_thingTableController hide" style="margin:0px; padding:10px; overflow: auto; overflow: auto;"></div>
+        <label class="bv_maxThingBrowserSearchResultsReached" style="margin-left:10px;"></label>
     </div>
     <div class="well well-small bv_thingControllerContainer hide" style="margin-top: 10px;">
         <div>

--- a/modules/Components/src/client/ACASThingBrowserView.html
+++ b/modules/Components/src/client/ACASThingBrowserView.html
@@ -71,7 +71,6 @@
                                 <div class="bar" style="width: 100%; margin: auto;"></div>
                             </div>
                         </div>
-                        <h5 class="bv_maxThingBrowserSearchResultsReached hide"></h5>
                     </td>
                 </tr>
                 </tbody>

--- a/modules/ServerAPI/src/client/ExampleThing.coffee
+++ b/modules/ServerAPI/src/client/ExampleThing.coffee
@@ -531,6 +531,7 @@ class ExampleThingBrowserController extends ACASThingBrowserController
 	controllerClass: ExampleThingController
 	modelClass: ExampleThingParent
 	columnFilters: true
+	maxResults: 100000
 	configs: [
 			name: "Code Name"
 			key: "codeName"

--- a/modules/ServerAPI/src/client/ExampleThing.coffee
+++ b/modules/ServerAPI/src/client/ExampleThing.coffee
@@ -344,7 +344,8 @@ class ExampleThingController extends AbstractThingFormController
 		@$('.bv_updatingThing').hide()
 		@trigger 'amClean'
 		@trigger 'thingSaved'
-		@socket.emit 'editLockEntity', @errorOwnerName, @model.get(@lockEditingForSessionKey)
+		if !@options.readOnly?
+			@socket.emit 'editLockEntity', @errorOwnerName, @model.get(@lockEditingForSessionKey)
 		@renderModelContent()
 
 		@auditTableController = new ExampleTableAuditController

--- a/modules/ServerAPI/src/client/ExampleThing.coffee
+++ b/modules/ServerAPI/src/client/ExampleThing.coffee
@@ -542,6 +542,12 @@ class ExampleThingBrowserController extends ACASThingBrowserController
 			name: "Scientist"
 			key: "scientist"
 		,
+			name: "My Color"
+			key: "color"
+		,
+			name: "Completion Date"
+			key: 'completion date'
+		,
 			name: "Recorded By"
 			key: "recordedBy"
 			filter: false

--- a/modules/ServerAPI/src/server/ControllerRedirectConf.coffee
+++ b/modules/ServerAPI/src/server/ControllerRedirectConf.coffee
@@ -30,7 +30,7 @@
 					deepLink: "project"
 				relatedFilesRelativePath: "entities/projects"
 			THING:
-				entityName: "example thing"
+				entityName: "things/example thing"
 				"Example Thing":
 					deepLink: "example_thing"
 				relatedFilesRelativePath: "entities/exampleThings"


### PR DESCRIPTION
## Description
 - Use new "flat" advanced search returns and on click of a row, fetch the full ls thing object
 - Fix issue with dates values rendering as Nan-na-na
 - Fix issues with Search messages not rendering properly
 - Add notification of when max search results has been hit

## Related Issue
ACAS-460

## How Has This Been Tested?
ACAS client tests of new roo route changes
Manual testing of ACASThing browser with 10,000 things, clicking on rows, hitting max limit...etc.