### PR TITLE
ACAS-488: Allow user to limit by max results input

### DIFF
--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -53,7 +53,6 @@ class DownloadDryResultsController extends Backbone.View
 		@$('.bv_download').addClass("disabled")
 		url = "/cmpdReg/standardizationDryRunSearchExport"
 		modelData = @options.searchModel.toJSON()
-		delete modelData.maxResults
 		fileName = "download.sdf"
 		fetch(url, {
 			method: 'POST'


### PR DESCRIPTION
## Description
 - Allow the user to limit the download sdf results by passing the max results input to the service

## Related Issue
ACAS-488

## How Has This Been Tested?
Clicked download and verified the results were limited
Removed the input and verified that the results were not limited by max results