### PR TITLE
Fix Via Revert - CmpdReg Salts: Can't Download SDF

### DIFF
--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -406,7 +406,7 @@ class SaltBrowserController extends Backbone.View
 		# Calls Custom Route to Download SDF of All Salts Registered 
 		$.ajax(
 				type: 'GET'
-				url: "/cmpdReg/salts/sdf" 
+				url: "/api/cmpdRegAdmin/salts/sdf" 
 				success: (salts) =>
 					# Server should've returned salts in correct formatting
 					@downloadSDF("allSalts.sdf", salts)


### PR DESCRIPTION
**Steps to Reproduce:**

Log in to ACAS with CmpdRe user/admin credentials
Open "CmpdReg Salts" >> Click "Download All Salts SDF" button given above the Salts table

**Fix Results:**

Saved salts are downloaded in SDF format

**Previous Results:**

SDF file is not getting downloaded
Browser console shows 404 status