### PR TITLE
Fix backwards compability with older maestro sketcher versions which used sketcherExportMolBlock

### DIFF
--- a/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
+++ b/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
@@ -6,7 +6,7 @@ $(function() {
             function waitForReady (resolve, reject) {
                 var _a;
                 maestro = $(el)[0].contentWindow.Module;
-                const sketcherImportText = (_a = this.maestro) === null || _a === void 0 ? void 0 : (_a.sketcher_import_text || _a.sketcherExportMolBlock);
+                const sketcherImportText = (_a = this.maestro) === null || _a === void 0 ? void 0 : (_a.sketcher_import_text || _a.sketcherImportText);
                 // Wait until sketcher is initialized
                 if (!sketcherImportText) {
                     self = this;

--- a/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
+++ b/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
@@ -6,7 +6,7 @@ $(function() {
             function waitForReady (resolve, reject) {
                 var _a;
                 maestro = $(el)[0].contentWindow.Module;
-                const sketcherImportText = (_a = this.maestro) === null || _a === void 0 ? void 0 : _a.sketcher_import_text;
+                const sketcherImportText = (_a = this.maestro) === null || _a === void 0 ? void 0 : (_a.sketcher_import_text || _a.sketcherExportMolBlock);
                 // Wait until sketcher is initialized
                 if (!sketcherImportText) {
                     self = this;

--- a/modules/Components/src/client/ACASFormChemicalStructure.coffee
+++ b/modules/Components/src/client/ACASFormChemicalStructure.coffee
@@ -108,7 +108,7 @@ class MaestroChemicalStructureController extends Backbone.View
 			@maestro.sketcher_import_text(molStr)
 		else
 			# Older versions of maestro
-			@maestro.sketcherImportMolBlock(molStr)
+			@maestro.sketcherImportText(molStr)
 
 	clear: ->
 		@maestro.clearSketcher()


### PR DESCRIPTION
## Description
  - MaestroJSUtil was missing a check for the older `sketcherExportMolBlock` to be backwards compatible with older maestro sketchers

## Related Issue
ACAS-469

## How Has This Been Tested?
Updated a server running older maestro sketcher and verified the sketcher loaded.