### PR TITLE
ACAS-469-maestro-sketcher-update

### DIFF
--- a/modules/CmpdReg/src/client/CmpdReg.jade
+++ b/modules/CmpdReg/src/client/CmpdReg.jade
@@ -11,6 +11,7 @@ html#CmpdRegView
 
 		include ../public/html/CmpdReg/DeleteLotView.html
 		include ../public/html/CmpdReg/ReparentLotView.html
+		include ../public/html/Components/ACASFormChemicalStructureView.html
 
 		script(type='text/javascript', src="/CmpdReg/client/lib/jquery-1.7.2.min.js")
 		script(type='text/javascript', src="/CmpdReg/client/lib/json2.js")
@@ -65,7 +66,8 @@ html#CmpdRegView
 
 		script(type='text/javascript', src="/CmpdReg/client/custom/Lot_Custom.js")
 		script(type='text/javascript', src="/javascripts/src/CmpdReg/ReparentLot.js")
-
+		script(type='text/javascript', src="/javascripts/src/Components/UtilityFunctions.js")
+		script(type='text/javascript', src="/javascripts/src/Components/ACASFormChemicalStructure.js")
 
 
 		include ../public/CmpdReg/client/templates/StructureImageView.inc

--- a/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
+++ b/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
@@ -619,7 +619,7 @@ div {
     height: 27px;
     width: 90px;
     position: absolute;
-    left: 760px;
+    left: 680px;
     top: 560px;
 }
 .RegistrationSearchView a.cancelButton, .EditParentSearchView a.cancelEditButton {
@@ -627,7 +627,7 @@ div {
     height: 27px;
     width: 90px;
     position: absolute;
-    left: 665px;
+    left: 580px;
     top: 560px;
 }
 /****** REGISTRATION STEP 2 ******/

--- a/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
+++ b/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
@@ -1,11 +1,12 @@
 $(function() {
 
 	window.MaestroJSUtil = {
+        // See implementation of "setRepresentation" in src/components/Sketcher/index.tsx of the rc-maestro-sketcher repository as a reference
 		"getSketcher": function getSketcher (el) {
             function waitForReady (resolve, reject) {
                 var _a;
                 maestro = $(el)[0].contentWindow.Module;
-                const sketcherImportText = (_a = this.maestro) === null || _a === void 0 ? void 0 : _a.sketcherImportText;
+                const sketcherImportText = (_a = this.maestro) === null || _a === void 0 ? void 0 : _a.sketcher_import_text;
                 // Wait until sketcher is initialized
                 if (!sketcherImportText) {
                     self = this;

--- a/modules/CmpdReg/src/client/src/Salt.js
+++ b/modules/CmpdReg/src/client/src/Salt.js
@@ -154,7 +154,6 @@ $(function() {
 			_.bindAll(this, 'validationError', 'saveSalt', 'render');
 			$(this.el).html(this.template());
 			this.exportFormat = "mol";
-			this.useMaestro = true;
 
 			this.sketcherLoaded = false;
 		},

--- a/modules/CmpdReg/src/client/src/Salt.js
+++ b/modules/CmpdReg/src/client/src/Salt.js
@@ -154,66 +154,25 @@ $(function() {
 			_.bindAll(this, 'validationError', 'saveSalt', 'render');
 			$(this.el).html(this.template());
 			this.exportFormat = "mol";
-			if(window.configuration.sketcher == 'marvin') {
-				this.useMarvin = true;
-				if (window.configuration.marvin.exportFormat) {
-					this.exportFormat = window.configuration.marvin.exportFormat;
-				}
-			} else if(window.configuration.sketcher == 'ketcher') {
-				this.useKetcher = true;
-			} else if(window.configuration.sketcher == 'maestro') {
-				this.useMaestro = true;
-			} else {
-				alert("No registration sketcher configured");
-			}
+			this.useMaestro = true;
 
 			this.sketcherLoaded = false;
 		},
 
 		render: function () {
 			var self = this;
-			if (this.useMarvin) {
-				this.$('#newSaltMarvinSketch').attr('src',"/CmpdReg/marvinjs/editorws.html");
-				MarvinJSUtil.getEditor("#newSaltMarvinSketch").then(function (sketcherInstance) {
-					self.marvinSketcherInstance = sketcherInstance;
-					if (typeof window.marvinStructureTemplates !== 'undefined') {
-						for (i = 0; i < window.marvinStructureTemplates.length; i++) {
-							sketcherInstance.addTemplate(window.marvinStructureTemplates[i]);
-						}
-					}
-					self.sketcherLoaded = true;
-				}, function (error) {
-					alert("Cannot retrieve newSaltMarvinSketch sketcher instance from iframe:" + error);
-				});
-
-			} else if (this.useKetcher) {
-				this.$('#newSaltMarvinSketch').attr('src',"/lib/ketcher-2.0.0-alpha.3_custom/ketcher.html?api_path=/api/cmpdReg/ketcher/");
-				this.$('#newSaltMarvinSketch').on('load', function () {
-					self.ketcher = self.$('#newSaltMarvinSketch')[0].contentWindow.ketcher;
-					self.sketcherLoaded = true;
-				});
-			} else if (this.useMaestro) {
-				this.$('#newSaltMarvinSketch').attr('src',"/CmpdReg/maestrosketcher/wasm_shell.html");
-                MaestroJSUtil.getSketcher('#newSaltMarvinSketch').then(function (maestro) {
-					self.maestro = maestro;
-					self.sketcherLoaded = true;
-				});
-			} else {
-				alert("No registration sketcher configured");
-			}
-
+			var sketcher = window.configuration.sketcher
+			this.chemicalStructureController = UtilityFunctions.prototype.getNewSystemChemicalSketcherController(sketcher)
+			this.$('.marvinWrapper').html(this.chemicalStructureController.render().el)
+			this.chemicalStructureController.bind('sketcherLoaded', function() {
+				self.sketcherLoaded = true;
+			});
 			this.hide();
 			return this;
 		},
 
 		show: function() {
-			if (this.useMarvin) {
-				this.marvinSketcherInstance.clear()
-			} else if (this.useKetcher) {
-				mol = this.ketcher.setMolecule("");
-			} else if (this.useMaestro) {
-				mol = this.maestro.clearSketcher()
-			}
+			this.chemicalStructureController.clear();
 			$(this.el).show();
 		},
 
@@ -227,7 +186,7 @@ $(function() {
 			this.hide();
 		},
 
-		saveSalt: function() {
+		saveSalt: async function() {
             this.trigger('clearErrors', "NewSaltController");
 
             var salt = new Salt();
@@ -238,14 +197,11 @@ $(function() {
 			if(this.sketcherLoaded) {
 				self.exportStructComplete = false;
 
-				var gotMol = function (molecule) {
-					//Maestro doesn't use the counts line so skip this check when useMaestro is true
-					if (!self.useMaestro && molecule.indexOf("0  0  0  0  0  0  0  0  0  0999") > -1)
-						mol = '';
-					else if (molecule.indexOf("M  V30 COUNTS 0 0 0 0 0") > -1)
-						mol = '';
-					else
-						mol = molecule;
+				var gotMol = function (mol) {
+					if(self.chemicalStructureController.isEmptyMol(mol)) {
+						mol = ''
+					}
+					
 					self.exportStructComplete = true; // for spec support
 
 					var saltSetSucceeded = salt.set({
@@ -284,24 +240,8 @@ $(function() {
 					}
 				}
 
-				if (this.useMarvin) {
-					this.marvinSketcherInstance.exportStructure(this.exportFormat).then(
-						gotMol,
-						function (error) {
-							alert("Molecule export failed from search sketcher:"+error);
-						}
-					);
-
-				} else if (this.useKetcher) {
-					mol = this.ketcher.getMolfile();
-					if (mol.indexOf("  0  0  0     1  0            999") > -1) mol = '';
-					gotMol(mol);
-				} else if (this.useMaestro) {
-					mol = this.maestro.sketcherExportMolBlock();
-					gotMol(mol);
-				} else {
-					alert("No new salt sketcher configured");
-				}
+				mol = await this.chemicalStructureController.getMol()
+				gotMol(mol);
 
 			}
 

--- a/modules/CmpdReg/src/client/templates/LotForm/NewSaltView.inc
+++ b/modules/CmpdReg/src/client/templates/LotForm/NewSaltView.inc
@@ -2,7 +2,6 @@
 	<h2 class="form_title">Register New Salt:</h2>
 	<hr>
 		<div class="marvinWrapper">
-			<iframe id="newSaltMarvinSketch" class="sketcher-frame"></iframe>
 		</div>
 		<div class="corpNameInput">
 		<label class="FormLabel">Salt Name </label>

--- a/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
+++ b/modules/CmpdReg/src/client/templates/LotForm/ParentView.inc
@@ -21,8 +21,7 @@
 		<div class="disableCmpdRegistrationMessage hide"></div>
 	</div>
 
-	<div class="marvinWrapper hide"> <!--dependent? change name...-->
-		<iframe src="/CmpdReg/marvinjs/editorws.html" id="editParentMarvinSketch" class="sketcher-frame"></iframe>
+	<div class="marvinWrapper hide">
 	</div>
 
   <div class="parentStructureForm">

--- a/modules/CmpdReg/src/client/templates/RegistrationSearchView.inc
+++ b/modules/CmpdReg/src/client/templates/RegistrationSearchView.inc
@@ -2,18 +2,17 @@
 
 	<h2 class="form_title">Registration Step 1: Draw Structure</h2>
 	
-		<div class="marvinWrapper"> <!--dependent? change name...-->
-			<iframe id="registrationSearchMarvinSketch" class="sketcher-frame"></iframe>
-		<div class="corpNameInput">
-			<label>Or enter compound ID </label>
-			<input type=text class="corpName" />
+		<div class="marvinWrapper"></div>
+		<div>
+			<div class="corpNameInput">
+				<label>Or enter compound ID </label>
+				<input type=text class="corpName" />
+			</div>	
+			<div class="buttons">
+				<a class="nextButton" href="#" onclick="this.blur(); return false;"><span></span></a>
+				<a class="cancelButton" href="#" onclick="this.blur(); return false;"><span></span></a>
 			</div>
 		</div>
-		
-	<div class="buttons">
-		<a class="nextButton" href="#" onclick="this.blur(); return false;"><span></span></a>
-		<a class="cancelButton" href="#" onclick="this.blur(); return false;"><span></span></a>
-	</div>
 	
 	<div class="registrationSearchMarvinSize"></div>
 

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -547,15 +547,9 @@ exports.regSearch = (req, resp) ->
 	)
 
 exports.getMarvinJSLicense = (req, resp) ->
-	fs = require 'fs'
 	cmpdRegCall = (config.all.client.service.cmpdReg.persistence.basepath).replace '\/acas', "/"
 	licensePath = cmpdRegCall + 'marvin4js-license.cxl'
-	licensePath = "http://localhost:3001/dataFiles/marvin4js-license.cxl"
-	stream = fs.createReadStream("/home/runner/build/privateUploads/marvin4js-license.cxl");
-	stream.pipe(resp);
-	# console.log licensePath
-
-	# Get the file from the license path
+	console.log licensePath
 	req.pipe(request(licensePath)).pipe(resp)
 
 exports.getMultipleFilePicker = (req, resp) ->

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -547,9 +547,15 @@ exports.regSearch = (req, resp) ->
 	)
 
 exports.getMarvinJSLicense = (req, resp) ->
+	fs = require 'fs'
 	cmpdRegCall = (config.all.client.service.cmpdReg.persistence.basepath).replace '\/acas', "/"
 	licensePath = cmpdRegCall + 'marvin4js-license.cxl'
-	console.log licensePath
+	licensePath = "http://localhost:3001/dataFiles/marvin4js-license.cxl"
+	stream = fs.createReadStream("/home/runner/build/privateUploads/marvin4js-license.cxl");
+	stream.pipe(resp);
+	# console.log licensePath
+
+	# Get the file from the license path
 	req.pipe(request(licensePath)).pipe(resp)
 
 exports.getMultipleFilePicker = (req, resp) ->

--- a/modules/Components/src/client/ACASFormChemicalStructure.coffee
+++ b/modules/Components/src/client/ACASFormChemicalStructure.coffee
@@ -94,10 +94,21 @@ class MaestroChemicalStructureController extends Backbone.View
 
 	getMol: ->
 		mol = await new Promise (resolve, reject) =>
-			resolve @maestro.sketcherExportMolBlock()
+			# To be backwards comatable we test for the presence of the new sketcher_export_text function
+			if @maestro.sketcher_export_text?
+				resolve @maestro.sketcher_export_text(@maestro.Format.MDL_MOLV3000)
+			else
+				# Older versions of maestro
+				resolve @maestro.sketcherExportMolBlock()
+		return mol
 
 	setMol: (molStr) ->
-		@maestro.sketcherImportText molStr
+			# To be backwards comatable we test for the presence of the new sketcher_import_text function
+		if @maestro.sketcher_import_text?
+			@maestro.sketcher_import_text(molStr)
+		else
+			# Older versions of maestro
+			@maestro.sketcherImportMolBlock(molStr)
 
 	clear: ->
 		@maestro.clearSketcher()

--- a/modules/Components/src/client/UtilityFunctions.coffee
+++ b/modules/Components/src/client/UtilityFunctions.coffee
@@ -129,3 +129,17 @@ class UtilityFunctions
 		document.body.appendChild a
 		a.click()
 		document.body.removeChild a
+
+	getNewSystemChemicalSketcherController: (sketcher) ->
+		# Chemical Structure Controller Set by Sketcher Config Setting 
+		chemicalStructureController = null
+		if sketcher == 'marvin'
+			chemicalStructureController = new MarvinJSChemicalStructureController
+		else if  sketcher  == 'ketcher'
+			chemicalStructureController = new KetcherChemicalStructureController 
+		else if sketcher == 'maestro'
+			chemicalStructureController = new MaestroChemicalStructureController
+		else 
+			console.log("No Chemical Sketcher Configured!")
+			alert("Please contact your ACAS System Admin. There is no chemical sketcher configured.")
+		return chemicalStructureController

--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -259,7 +259,7 @@ class SaltBrowserController extends Backbone.View
 		if (saltName == "" || saltName == null)
 			fieldsFilled = false
 
-		saltStruct = @chemicalStructureController.getMol()
+		saltStruct = await @chemicalStructureController.getMol()
 		if (@chemicalStructureController.isEmptyMol(saltStruct))
 			fieldsFilled = false
 		
@@ -368,7 +368,7 @@ class SaltBrowserController extends Backbone.View
 			fieldsFilled = false
 			console.log("Salt Name Was Empty! Cannot Register!")
 
-		saltStruct = @chemicalStructureController.getMol()
+		saltStruct = await @chemicalStructureController.getMol()
 		if (saltStruct == "" || saltStruct == null)
 			fieldsFilled = false
 			console.log("Salt Structure Was Empty! Cannot Register!")
@@ -515,7 +515,7 @@ class SaltBrowserController extends Backbone.View
 		@$('.bv_fieldNotifications').show()
 
 		# Get Mol
-		saltStruct = @chemicalStructureController.getMol()
+		saltStruct = await @chemicalStructureController.getMol()
 
 		if (@chemicalStructureController.isEmptyMol(saltStruct))
 			@editFieldNotificationController.clearAllNotificiations() 
@@ -610,7 +610,7 @@ class SaltBrowserController extends Backbone.View
 		@notificationController.clearAllNotificiations() 
 		
 		# Get Mol
-		saltStruct = @chemicalStructureController.getMol()
+		saltStruct = await @chemicalStructureController.getMol()
 
 		saltDict = 
 		{

--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -236,7 +236,7 @@ class SaltBrowserController extends Backbone.View
 		@$('.bv_createSalt').show()
 
 		# Chemical Structure Controller Set by Sketcher Config Setting 
- 		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
+		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
 		$('.bv_chemicalStructureForm').html @chemicalStructureController.render().el
 
 	handleConfirmCreateSaltClicked: =>
@@ -484,7 +484,7 @@ class SaltBrowserController extends Backbone.View
 		molStr = @saltController.model.get("molStructure")
 
 		# Chemical Structure Controller Set by Sketcher Config Setting 
- 		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
+		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
 
 		$('.bv_editChemicalStructureForm').html @chemicalStructureController.render().el
 		@chemicalStructureController.on('sketcherLoaded', =>

--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -236,16 +236,7 @@ class SaltBrowserController extends Backbone.View
 		@$('.bv_createSalt').show()
 
 		# Chemical Structure Controller Set by Sketcher Config Setting 
-		@chemicalStructureController = null
-		if window.conf.cmpdreg.sketcher == 'marvin'
-			@chemicalStructureController = new MarvinJSChemicalStructureController
-		else if  window.conf.cmpdreg.sketcher  == 'ketcher'
-			@chemicalStructureController = new KetcherChemicalStructureController 
-		else if window.conf.cmpdreg.sketcher == 'maestro'
-			@chemicalStructureController = new MaestroChemicalStructureController
-		else 
-			console.log("No Chemical Sketcher Configured!")
-			alert("Please contact your ACAS System Admin. There is no chemical sketcher configured.")
+ 		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
 		$('.bv_chemicalStructureForm').html @chemicalStructureController.render().el
 
 	handleConfirmCreateSaltClicked: =>
@@ -493,16 +484,7 @@ class SaltBrowserController extends Backbone.View
 		molStr = @saltController.model.get("molStructure")
 
 		# Chemical Structure Controller Set by Sketcher Config Setting 
-		@chemicalStructureController = null
-		if window.conf.cmpdreg.sketcher == 'marvin'
-			@chemicalStructureController = new MarvinJSChemicalStructureController
-		else if  window.conf.cmpdreg.sketcher  == 'ketcher'
-			@chemicalStructureController = new KetcherChemicalStructureController 
-		else if window.conf.cmpdreg.sketcher == 'maestro'
-			@chemicalStructureController = new MaestroChemicalStructureController
-		else 
-			console.log("No Chemical Sketcher Configured!")
-			alert("Please contact your ACAS System Admin. There is no chemical sketcher configured.")
+ 		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
 
 		$('.bv_editChemicalStructureForm').html @chemicalStructureController.render().el
 		@chemicalStructureController.on('sketcherLoaded', =>

--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -236,7 +236,7 @@ class SaltBrowserController extends Backbone.View
 		@$('.bv_createSalt').show()
 
 		# Chemical Structure Controller Set by Sketcher Config Setting 
-		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
+		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.conf.cmpdreg.sketcher)
 		$('.bv_chemicalStructureForm').html @chemicalStructureController.render().el
 
 	handleConfirmCreateSaltClicked: =>
@@ -484,7 +484,7 @@ class SaltBrowserController extends Backbone.View
 		molStr = @saltController.model.get("molStructure")
 
 		# Chemical Structure Controller Set by Sketcher Config Setting 
-		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.configuration.sketcher)
+		@chemicalStructureController = UtilityFunctions::getNewSystemChemicalSketcherController(window.conf.cmpdreg.sketcher)
 
 		$('.bv_editChemicalStructureForm').html @chemicalStructureController.render().el
 		@chemicalStructureController.on('sketcherLoaded', =>


### PR DESCRIPTION
## Description
 - To be reviewed after https://github.com/mcneilco/acas/pull/1019
 - Updates the maestro sketcher usage to handle newer versions of maestro sketcher
    - sketcherImportText became sketcher_import_text
    - sketcherExportText became sketcher_export_text
    - sketcher_export_text takes an additional parameter to export a mol

## Related Issue
ACAS-469

## How Has This Been Tested?
Ran through compound registration, search, edit parent and salt creation workflow in creg
Ran through salt browser editing and creation