### PR TITLE
ACAS-387: Add reasons for standardization needed

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -745,6 +745,8 @@ client.cmpdreg.marvin.sketchBondLength=20
 client.cmpdreg.marvin.delayShowStep2Next=750
 client.cmpdreg.marvin.exportFormat=mol:V3
 client.cmpdreg.serverSettings.liveDesign.preprocessorSettings=
+client.cmpdreg.serverSettings.liveDesign.url=http://localhost:8010/ld-chem
+
 client.cmpdreg.serverSettings.maxStandardizationDisplay=20000
 
 

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -1138,11 +1138,18 @@ exports.allowCmpdRegistration = (req, resp) ->
 					message: "Compounds can not be registered at this time due to an error getting current standardization settings. Please contact an administrator for help."
 				resp.json response
 			else
-				allowCmpdRegistration = !getStandardizationSettingsResp.needsStandardization
+				allowCmpdRegistration = !getStandardizationSettingsResp.needsStandardization && !getStandardizationSettingsResp.valid
 				if allowCmpdRegistration
 					message = "Compounds can be registered"
 				else
-					message = "Compounds can not be registered at this time because the registered compounds require standardization."
+					message = "Compounds can not be registered at this time because "
+					reasons = []
+					if !getStandardizationSettingsResp.valid
+						reasons.push "the standardization settings are invalid"
+					if getStandardizationSettingsResp.needsStandardization
+						reasons.push "the registed compounds require standardization"
+					message += reasons.join(" and ")
+					message += ". Please contact an administrator for help."
 				response =
 					allowCmpdRegistration: allowCmpdRegistration
 					message: message

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -1138,7 +1138,7 @@ exports.allowCmpdRegistration = (req, resp) ->
 					message: "Compounds can not be registered at this time due to an error getting current standardization settings. Please contact an administrator for help."
 				resp.json response
 			else
-				allowCmpdRegistration = !getStandardizationSettingsResp.needsStandardization && !getStandardizationSettingsResp.valid
+				allowCmpdRegistration = !getStandardizationSettingsResp.needsStandardization && getStandardizationSettingsResp.valid
 				if allowCmpdRegistration
 					message = "Compounds can be registered"
 				else
@@ -1147,7 +1147,7 @@ exports.allowCmpdRegistration = (req, resp) ->
 					if !getStandardizationSettingsResp.valid
 						reasons.push "the standardization settings are invalid"
 					if getStandardizationSettingsResp.needsStandardization
-						reasons.push "the registed compounds require standardization"
+						reasons.push "the registered compounds require standardization"
 					message += reasons.join(" and ")
 					message += ". Please contact an administrator for help."
 				response =

--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -711,6 +711,8 @@ class StandardizationController extends Backbone.View
 				@$('.bv_getStandardizationHistoryError').show()
 
 	isDryRunOrStandardizationInProgress: (mostRecentHistoryEntry) ->
+		if !mostRecentHistoryEntry?
+			return false
 		dryRunStatus = mostRecentHistoryEntry.dryRunStatus
 		standardizationStatus = mostRecentHistoryEntry.standardizationStatus
 		if dryRunStatus is 'running'
@@ -734,20 +736,20 @@ class StandardizationController extends Backbone.View
 		@$(".bv_standardizationHistory").html @standardizationHistorySummaryTableController.render().el
 
 	setupExecuteButtons: (mostRecentHistory) ->
-		dryRunStatus = mostRecentHistory.dryRunStatus
-		standardizationStatus = mostRecentHistory.standardizationStatus
-		#Execution Dry-run Disabled when most recent history dryRunStatus is running or standardizationStatus running
-		if dryRunStatus is "running" or standardizationStatus is "running"
-			@$('.bv_executeDryRun').attr 'disabled', 'disabled'
-		#Execute Standardization Disabled when most recent history dryRunStatus != "complete" or standardizationStatus == "running" or standardization == "complete"
-		if dryRunStatus != 'complete' or standardizationStatus is 'running' or standardizationStatus is 'complete'
+		if mostRecentHistory?
+			dryRunStatus = mostRecentHistory.dryRunStatus
+			standardizationStatus = mostRecentHistory.standardizationStatus
+			#Execution Dry-run Disabled when most recent history dryRunStatus is running or standardizationStatus running
+			if dryRunStatus is "running" or standardizationStatus is "running"
+				@$('.bv_executeDryRun').attr 'disabled', 'disabled'
+			#Execute Standardization Disabled when most recent history dryRunStatus != "complete" or standardizationStatus == "running" or standardization == "complete"
+			if dryRunStatus != 'complete' or standardizationStatus is 'running' or standardizationStatus is 'complete'
+				@$('.bv_executeStandardization').attr 'disabled', 'disabled'
+		else
 			@$('.bv_executeStandardization').attr 'disabled', 'disabled'
 
