### PR TITLE
ACAS-271 followup: Fix download link after purging file

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -1117,7 +1117,8 @@ class PurgeFilesController extends Backbone.View
 		@$('.bv_purgeSummary').html response.summary
 		downloadUrl = window.conf.datafiles.downloadurl.prefix + "cmpdreg_bulkload/" + response.fileName
 		@$('.bv_purgedFileName').attr "href", downloadUrl
-		@$('.bv_purgedFileName').html response.fileName
+		@$('.bv_purgedFileName').attr "download", response.originalFileName
+		@$('.bv_purgedFileName').html response.originalFileName
 		@$('.bv_purgeSummaryWrapper .bv_downloadPurgedFile').show()
 		@$('.bv_purgeSummaryWrapper').show()
 		@fileInfoToPurge = null


### PR DESCRIPTION
## Description
- I'd forgotten to check this change in on my last PR. This fixes the display name and downloaded file name for the link shown _after_ you purge a file

## Related Issue

## How Has This Been Tested?
Local UI testing, confirmed acasclient tests pass this time. Added more acasclient tests for originalFileName in https://github.com/mcneilco/acasclient/pull/100