### PR TITLE
Add more descriptive error message when user attempts to delete Stereo Category and Vendors with dependencies

### DIFF
--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowser.coffee
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowser.coffee
@@ -290,10 +290,18 @@ class AbstractCodeTablesAdminBrowserController extends Backbone.View
 				@$(".bv_deletingStatusIndicator").addClass "hide"
 				@$(".bv_codeTablesAdminDeletedSuccessfullyMessage").removeClass "hide"
 				@handleSearchRequested()
-			error: (result) =>
+			error: (response) =>
 				@$(".bv_okayButton").removeClass "hide"
 				@$(".bv_deletingStatusIndicator").addClass "hide"
 				@$(".bv_errorDeletingCodeTablesAdminMessage").removeClass "hide"
+				errorMsg = response.responseText
+				if (errorMsg)
+					errorJSON = JSON.parse(errorMsg)
+					# Grabbing the first (and assumingly only) error and displaying the message in placeholder element 
+					@$('.bv_deleteCodeTablesAdminErrorMessageHolder').html errorJSON[0].message
+				else
+					noServerMessage = "There is no error message from the server."
+					@$('.bv_deleteCodeTablesAdminErrorMessageHolder').html noServerMessage
 		)
 
 	handleCancelDeleteClicked: =>

--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowserView.html
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowserView.html
@@ -128,6 +128,7 @@
                 </div>
                 <div class="bv_errorDeletingCodeTablesAdminMessage hide">
                     <p>An error occured deleting <%-upperDisplayName%> <span class="bv_codeTablesAdminCodeName"></span>.  Please contact support for additional help.</p>
+                    <p class="bv_deleteCodeTablesAdminErrorMessageHolder"></p>
                 </div>
             </div>
             <div class="modal-footer">

--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminView.html
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminView.html
@@ -110,6 +110,7 @@
             </div>
             <div class="bv_errorDeletingCodeTablesAdminMessage hide">
                 <p>An error occurred deleting <%-upperDisplayName%> <span class="bv_codeTablesAdminCodeName"></span>.  Please contact support for additional help.</p>
+                <p class="bv_deleteCodeTablesAdminErrorMessageHolder"></p>
             </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
**Steps to Reproduce:**

_Stereo Category_

CmpdReg Stereo Categories >> Select a Stereo Category which has dependencies (e.g. compounds, compound lots etc. registered under it) 
Attempt to 'Delete' the category 

_Vendors_

CmpdReg Vendors >> Select a Vendor which has dependencies (e.g. compounds, compound lots etc. associated with it) 
Attempt to 'Delete' the vendor

**New Implementation Results:**

_Stereo Category:_ The Stereo Category is not deletable & the action throws an error, describing the exact cause of the error 

_Vendor:_ The Vendor is not deletable & the action throws an error, describing the exact cause of the error

**Previous Results Which Caused Creation of Ticket:**

In both cases ACAS threw a generic error message:

Stereo Category: "An error occurred deleting Stereo Category <stereo_category_name>. Please contact support for additional help."
Vendor: "An error occurred deleting Vendor <vendor_name>. Please contact support for additional help."


## How Has This Been Tested?
Manually 

See Examples... 

<img width="656" alt="Delete Stereo Category" src="https://user-images.githubusercontent.com/97194463/193911663-a1c953a6-f72e-4edd-9f7f-2e723fd4bea4.png">
<img width="553" alt="Delete Vendor" src="https://user-images.githubusercontent.com/97194463/193911676-b582a6e4-968b-43d4-8b6c-15c7305d4782.png">
