### PR TITLE
ACAS-486: Standardization dry run UI change to go with service changes

### DIFF
--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -246,14 +246,14 @@ class StandardizationDryRunReportRowSummaryController extends Backbone.View
 
 	render: =>
 		toDisplay =
-			corpName: @model.get('corpName')
+			corpName: @model.get('parent').corpName
 			changedStructure: @model.get('changedStructure')
 			displayChange: @model.get('displayChange')
 			newDuplicates: @model.get('newDuplicates')
 			existingDuplicates: @model.get('existingDuplicates')
-			deltaMolWeight: @roundToTwo(@model.get('newMolWeight')- @model.get('oldMolWeight'))
+			deltaMolWeight: @roundToTwo(@model.get('deltaMolWeight'))
 			newMolWeight: @model.get('newMolWeight')
-			oldMolWeight: @model.get('oldMolWeight')
+			oldMolWeight: @model.get('parent').molWeight
 			asDrawnDisplayChange: @model.get('asDrawnDisplayChange')
 			standardizationStatus: @model.get('standardizationStatus')
 			standardizationComment: @model.get('standardizationComment')


### PR DESCRIPTION
## Description
 - Changes to the UI to match the service changes.
    -  Parent is now added to the response json with corpName and molWeight as attributes instead of being top level
 - Use delta mol weight calculated by the server to keep logic in one place

Changes. to be merged in only when closing ACAS-480-epic branch.

## Related Issue
ACAS-486

## How Has This Been Tested?
Ran queries and made sure UI looked correct for delta mol weight, old mol weight and corp name fields and that structures rendered in the UI (as they use the corp name returned to fetch images).