### PR TITLE
ACAS-271: Fallback for when register request is missing originalFileName

### DIFF
--- a/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
+++ b/modules/CmpdRegBulkLoader/src/server/routes/CmpdRegBulkLoaderRoutes.coffee
@@ -209,7 +209,10 @@ exports.registerCmpds = (req, resp) ->
 				resp.end JSON.stringify "Registration Summary here"
 			else
 				fileName = req.body.fileName
-				originalFileName = req.body.originalFileName
+				if req.body.originalFileName?
+					originalFileName = req.body.originalFileName
+				else
+					originalFileName = fileName
 				delete req.body.fileName
 
 				# get a list of scientists that are allowed to be registered chemists


### PR DESCRIPTION
## Description
Fall back to the required fileName key when registering an SDF file

## Related Issue
ACAS-271

## How Has This Been Tested?
Ran acasclient tests.