-
 	setupLastDryRunReportSummary: (mostRecentHistory)->		
-		standardizationStatus = mostRecentHistory.standardizationStatus
-		dryRunStatus = mostRecentHistory.dryRunStatus
-		if dryRunStatus == "complete" and standardizationStatus != "complete"
+		if mostRecentHistory? and mostRecentHistory.dryRunStatus == "complete" and mostRecentHistory.standardizationStatus != "complete"
 			@setupLastDryRunReportStatsSummaryTable()
 			@$(".bv_standardizationDryRunReportStats").show()
 			@standardizationDryRunReportSummaryController = new StandardizationDryRunReportSummaryController
@@ -820,7 +822,6 @@ class StandardizationReasonPanelController extends Backbone.View
 		@trigger 'readyForExecution', @$('.bv_reasonForStandardization')[0].value
 
 	handleCancelClicked: =>
-		console.log 'hiasdf'
 		@$('.bv_standardizationReasonPanel').modal "hide"
 		@trigger 'executionCancelled'
 

--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -19,14 +19,28 @@ class StandardizationCurrentSettingsController extends Backbone.View
 				@$('.bv_getCurrentSettingsError').show()
 
 	setupCurrentSettingsTable: (settings) ->
-		if settings.reasons?
-			reasons = settings.reasons.replace(/(?:\r\n|\r|\n)/g, '<br>')
+		if settings.reasons? && settings.reasons != ""
+			# Convert new line seperated string into ul list
+			reasonsHtml = settings.reasons.replace(/\n/g, "</li><li>")
+			reasonsHtml = "<ul><li>" + reasonsHtml + "</li></ul>"
+			reasons = settings.reasons
 		else
+			reasonsHtml = null
 			reasons = null
