### PR TITLE
ACAS-482 fixing registerdBy ACLS permissions

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -486,13 +486,13 @@ exports.getLotAcls = (lot, user, allowedProjects, checkDelete=true) ->
 			lotAcls.setWrite(false)
 		else
 			# If the user is not a cmpd reg admin, then they can only write the lot if disableEditMyLots is false
-			# and they are either the chemist or the lot recordedBy
+			# and they are either the chemist or the lot registerdBy
 			if config.all.client.cmpdreg.metaLot.disableEditMyLots == false
-				canWrite = (lot.chemist? && lot.chemist == user.username) || (lot.recordedBy? && lot.recordedBy == user.username)
+				canWrite = (lot.chemist? && lot.chemist == user.username) || (lot.registerdBy? && lot.registerdBy == user.username)
 				if canWrite
 					lotAcls.setWrite(true)
 				else
-					console.log "User #{user.username} does not have permission to edit lot #{lot.corpName} which is not their lot (recordedBy: #{lot.recordedBy}, chemist: #{lot.chemist})"
+					console.log "User #{user.username} does not have permission to edit lot #{lot.corpName} which is not their lot (registerdBy: #{lot.registerdBy}, chemist: #{lot.chemist})"
 					lotAcls.setWrite(false)
 
 	if lotAcls.getRead() && lotAcls.getWrite() && checkDelete


### PR DESCRIPTION
## Description
Get lot ACLs is currently broken for registeredBy users.  Instead of checking for registedBy, we are checking for a non-existent recordedBy attribute.  This causes users who registered a lot but aren't cmpdreg admins, or the "chemist" of the lot to be able to edit their own lots.

## Related Issue
ACAS-482

## How Has This Been Tested?
Configured a lot and permissions such that I reproduced the bug and could not edit a lot that was registeredBy me.
Updated the code and refreshed the page and verified I could not edit the lot.
Switched the registedBy user to another user and verified I could no longer edit the lot. (negative case test).