### PR TITLE
ACAS-271: Preserve file naming in SDF bulk loader

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -938,6 +938,7 @@ class FileRowSummaryController extends Backbone.View
 		#To get the current state, we need the bulk file ID to get lots and then generate the updated SDF file
 		reportID = @model.get('id')
 		fileName = @model.get('fileName')
+		originalFileName = @model.get('originalFileName')
 
 		#Get today's date to timestamp any updated SDF files
 		today = new Date
@@ -951,18 +952,20 @@ class FileRowSummaryController extends Backbone.View
 		today = '_' + mm + '_' + dd + '_' + yyyy
 
 		# Rename the SDF file representing the current
-		currentFileName = fileName.replace "\.sdf", today + "_current_state.sdf"
+		currentFileName = originalFileName.replace "\.sdf", today + "_current_state.sdf"
     
 		# Replace .sdf with .zip since the report file shares the same name 
 		reportName = fileName.replace "\.sdf", ".zip"
+		reportDisplayName = originalFileName.replace "\.sdf", ".zip"
 
 		toDisplay =
 			fileName: fileName
+			originalFileName: originalFileName
 			loadDate: fileDate
 			loadUser: @model.get('recordedBy')
 			currentFileLink: "/api/cmpdRegBulkLoader/getSDFFromBulkLoadFileID/" + reportID
 			currentFileName: currentFileName
-			reportName: reportName
+			reportName: reportDisplayName
 			#remove special characters from the links to prevent errors, but not from the displayed names
 			fileLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(fileName)
 			reportLink: window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(reportName)

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -1189,12 +1189,14 @@ class CmpdRegBulkLoaderAppController extends Backbone.View
 			@setupBulkRegCmpdsSummaryController(summary[0])
 			downloadUrl = window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(summary[1])
 			@$('.bv_downloadSummary').attr "href", downloadUrl
+			@$('.bv_downloadSummary').attr "download", summary[2]
 		@regCmpdsController.on 'validateComplete', (summary) =>
 			@$('.bv_bulkReg').hide()
 			@$('.bv_bulkValSummary').show()
 			@setupBulkValCmpdsSummaryController(summary[0])
 			downloadUrl = window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + encodeURIComponent(summary[1])
 			@$('.bv_downloadSummary').attr "href", downloadUrl
+			@$('.bv_downloadSummary').attr "download", summary[2]
 
 	setupBulkRegCmpdsSummaryController: (summary) ->
 		if @regCmpdsSummaryController?

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -116,7 +116,8 @@ class DetectSdfPropertiesController extends Backbone.View
 
 	handleFileUploaded: (file) =>
 		@fileName = file.name
-		@trigger 'fileChanged', @fileName
+		@originalFileName = file.originalName
+		@trigger 'fileChanged', file
 		@getProperties()
 
 	getProperties: =>
@@ -475,8 +476,13 @@ class AssignSdfPropertiesController extends Backbone.View
 					ignored: false
 				@assignedPropertiesList.add newAssignedProp
 
-	handleFileChanged: (newFileName) ->
-		@fileName = newFileName
+	handleFileChanged: (newFile) ->
+		if !newFile?
+			@fileName = null
+			@originalFileName = null
+		else
+			@fileName = newFile.name
+			@originalFileName = newFile.originalName
 
 	handleDbProjectChanged: ->
 		#this function only gets called if project select is shown in the configuration part of the GUI
@@ -721,6 +727,7 @@ class AssignSdfPropertiesController extends Backbone.View
 			@addProjectToMappingsPayLoad()
 		dataToPost =
 			fileName: @fileName
+			originalFileName: @originalFileName
 			mappings: JSON.parse(JSON.stringify(@assignedPropertiesListController.collection.models))
 			userName: window.AppLaunchParams.loginUser.username
 		if window.AppLaunchParams.cmpdRegConfig.serverSettings.corpParentFormat? and window.AppLaunchParams.cmpdRegConfig.serverSettings.corpParentFormat == 'ACASLabelSequence'
@@ -748,6 +755,7 @@ class AssignSdfPropertiesController extends Backbone.View
 			@addProjectToMappingsPayLoad()
 		dataToPost =
 			fileName: @fileName
+			originalFileName: @originalFileName
 			mappings: JSON.parse(JSON.stringify(@assignedPropertiesListController.collection.models))
 			userName: window.AppLaunchParams.loginUser.username
 		if window.AppLaunchParams.cmpdRegConfig.serverSettings.corpParentFormat? and window.AppLaunchParams.cmpdRegConfig.serverSettings.corpParentFormat == 'ACASLabelSequence'
@@ -830,8 +838,8 @@ class BulkRegCmpdsController extends Backbone.View
 	setupAssignSdfPropertiesController: =>
 		@assignSdfPropertiesController = new AssignSdfPropertiesController
 			el: @$('.bv_assignSdfProperties')
-		@detectSdfPropertiesController.on 'fileChanged', (newFileName) =>
-			@assignSdfPropertiesController.handleFileChanged newFileName
+		@detectSdfPropertiesController.on 'fileChanged', (newFile) =>
+			@assignSdfPropertiesController.handleFileChanged newFile
 		@assignSdfPropertiesController.on 'templateChanged', (templateName, mappings) =>
 			@detectSdfPropertiesController.handleTemplateChanged(templateName, mappings)
 		@assignSdfPropertiesController.on 'saveComplete', (saveSummary) =>

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -261,11 +261,11 @@
 </script>
 
 <script type="text/template" id="FileRowSummaryView" xmlns="http://www.w3.org/1999/html">
