### PR TITLE
ACAS-498: Add Writeup field to CReg analytical files

### DIFF
--- a/modules/CmpdReg/src/client/MultipleFilePicker/css/style_nocompile.css
+++ b/modules/CmpdReg/src/client/MultipleFilePicker/css/style_nocompile.css
@@ -9,7 +9,7 @@ body {
 
 div#upload-app {
     /* ORIGINAL WIDTH width: 510px;*/
-    width: 625px;
+    width: 825px;
 
     position: fixed;
     bottom: 60px; important!
@@ -45,7 +45,7 @@ span.drop-text {
 }
 #drop-view {
     /* ORIGINAL WIDTH width: 500px;*/
-    width: 615px;
+    width: 815px;
     height: 200px;
     overflow: auto;
 }
@@ -57,6 +57,10 @@ div.hover {
 }
 .fileTable .description {
     width: 90px;
+}
+.fileTable .writeup {
+    width: 200px;
+    height: 50px;
 }
 .notuploaded {
     color: #ffcccc;
@@ -82,10 +86,14 @@ select.ie-description {
 
 }
 .fileInputTable .fileInput {
-    width: 364px;
+    width: 353px;
 }
 .fileInputTable .fileType {
-    width: 185px;
+    width: 184px;
+}
+.fileInputTable .writeup {
+    width: 200px;
+    height: 50px;
 }
 .fileInputTable .cancel {
     /*    width: 110px;*/
@@ -147,7 +155,10 @@ input.cancelBtn.btn, input.reset.btn, input.upload.btn {
     width: 100px;
 }
 .statusHead {
-    width: 70px;
+    width: 80px;
+}
+.writeupHead {
+    width: 200px;
 }
 .removeHead {
     width: 40px;

--- a/modules/CmpdReg/src/client/MultipleFilePicker/javascript/src/file.js
+++ b/modules/CmpdReg/src/client/MultipleFilePicker/javascript/src/file.js
@@ -26,6 +26,7 @@ $(function () {
                 this.set({name: file.name});
                 this.set({size: file.size});
                 this.set({type: file.type});
+                this.set({writeup: file.writeup})
                 this.set({file: file});
                 this.set({url: ''});
 
@@ -356,7 +357,7 @@ $(function () {
                 if(false){
                     this.$('form .fileInputTable').append('<tr class="fileInputRow"><td class="fileInput"><input type="file" class="file-upload" name="file[]"/></td><td class="fileType"><select class="ie-description" name="description[]"></select></td><td></td></tr>');
                 } else {
-                    this.$('form .fileInputTable').append('<tr class="fileInputRow"><td class="fileInput"><input type="file" class="file-upload" name="file[]"/></td><td class="fileType"><select class="ie-description" name="description[]"></select></td><td class="cancel">cancel</td></tr>');
+                    this.$('form .fileInputTable').append('<tr class="fileInputRow"><td class="fileInput"><input type="file" class="file-upload" name="file[]"/></td><td class="fileType"><select class="ie-description" name="description[]"></select></td><td class="writeupWrapper"><textarea class="writeup" name="writeup[]"/></td><td class="cancel">cancel</td></tr>');
                 }
                 var desController = this.setupCodeController(this.$('.ie-description:last'), 'fileTypes', 'description');
             }

--- a/modules/CmpdReg/src/client/MultipleFilePicker/templates/DropView.inc
+++ b/modules/CmpdReg/src/client/MultipleFilePicker/templates/DropView.inc
@@ -6,6 +6,7 @@
 			<td class="fileSizeHead">File Size</td>
 			<td class="descriptionHead">File Type</td>
 			<td class="statusHead">Status</td>
+			<td class="writeupHead">Writeup</td>
 			<td class="removeHead">Remove</td>
 		</tr>
 	</table>

--- a/modules/CmpdReg/src/client/MultipleFilePicker/templates/jspVersion/file_template_desc_jsp.inc
+++ b/modules/CmpdReg/src/client/MultipleFilePicker/templates/jspVersion/file_template_desc_jsp.inc
@@ -3,5 +3,6 @@
 		<td class="size"><%= size %> bytes</td>
 		<td><select class="description" ></select></td>
 		<td class="<%= uploaded ? '' : 'not' %>uploaded"><%= uploaded ? '' : 'not ' %>uploaded</td>
+		<td><textarea disabled class="writeup" ><%= writeup %></textarea></td>
 		<td><input type="button" class="delete" value="remove"></td>
 </script>


### PR DESCRIPTION
## Description
## Description
ACAS-498 adds a new "Writeup" text field associated with each analytical file attached to a Lot in CReg. The purpose of this is to store standard NMR and LCMS writeup information (https://pubsapp.acs.org/paragonplus/submission/acs_nmr_guidelines.pdf) used in publications, alongside the corresponding pdfs and raw data.

The frontend portion here adds the new `textarea` to the form, makes sure it is saved and rendered properly, and tweaks some styling so that saved and new rows line up properly. See screenshot below.

## Related Issue

## How Has This Been Tested?
Tested locally that I can upload and save an analytical file with a writeup. Confirmed that it's rendered properly when the page is reloaded after save.
<img width="903" alt="Screen Shot 2022-11-03 at 1 05 37 PM" src="https://user-images.githubusercontent.com/18313455/199823935-5f30a545-9795-4d1b-b9cf-e8d85de90328.png">