### PR TITLE
ACAS-466: heart beat monitor in ui

### DIFF
--- a/modules/Components/src/client/ACASToast.coffee
+++ b/modules/Components/src/client/ACASToast.coffee
@@ -37,43 +37,45 @@ class ACASToast extends Backbone.View
             title: @title
             text: @text
             iconType: @iconType
-        toastElem = parser.parseFromString(txt, 'text/html').querySelector('.toast')
+        @toastElem = parser.parseFromString(txt, 'text/html').querySelector('.toast')
         # append toast message to it
-        @toastContainer.appendChild(toastElem)
+        @toastContainer.appendChild(@toastElem)
         # wait just a bit to add active class to the message to trigger animation
-        setTimeout(() ->                 
-            toastElem.classList.add('active');
+        setTimeout(() =>                 
+            @toastElem.classList.add('active');
         , 1)
         # grab the close button
-        closeElem = toastElem.querySelector('.t-close')
+        closeElem = @toastElem.querySelector('.t-close')
         # Bind close event to close toast message
-        closeElem.addEventListener('click', @handleCloseToastClicked)
+        closeElem.addEventListener('click', @handleCloseToastClicked.bind(@))
         # check duration. if duration is 0, toast message will not be closed
         if @duration > 0
             setTimeout( () =>
 
-                @closeToast(toastElem)
+                @closeToast()
             , @duration)
         
 
     getToastContainer: -> 
         # Get toast container based on position
         @toastContainer = document.querySelector(".toast-container.#{@position}")
+        return @toastContainer
     
     handleCloseToastClicked: (el) ->
-        # get toast element
-        toastElement = el.target.parentElement;
         # remove active class from it to trigger css animation with duration of 300ms
-        toastElement.classList.remove('active');
+        @toastElem.classList.remove('active');
         # wait for 350ms and then remove element
-        setTimeout( () ->                 
-            toastElement.remove();
+        setTimeout( () =>                 
+            @toastElem.remove();
         , 350)
     
-    closeToast: (toastElement) ->
+    closeToast: () ->
         # remove active class from it to trigger css animation with duration of 300ms
-        toastElement.classList.remove('active');
+        @toastElem.classList.remove('active');
         # wait for 350ms and then remove element
-        setTimeout( () ->                 
-            toastElement.remove();
+        setTimeout( () =>                 
+            @toastElem.remove();
         , 350)
+
+    isActive: () ->
+        $(@.toastElem).hasClass("active")

--- a/modules/Components/src/client/ACASToast.coffee
+++ b/modules/Components/src/client/ACASToast.coffee
@@ -7,6 +7,8 @@ class ACASToast extends Backbone.View
         @type = options.type
         @title = options.title
         @text = options.text
+        # On close function to be run if user initiates close
+        @onClose = options.onClose
         # Duration is in milliseconds
         @duration = options.duration
         # Supported positions are: top-right, top-center, top-left, bottom-right, bottom-center, bottom-left
@@ -67,6 +69,8 @@ class ACASToast extends Backbone.View
         # wait for 350ms and then remove element
         setTimeout( () =>                 
             @toastElem.remove();
+            if @onClose?
+                @onClose()
         , 350)
     
     closeToast: () ->

--- a/modules/ModuleMenus/src/client/ModuleMenus.coffee
+++ b/modules/ModuleMenus/src/client/ModuleMenus.coffee
@@ -118,9 +118,12 @@ class ModuleMenusController extends Backbone.View
 						@heartbeatToast = new ACASToast
 							type: "error"
 							title: "Logged out"
-							text: "You have been logged out. Please login again."
+							text: "You have been logged out. You must log back in to continue."
 							position: "bottom-right"
 							duration: 50000
+							onClose: =>
+								# Reload the page if the user clicks the close button on the heartbeat notification
+								location.reload()
 					else if @status != 200
 						@heartbeatToast = new ACASToast
 							type: "error"

--- a/modules/ModuleMenus/src/client/ModuleMenus.coffee
+++ b/modules/ModuleMenus/src/client/ModuleMenus.coffee
@@ -88,8 +88,47 @@ class ModuleMenusController extends Backbone.View
 		if window.AppLaunchParams.deployMode?
 			unless window.AppLaunchParams.deployMode.toUpperCase() =="PROD"
 				@$('.bv_deployMode h1').html(_.escape(window.AppLaunchParams.deployMode.toUpperCase()))
-
+		@heartbeat()
 		@
+
+	heartbeat: =>
+		## Fetch /api/about endpoint, if 401, then notify user they have been logged out
+		## If another error then try something else
+		setInterval =>
+				originalStatus = @status
+				try
+					response = await fetch("/api/about", method: 'GET')
+					@status = response.status
+					@statusText = response.statusText
+				catch error
+					@status = "error"
+					@statusText = "Response error"
+				
+
+				# Check if the heartbeat notification exists and is active/visible
+				active = @heartbeatToast? && @heartbeatToast.isActive()
+
+				# If we aren't showing the heartbeat notification or the status has changed, then update/show the heartbeat notification
+				if !active || originalStatus != @status
+					if @heartbeatToast?
+						@heartbeatToast.closeToast()
+						@heartbeatToast.remove()
+					
+					if @status == 401
+						@heartbeatToast = new ACASToast
+							type: "error"
+							title: "Logged out"
+							text: "You have been logged out. Please login again."
+							position: "bottom-right"
+							duration: 50000
+					else if @status != 200
+						@heartbeatToast = new ACASToast
+							type: "error"
+							title: "Unable to communicate with ACAS: #{@statusText}"
+							text: "You may have been disconnected. Please refresh."
+							position: "bottom-right"
+							duration: 50000
+		, 10000		
 
 	handleHome: =>
 		$('.bv_mainModuleWrapper').hide()


### PR DESCRIPTION
## Description
Heart beat monitor which checks every 10 seconds for a disconnection or logout of ACAS and displays a message.
If the message is already being shown and the status does not change then the message is left
If the status changes (either a successful connection or not) the message is removed or change to match the current status.

## Related Issue
ACAS-466

## How Has This Been Tested?
Logged into ACAS and restarted the backend and verified a message about not being able to communicate with ACAS showed.
Once ACAS restarted but the user was logged out, verified the message was updated to match new "logged out" status.
Logged back in via another tab and verified that the message went away.