-    <td class='bv_fileName'><a href='<%-fileLink%>'><%-fileName%></a></td>
+    <td class='bv_fileName'><a href='<%-fileLink%>'download="<%-originalFileName%>" ><%-originalFileName%></a></td>
     <td class='bv_loadDate'><%-loadDate%></td>
     <td class='bv_loadUser'><%-loadUser%></td>
     <td class="bv_currentSDF"><a href=<%-currentFileLink%> download="<%-currentFileName%>">Download</a></td>
-    <td class='bv_Report'><a href='<%-reportLink%>'><%-reportName%></a></td>
+    <td class='bv_Report'><a href='<%-reportLink%>' download="<%-reportName%>"><%-reportName%></a></td>
 </script>
 
 <script type="text/template" id="FileSummaryTableView" xmlns="http://www.w3.org/1999/html">

--- a/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
+++ b/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
@@ -174,7 +174,8 @@ exports.registerCmpds = (req, resp) ->
 		#remove .sdf from fileName and originalFileName
 		fileName = fileName.substring(0, fileName.length-4)
 		originalFileName = originalFileName.substring(0, originalFileName.length-4)
-		zipFileName = originalFileName+".zip"
+		zipFileName = fileName+".zip"
+		zipFileDisplayName = originalFileName+".zip"
 		fs = require 'fs'
 		JSZip = require 'jszip'
 		zip = new JSZip()
@@ -194,7 +195,7 @@ exports.registerCmpds = (req, resp) ->
 		fstream = zip.generateNodeStream({type:"nodebuffer", streamFiles:true}).pipe(fs.createWriteStream(zipFilePath))
 		fstream.on 'finish', ->
 			console.log "finished create write stream"
-			resp.json [json, zipFileName]
+			resp.json [json, zipFileName, zipFileDisplayName]
 		fstream.on 'error', (err) ->
 			console.log "error writing stream for zip"
 			console.log err
@@ -210,7 +211,6 @@ exports.registerCmpds = (req, resp) ->
 				fileName = req.body.fileName
 				originalFileName = req.body.originalFileName
 				delete req.body.fileName
-				delete req.body.originalFileName
 
 				# get a list of scientists that are allowed to be registered chemists
 				exports.getScientistsInternal (authors) =>

--- a/modules/Components/src/client/LSFileChooserView.html
+++ b/modules/Components/src/client/LSFileChooserView.html
@@ -24,7 +24,7 @@
 {% for (var i=0, file; file=o.files[i]; i++) { %}
     <tr class="template-upload fade">
         <td class="preview"\><span class="fade"></span></td>
-        <td class="name" width="500px;""><span>{%=file.name%}</span></td>
+        <td class="name" width="500px;""><span>{%=file.originalName%}</span></td>
         <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
         {% if (file.error) { %}
             <td class="error" colspan="2"><span class="label label-important">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
@@ -56,17 +56,17 @@
     <tr class="template-download fade">
         {% if (file.error) { %}
             <td></td>
-            <td class="name"><span>{%=file.name%}</span></td>
+            <td class="name"><span>{%=file.originalName%}</span></td>
             <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
             <td class="error" colspan="2"><span class="label label-important">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
         {% } else { %}
             <td class="preview" valign="middle">
             	<i class='bv_status'></i>
             {% if (file.thumbnail_url) { %}
-                <a href="{%=file.url%}" title="{%=file.name%}" rel="gallery" download="{%=file.name%}"><img src="{%=file.thumbnail_url%}"></a>
+                <a href="{%=file.url%}" title="{%=file.originalName%}" rel="gallery" download="{%=file.originalName%}"><img src="{%=file.thumbnail_url%}"></a>
             {% } %}</td>
             <td class="name">
-                <a href="{%=file.url%}" title="{%=file.name%}" rel="{%=file.thumbnail_url&&'gallery'%}" download="{%=file.name%}">{%=file.name%}</a>
+                <a href="{%=file.url%}" title="{%=file.originalName%}" rel="{%=file.thumbnail_url&&'gallery'%}" download="{%=file.originalName%}">{%=file.originalName%}</a>
             </td>
             <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
             <td colspan="2">


### PR DESCRIPTION
## Description
ACAS introduces spaces and numbers in parentheses to keep SDF and zip filenames distinct because it drops them all into a common privateUploads folder. This makes life harder for users who may upload the same file multiple times but get different filenames when they re-download that same file from ACAS, or when they download derived zipfiles.

This acas change adds an "originalFileName" variable which is tracked and passed to the roo layer. Across the validation, registration, and purge pages, these changes make it so we show the original filename (`example.sdf`) and download as the original filename (`example.sdf`), but href to the correct filename (`example (26).sdf`) in cases where the same filename has been uploaded many times.

These changes are co-dependent with https://github.com/mcneilco/acas-roo-server/pull/370

## Related Issue

## How Has This Been Tested?
Local testing of uploading the same file many times. Confirmed that the validation download zip, its contents, the registration download zip, and all the links on the purge files page (including the link / summary after purging) all show the original filename, and all download the correct numbered / distinct file.