+		if settings.suggestedConfigurationChanges? && settings.suggestedConfigurationChanges != ""
+			msg = "Your standardizer settings are incomplete and have been automatically interpreted.<br>Please update your standardizer configuration with the following to avoid ambiguity:"
+			suggestedConfigurationChangesHtml = settings.suggestedConfigurationChanges.replace(/\n/g, "</li><li>")
+			suggestedConfigurationChangesHtml = "<ul><li>" + suggestedConfigurationChangesHtml + "</li></ul>"
+			suggestedConfigurationChangesHtml = "<b>#{msg}</b><br>#{suggestedConfigurationChangesHtml}"
+			suggestedConfigurationChanges = settings.suggestedConfigurationChanges
+		else
+			suggestedConfigurationChangesHtml = null
+			suggestedConfigurationChanges = null
 		@$('.bv_currentSettingsTable').dataTable
 			"aaData": [
 				[ "Needs standardization", settings.needsStandardization],
-				[ "Reasons", reasons],
+				[ "Reasons for standardization", reasonsHtml],
+				[ "Suggested configuration changes", suggestedConfigurationChangesHtml],
 				[ "Time modified", UtilityFunctions::convertMSToYMDTimeDate(settings.modifiedDate, "12hr")]
 			]
 			"aoColumns": [

--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -20,38 +20,38 @@ class StandardizationCurrentSettingsController extends Backbone.View
 
 	setupCurrentSettingsTable: (settings) ->
 
-		if settings.invalidReasons? && settings.invalidReasons != ""
-			# Convert new line seperated string into ul list
-			invalidReasonsHtml = settings.invalidReasons.replace(/\n/g, "</li><li>")
-			invalidReasonsHtml = "<ul><li>" + invalidReasonsHtml + "</li></ul>"
-		else
-			invalidReasonsHtml = null
+		invalidReasonsHtml = ""
+		if settings.invalidReasons? && settings.invalidReasons.length > 0
+			# Convert array to a ul li list
+			invalidReasonsHtml = "<ul>"
+			for reason in settings.invalidReasons
+				invalidReasonsHtml += "<li>" + reason + "</li>"
+			invalidReasonsHtml += "</ul>"
 
-		if settings.needsRestandardizationReasons? && settings.needsRestandardizationReasons != ""
-			# Convert new line seperated string into ul list
-			needsRestandardizationReasonsHtml = settings.needsRestandardizationReasons.replace(/\n/g, "</li><li>")
-			needsRestandardizationReasonsHtml = "<ul><li>" + needsRestandardizationReasonsHtml + "</li></ul>"
-			needsStandardizationReasons = settings.needsRestandardizationReasons
-		else
-			needsRestandardizationReasonsHtml = null
-			needsStandardizationReasons = null
+		needsRestandardizationReasonsHtml = ""
+		if settings.needsRestandardizationReasons? && settings.needsRestandardizationReasons.length > 0
+			# Convert array to a ul li list
+			needsRestandardizationReasonsHtml = "<ul>"
+			for reason in settings.needsRestandardizationReasons
+				needsRestandardizationReasonsHtml += "<li>" + reason + "</li>"
+			needsRestandardizationReasonsHtml += "</ul>"
 
+		suggestedConfigurationChangesHtml = ""
 		if settings.suggestedConfigurationChanges? && settings.suggestedConfigurationChanges != ""
-			msg = "Your standardizer settings are incomplete and have been automatically interpreted.<br>Please update your standardizer configuration with the following to avoid ambiguity:"
-			suggestedConfigurationChangesHtml = settings.suggestedConfigurationChanges.replace(/\n/g, "</li><li>")
-			suggestedConfigurationChangesHtml = "<ul><li>" + suggestedConfigurationChangesHtml + "</li></ul>"
-			suggestedConfigurationChangesHtml = "<b>#{msg}</b><br>#{suggestedConfigurationChangesHtml}"
-		else
-			suggestedConfigurationChangesHtml = null
+			# Convert array to a ul li list
+			suggestedConfigurationChangesHtml = "<ul>"
+			for reason in settings.suggestedConfigurationChanges
+				suggestedConfigurationChangesHtml += "<li>" + reason + "</li>"
+			suggestedConfigurationChangesHtml += "</ul>"
 
 
 		settingsTableData = [[ "Settings valid", settings.valid]]
 		if !settings.valid
 			# Only show invalid reasons if the settings are not valid
 			settingsTableData.push [ "Settings invalid reasons", invalidReasonsHtml]
-		settingsTableData.push [ "Needs standardization", settings.needsStandardization]
-		if settings.needsStandardization
-			# Only show reasons for needing standardization if the needsStandardization is true
+		settingsTableData.push [ "Needs standardization", settings.needsRestandardization]
+		if settings.needsRestandardization
+			# Only show reasons for needing standardization if the needsRestandardization is true
 			settingsTableData.push [ "Reasons for needing standardization", needsRestandardizationReasonsHtml]
 		if settings.valid && settings.suggestedConfigurationChangesHtml != null
 			# Only show suggestions for config changes if the settings are valid

--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -19,19 +19,25 @@ class StandardizationCurrentSettingsController extends Backbone.View
 				@$('.bv_getCurrentSettingsError').show()
 
 	setupCurrentSettingsTable: (settings) ->
+		if settings.reasons?
+			reasons = settings.reasons.replace(/(?:\r\n|\r|\n)/g, '<br>')
+		else
+			reasons = null
 		@$('.bv_currentSettingsTable').dataTable
 			"aaData": [
 				[ "Needs standardization", settings.needsStandardization],
+				[ "Reasons", reasons],
 				[ "Time modified", UtilityFunctions::convertMSToYMDTimeDate(settings.modifiedDate, "12hr")]
 			]
 			"aoColumns": [
-				{ "sTitle": "Name" },
-				{ "sTitle": "Value" }
+				{ "sTitle": "Name", "sWidth": "20%" },
+				{ "sTitle": "Value",  "sWidth": "80%" }
 			]
 			bFilter: false
 			bInfo: false
 			bPaginate: false
 			bSort: false
+		@trigger 'ready', reasons
 
 class DownloadDryResultsController extends Backbone.View
 	template: _.template($("#DownloadDryRunResultsView").html())
@@ -682,6 +688,10 @@ class StandardizationController extends Backbone.View
 			@currentSettingsController.undelegateEvents()
 		@currentSettingsController = new StandardizationCurrentSettingsController
 			el: @$('.bv_currentSettings')
+		@currentSettingsController.on 'ready', @setDefaultReasons.bind(@)
+
+	setDefaultReasons : (reasons) =>
+		@standardizationReasonPanel.setDefaultReasons reasons
 
 	getStandardizationHistory: ->
 		$.ajax
@@ -814,3 +824,8 @@ class StandardizationReasonPanelController extends Backbone.View
 		@$('.bv_standardizationReasonPanel').modal "hide"
 		@trigger 'executionCancelled'
 
+	setDefaultReasons: (reasons) =>
+		# Set the reason in the text area bv_reasonForStandardization
+		if reasons? and reasons.length > 0
+			@$('.bv_reasonForStandardization')[0].value = reasons
+			@handleReasonChanged()

--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -43,16 +43,22 @@ class StandardizationCurrentSettingsController extends Backbone.View
 			suggestedConfigurationChangesHtml = "<b>#{msg}</b><br>#{suggestedConfigurationChangesHtml}"
 		else
 			suggestedConfigurationChangesHtml = null
+
+
+		settingsTableData = [[ "Settings valid", settings.valid]]
+		if !settings.valid
+			# Only show invalid reasons if the settings are not valid
+			settingsTableData.push [ "Settings invalid reasons", invalidReasonsHtml]
+		settingsTableData.push [ "Needs standardization", settings.needsStandardization]
+		if settings.needsStandardization
+			# Only show reasons for needing standardization if the needsStandardization is true
+			settingsTableData.push [ "Reasons for needing standardization", needsRestandardizationReasonsHtml]
+		if settings.valid && settings.suggestedConfigurationChangesHtml != null
+			# Only show suggestions for config changes if the settings are valid
+			settingsTableData.push [ "Suggested configuration changes", suggestedConfigurationChangesHtml]
 	
 		@$('.bv_currentSettingsTable').dataTable
-			"aaData": [
-				[ "Settings valid", settings.valid],
-				[ "Settings invalid reasons", invalidReasonsHtml],
-				[ "Needs standardization", settings.needsStandardization],
-				[ "Reasons for needing standardization", needsRestandardizationReasonsHtml],
-				[ "Suggested configuration changes", suggestedConfigurationChangesHtml],
-				[ "Time modified", UtilityFunctions::convertMSToYMDTimeDate(settings.modifiedDate, "12hr")]
-			]
+			"aaData": settingsTableData
 			"aoColumns": [
 				{ "sTitle": "Name", "sWidth": "20%" },
 				{ "sTitle": "Value",  "sWidth": "80%" }

--- a/modules/Standardization/src/client/Standardization.coffee
+++ b/modules/Standardization/src/client/Standardization.coffee
@@ -19,27 +19,37 @@ class StandardizationCurrentSettingsController extends Backbone.View
 				@$('.bv_getCurrentSettingsError').show()
 
 	setupCurrentSettingsTable: (settings) ->
-		if settings.reasons? && settings.reasons != ""
+
+		if settings.invalidReasons? && settings.invalidReasons != ""
 			# Convert new line seperated string into ul list
-			reasonsHtml = settings.reasons.replace(/\n/g, "</li><li>")
-			reasonsHtml = "<ul><li>" + reasonsHtml + "</li></ul>"
-			reasons = settings.reasons
+			invalidReasonsHtml = settings.invalidReasons.replace(/\n/g, "</li><li>")
+			invalidReasonsHtml = "<ul><li>" + invalidReasonsHtml + "</li></ul>"
 		else
-			reasonsHtml = null
-			reasons = null
+			invalidReasonsHtml = null
+
+		if settings.needsRestandardizationReasons? && settings.needsRestandardizationReasons != ""
+			# Convert new line seperated string into ul list
+			needsRestandardizationReasonsHtml = settings.needsRestandardizationReasons.replace(/\n/g, "</li><li>")
+			needsRestandardizationReasonsHtml = "<ul><li>" + needsRestandardizationReasonsHtml + "</li></ul>"
+			needsStandardizationReasons = settings.needsRestandardizationReasons
+		else
+			needsRestandardizationReasonsHtml = null
+			needsStandardizationReasons = null
+
 		if settings.suggestedConfigurationChanges? && settings.suggestedConfigurationChanges != ""
 			msg = "Your standardizer settings are incomplete and have been automatically interpreted.<br>Please update your standardizer configuration with the following to avoid ambiguity:"
 			suggestedConfigurationChangesHtml = settings.suggestedConfigurationChanges.replace(/\n/g, "</li><li>")
 			suggestedConfigurationChangesHtml = "<ul><li>" + suggestedConfigurationChangesHtml + "</li></ul>"
 			suggestedConfigurationChangesHtml = "<b>#{msg}</b><br>#{suggestedConfigurationChangesHtml}"
-			suggestedConfigurationChanges = settings.suggestedConfigurationChanges
 		else
 			suggestedConfigurationChangesHtml = null
-			suggestedConfigurationChanges = null
+	
 		@$('.bv_currentSettingsTable').dataTable
 			"aaData": [
+				[ "Settings Valid", settings.valid],
+				[ "Settings Invalid Reasons", invalidReasonsHtml],
 				[ "Needs standardization", settings.needsStandardization],
-				[ "Reasons for standardization", reasonsHtml],
+				[ "Reasons for needing standardization", needsRestandardizationReasonsHtml],
 				[ "Suggested configuration changes", suggestedConfigurationChangesHtml],
 				[ "Time modified", UtilityFunctions::convertMSToYMDTimeDate(settings.modifiedDate, "12hr")]
 			]

--- a/modules/Standardization/src/client/Standardization.html
+++ b/modules/Standardization/src/client/Standardization.html
@@ -85,7 +85,7 @@
 
 <script type="text/template" id="StandardizationCurrentSettingsView" xmlns="http://www.w3.org/1999/html">
     <h4>Current Settings</h4>
-    <table class="table table-bordered table-striped table-hover bv_currentSettingsTable" style="margin: 0px; width: 400px; ">
+    <table class="table table-bordered table-striped table-hover bv_currentSettingsTable" style="margin: 0px; ">
     </table>
     <div class="alert bv_getCurrentSettingsError">
         There was an error getting the current standardization settings. Please contact an administrator.
@@ -531,12 +531,13 @@
 </script>
 
 <script type="text/template" id="StandardizationReasonPanelView" xmlns="http://www.w3.org/1999/html">
-    <div class="modal bv_standardizationReasonPanel hide">
+    <div class="modal bv_standardizationReasonPanel hide" style="width:900px";>
         <div class="modal-header">
             <h4>Standardization Reason</h4>
         </div>
         <div class="controls modal-body">
-            Reason for standardization: <textarea rows="2" class="bv_reasonForStandardization" style="width:500px;height:140px;" placeholder=""></textarea>
+            <label>Reason for standardization:</label>
+            <textarea rows="2" class="bv_reasonForStandardization" style="width:800px;height:140px;" placeholder=""></textarea>
 
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Description

For cmpd reg standardization
 - Add Settings Valid true/false to Current Settings panel
 - Add Settings Invalid Reasons list to Current Settings panel
 - Add Needs standardization true/false to Current Settings panel
 - Add Reasons for needing standardization to Current Settings panel
 - Add Suggested configuration changes to Current Settings panel
 - Updated message in Creg and bulk Loader to reflect the invalid settings and needs standardization state
 
## Related Issue
ACAS-387

## How Has This Been Tested?
**Changed the standardization settings to be in an invalid state and changed the hash scheme to make it so it required restandardization.**

**Verified the CmpdReg standardization module showed the appropriate messages and the the dry run  was disabled:**
![Screen Shot 2022-10-27 at 6 36 14 PM](https://user-images.githubusercontent.com/868119/198443146-92dfb741-83d8-40bf-9bc3-0bdbd5dd3c3b.png)

**Verified both creg and bulk load displayed the appropriate message:**
![Screen Shot 2022-10-27 at 1 34 26 PM](https://user-images.githubusercontent.com/868119/198392853-e1d291fa-3ae6-49fc-84fe-e2ab340e00d4.png)

![Screen Shot 2022-10-27 at 1 34 35 PM](https://user-images.githubusercontent.com/868119/198392878-5fe2448c-8f2e-42ec-ab07-71e5401a3bed.png)

**Removed just the invalid setting and verified the CmpdReg standardization module showed the appropriate messages:**
![Screen Shot 2022-10-27 at 1 45 36 PM](https://user-images.githubusercontent.com/868119/198394431-385d9d20-5368-470c-b74b-4d5fe314e73b.png)

**Verified both creg and bulk load displayed the appropriate message:**
![Screen Shot 2022-10-27 at 1 46 06 PM](https://user-images.githubusercontent.com/868119/198394559-3c9ed6ab-fd73-48f0-be93-471b983cdbc9.png)

![Screen Shot 2022-10-27 at 1 46 35 PM](https://user-images.githubusercontent.com/868119/198394607-6d1f705d-802d-4961-9a0e-5eff47e99cbb.png)

**Set the hash scheme back to original setting and verified the appropriate messages:**

![Screen Shot 2022-10-27 at 1 48 53 PM](https://user-images.githubusercontent.com/868119/198394996-140b9c3a-3856-4b0e-8eb6-7ba1cd158daf.png)


![Screen Shot 2022-10-27 at 1 50 44 PM](https://user-images.githubusercontent.com/868119/198395348-8246f4f1-b961-4fa6-842b-f02b490e6e82.png)

![Screen Shot 2022-10-27 at 1 50 51 PM](https://user-images.githubusercontent.com/868119/198395393-c2eb9b34-9364-440e-acfb-02baaa5ff2c6.png)
