### PR TITLE
ACAS-491: GitHub actions fix deprecation warnings

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Run docker-compose up - assumes racas-oss:${{ env.ACAS_TAG }} and acas-roo-server-oss:${{ env.ACAS_TAG }}-indigo exist and are up to date
         id: dockerComposeUp
         run: |
-          echo ::set-output name=docker_compose_pull_failure::false
-          docker-compose -f "docker-compose.yml" up -d || echo ::set-output name=docker_compose_pull_failure::true
+          echo "docker_compose_pull_failure=false" >> $GITHUB_OUTPUT
+          docker-compose -f "docker-compose.yml" up -d || echo "docker_compose_pull_failure=true" >> $GITHUB_OUTPUT
       - name: Get docker images fallback tag name
         run: |
           echo "DEFAULT_BRANCH_ACAS_TAG=$(echo ${{ github.event.repository.default_branch }} | sed -e 's/\//-/g')" >> $GITHUB_ENV

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -99,7 +99,7 @@ jobs:
           echo "password=secret" >> ~/.acas/credentials
           echo "url=http://localhost:3000" >> ~/.acas/credentials
       - name: Set Up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Display Python version

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -23,11 +23,11 @@ jobs:
       - name: Set ACAS_TAG to ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
         run: echo "ACAS_TAG=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
           # Check out the branch specified by ACAS_CLIENT_REF
           ref: ${{ env.ACAS_CLIENT_REF }}
       - name: Build (no push)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: false
           load: true
@@ -111,7 +111,7 @@ jobs:
       - name: Run tests
         run: python -m unittest discover -s ./acasclient -p "test_*.py" -v
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           # Only push tags and release branches
           push: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -30,7 +30,7 @@ jobs:
             echo "ACAS_REF=$(echo $INPUT_BRANCH_NAME)" >> $GITHUB_ENV
           fi 
       - name: Get the latest commit of ${{ env.ACAS_REF }} and apply tag ${{ github.event.inputs.tag-name }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.ACAS_WORKFLOWS_TOKEN }}
           script: |

--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -24,7 +24,7 @@ jobs:
       # and 2022.1.1-dev9 will become 2022.1.1-dev10
       - name: Get next dev tag name
         run: |
-          LAST_TAG=$(git tag --sort=committerdate --merged ${{ env.BRANCH_NAME }} | grep -e '-dev' | tail -1)
+          LAST_TAG=$(git tag --sort=v:refname --merged ${{ env.BRANCH_NAME }} | grep -e '-dev' | tail -1)
           echo "NEXT_TAG=$(echo $LAST_TAG | awk -F-dev -v OFS=-dev '{$NF += 1 ; print}')" >> $GITHUB_ENV
       # Trigger the build
       - name: Trigger the tagger workflow with branch ${{env.BRANCH_NAME}} and tag ${{ env.NEXT_TAG }}

--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -28,7 +28,7 @@ jobs:
           echo "NEXT_TAG=$(echo $LAST_TAG | awk -F-dev -v OFS=-dev '{$NF += 1 ; print}')" >> $GITHUB_ENV
       # Trigger the build
       - name: Trigger the tagger workflow with branch ${{env.BRANCH_NAME}} and tag ${{ env.NEXT_TAG }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.ACAS_WORKFLOWS_TOKEN }}
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ venv
 chemaxon
 .chemaxon
 .vscode
-.github


### PR DESCRIPTION
## Description
Fixing warnings:
- Bump `docker/*`, `setup-python`, and `github-script` action versions to fix Node 12 deprecation warnings
- Replaced set-output based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

A few small unrelated changes:
- Applied a fix for sorting git tags (`--sort=v:refname` rather than `--sort=committerdate`) that I'd applied to acas-roo-server and racas but forgot to apply to acas
- Removed `.github` from gitignore because we do want to track the workflow files in there

## Related Issue

## How Has This Been Tested?
Tested via this PR.
Latest run has no warnings: https://github.com/mcneilco/acas/actions/runs/3389274203