### PR TITLE
Fixed .sdf <-> .zip swapping, removed redundant/unused variables

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -261,7 +261,7 @@
 </script>
 
 <script type="text/template" id="FileRowSummaryView" xmlns="http://www.w3.org/1999/html">
-    <td class='bv_fileName'><a href='<%-fileLink%>'download="<%-fileName%>" ><%-fileName%></a></td>
+    <td class='bv_fileName'><a href='<%-fileLink%>'download="<%-originalFileName%>" ><%-originalFileName%></a></td>
     <td class='bv_loadDate'><%-loadDate%></td>
     <td class='bv_loadUser'><%-loadUser%></td>
     <td class="bv_currentSDF"><a href=<%-currentFileLink%> download="<%-currentFileName%>">Download</a></td>


### PR DESCRIPTION
## Description

**Problem**
- Users were using CReg Bulk Loader to load .sdf files with .sdf extensions in multiple locations within the file name (artifacts of previous downloads)
- Downloading summary files/current files were broken since the logic to replace ".sdf" with ".zip" only ran once, and was renaming the first ".sdf" in the file string, not the extension at the end. As a result, the link in the panel could not locate the correct file. 

**Fix**
- Removed the functions using .replace(".sdf", ".zip") and .replace(".sdf", {todays_date} + ".sdf") and replaced them with logic that would remove the last four characters of the file name string and then add ".zip" or {todays_date} + ".sdf" 
- Also removed unused variables

## How Has This Been Tested?
1. Renamed a test .sdf file to "compounds_for_bulkloader_1(6).sdf_2022-09-30_validated (3).sdf" 
2. Bulk loaded / registered file.
3. Tried downloading summary, current file, and original file to see if there were incorrect swapping between ".zip" and ".sdf" or if the file could not be found. 

