### PR TITLE
ACAS-461: Change default server.service.projects.restrictExperiments to true

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -593,7 +593,7 @@ server.curveRender.curveLwd=1.5
 server.curveRender.plotPointsOnOverlay=false
 
 # Restrict experiment search by project
-server.service.projects.restrictExperiments=false
+server.service.projects.restrictExperiments=true
 
 server.flyway.location=com.labsynch.labseer.db.migration.postgres,db/migration/postgres,db/migration/indigo/postgres
 


### PR DESCRIPTION
## Description
Change default for `server.service.projects.restrictExperiments` to `true`
This restricts experiments in experiment search to only those the user has project acls for.

## Related Issue
ACAS-461

## How Has This Been Tested?
Ran ACAS client tests.