### PR TITLE
Switch "data column order" stringValues to codeValues

### DIFF
--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -1034,7 +1034,7 @@ class ACASFormLSBooleanFieldController extends ACASFormAbstractFieldController
 
 	renderModelContent: =>
 		# If value is anything other than true (i.e. null), then default to unchecked
-		if @getModel().get('value') is "true"
+		if @getModel().get('value').toLowerCase() is "true"
 			@$('input').attr 'checked', 'checked'
 		else
 			@$('input').removeAttr 'checked'

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -4088,11 +4088,11 @@ getProtocolEndpointData <- function(protocol) {
 
           #depending on what the lsKind is, record the data
           if (value[['lsKind']] == "column name") {
-            columnNameEntry = value[['stringValue']]
+            columnNameEntry = value[['codeValue']]
           } else if (value[['lsKind']] == "column units") {
-            unitsEntry = value[['stringValue']]
+            unitsEntry = value[['codeValue']]
           } else if (value[['lsKind']] == "column type") {
-            dataTypeEntry = value[['stringValue']]
+            dataTypeEntry = value[['codeValue']]
           }
           
         }
@@ -4415,11 +4415,13 @@ generateExptColStateValues <- function(dataRow, recordedBy, lsTransaction){
                                   numericValue = dataRow$order
     )}
   if (!is.null(dataRow$valueKind) && !is.na(dataRow$valueKind)) {
-	values[[length(values)+1]] <- createStateValue(lsType = "stringValue",
+	values[[length(values)+1]] <- createStateValue(lsType = "codeValue",
                                   lsKind = "column name",
                                   lsTransaction = lsTransaction,
                                   recordedBy = recordedBy,
-                                  stringValue = dataRow$valueKind
+                                  codeValue = dataRow$valueKind,
+                                  codeType = "data column",
+                                  codeKind = "column name" 
     )}
   if (!is.null(dataRow$Conc) && !is.na(dataRow$Conc)) {
   	values[[length(values)+1]] <- createStateValue(lsType = "numericValue",
@@ -4429,11 +4431,13 @@ generateExptColStateValues <- function(dataRow, recordedBy, lsTransaction){
                                     numericValue = as.numeric(dataRow$Conc)
       )}
   if (!is.null(dataRow$concUnits) && !is.na(dataRow$concUnits)) {
-  	values[[length(values)+1]] <- createStateValue(lsType = "stringValue",
+  	values[[length(values)+1]] <- createStateValue(lsType = "codeValue",
                                     lsKind = "column conc units",
                                     lsTransaction = lsTransaction,
                                     recordedBy = recordedBy,
-                                    stringValue = as.character(dataRow$concUnits)
+                                    codeValue = as.character(dataRow$concUnits),
+                                    codeType = "data column",
+                                    codeKind = "column conc units" 
       )}          
   if (!is.null(dataRow$time) && !is.na(dataRow$time)) {
   	values[[length(values)+1]] <- createStateValue(lsType = "numericValue",
@@ -4443,39 +4447,50 @@ generateExptColStateValues <- function(dataRow, recordedBy, lsTransaction){
                                     numericValue = as.numeric(dataRow$time)
       )}
   if (!is.null(dataRow$timeUnit) && !is.na(dataRow$timeUnit)) {
-  	values[[length(values)+1]] <- createStateValue(lsType = "stringValue",
+  	values[[length(values)+1]] <- createStateValue(lsType = "codeValue",
                                     lsKind = "column time units",
                                     lsTransaction = lsTransaction,
                                     recordedBy = recordedBy,
-                                    stringValue = as.character(dataRow$timeUnit)
+                                    codeValue = as.character(dataRow$timeUnit),
+                                    codeType = "data column",
+                                    codeKind = "column time units" 
       )}  
   if (!is.null(dataRow$Units) && !is.na(dataRow$Units)) {
-	values[[length(values)+1]] <- createStateValue(lsType = "stringValue",
+	values[[length(values)+1]] <- createStateValue(lsType = "codeValue",
                                   lsKind = "column units",
                                   lsTransaction = lsTransaction,
                                   recordedBy = recordedBy,
-                                  stringValue = as.character(dataRow$Units)
+                                  codeValue = as.character(dataRow$Units),
+                                  codeType = "data column",
+                                  codeKind = "column units" 
     )}
   if (!is.null(dataRow$valueType) && !is.na(dataRow$valueType)) {
-	values[[length(values)+1]] <- createStateValue(lsType = "stringValue",
+	values[[length(values)+1]] <- createStateValue(lsType = "codeValue",
                                   lsKind = "column type",
                                   lsTransaction = lsTransaction,
                                   recordedBy = recordedBy,
-                                  stringValue = dataRow$valueType
+                                  codeValue = dataRow$valueType,
+                                  codeType = "data column",
+                                  codeKind = "column type" 
     )}
   if (!is.null(dataRow$hideColumn) && !is.na(dataRow$hideColumn)) {
-	values[[length(values)+1]] <- createStateValue(lsType = "stringValue",
+	values[[length(values)+1]] <- createStateValue(lsType = "codeValue",
                                   lsKind = "hide column",
                                   lsTransaction = lsTransaction,
                                   recordedBy = recordedBy,
-                                  stringValue = as.character(dataRow$hideColumn)
+                                  codeValue = as.character(dataRow$hideColumn),
+                                  codeType = "boolean",
+                                  codeKind = "boolean" 
     )}
   if (!is.null(dataRow$conditionColumn) && !is.na(dataRow$conditionColumn)) {
-  	values[[length(values)+1]] <- createStateValue(lsType = "stringValue",
+  	values[[length(values)+1]] <- createStateValue(lsType = "codeValue",
                                     lsKind = "condition column",
                                     lsTransaction = lsTransaction,
                                     recordedBy = recordedBy,
-                                    stringValue = as.character(dataRow$conditionColumn)
+                                    codeValue = as.character(dataRow$conditionColumn),
+                                    codeType = "boolean",
+                                    codeKind = "boolean" 
+
       )}
 #	return(removeEmptyValues_DV(values))
 	return(values)

--- a/modules/ServerAPI/conf/ExperimentConfJSON.coffee
+++ b/modules/ServerAPI/conf/ExperimentConfJSON.coffee
@@ -153,31 +153,31 @@
 				typeName: "numericValue"
 				kindName: "column order"
 			,
-				typeName: "stringValue"
+				typeName: "codeValue"
 				kindName: "column name"
 			,
-				typeName: "stringValue"
+				typeName: "codeValue"
 				kindName: "column units"
 			,
-				typeName: "stringValue"
+				typeName: "codeValue"
 				kindName: "column type"
 			,
-				typeName: "stringValue"
+				typeName: "codeValue"
 				kindName: "hide column"	
 			,
 				typeName: "numericValue"
 				kindName: "column concentration"	
 			,
-				typeName: "stringValue"
+				typeName: "codeValue"
 				kindName: "column conc units"	
 			,
 				typeName: "numericValue"
 				kindName: "column time"	
 			,
-				typeName: "stringValue"
+				typeName: "codeValue"
 				kindName: "column time units"	
 			,
-				typeName: "stringValue"
+				typeName: "codeValue"
 				kindName: "condition column"	
 			,
 				typeName: "codeValue"

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -581,7 +581,7 @@ class EndpointController extends ACASFormStateTableFormController
 EndpointsValuesConf = [
 	key: 'column name'
 	modelDefaults:
-		type: 'stringValue'
+		type: 'codeValue'
 		kind: 'column name'
 		codeType: 'data column'
 		codeKind: 'column name'
@@ -601,7 +601,7 @@ EndpointsValuesConf = [
 ,
 	key: 'column units'
 	modelDefaults:
-		type: 'stringValue'
+		type: 'codeValue'
 		kind: 'column units'
 		codeType: 'data column'
 		codeKind: 'column units'
@@ -621,7 +621,7 @@ EndpointsValuesConf = [
 ,
 	key: 'column type'
 	modelDefaults:
-		type: 'stringValue'
+		type: 'codeValue'
 		kind: 'column type'
 		codeType: 'data column'
 		codeKind: 'column type'
@@ -653,7 +653,7 @@ EndpointsValuesConf = [
 ,
 	key: 'column time units'
 	modelDefaults:
-		type: 'stringValue'
+		type: 'codeValue'
 		kind: 'column time units'
 		codeType: 'data column'
 		codeKind: 'column time units'
@@ -687,7 +687,7 @@ EndpointsValuesConf = [
 ,
 	key: 'column conc units'
 	modelDefaults:
-		type: 'stringValue'
+		type: 'codeValue'
 		kind: 'column conc units'
 		codeType: 'data column'
 		codeKind: 'column conc units'
@@ -707,7 +707,7 @@ EndpointsValuesConf = [
 ,
 	key: 'hide column'
 	modelDefaults:
-		type: 'stringValue'
+		type: 'codeValue'
 		kind: 'hide column'
 		codeType: 'boolean'
 		codeKind: 'boolean'
@@ -720,7 +720,7 @@ EndpointsValuesConf = [
 ,
 	key: 'condition column'
 	modelDefaults:
-		type: 'stringValue'
+		type: 'codeValue'
 		kind: 'condition column'
 		codeType: 'boolean'
 		codeKind: 'boolean'
@@ -917,13 +917,13 @@ class EndpointListController extends AbstractFormController
 									for j in i.lsValues
 										#only looking at the data that is not ignored
 										if j.lsKind == "column name" and j.ignored == false
-											if j.stringValue == rowEndpointName
+											if j.codeValue == rowEndpointName
 												endpointRowValueMatch = true
 										if j.lsKind == "column units" and j.ignored == false
-											if j.stringValue == rowUnits
+											if j.codeValue == rowUnits
 												endpointRowUnitsMatch = true
 										if j.lsKind == "column type" and j.ignored == false
-											if j.stringValue == rowDataType 
+											if j.codeValue == rowDataType 
 												endpointRowDataTypeMatch = true
 
 								#if all the criteria pass, record the experiment, end the loop early & move on to the next one


### PR DESCRIPTION
## Description
For the endpoint manager, the items in the "data column order " state have been saved with "stringValue" types when they should be saved with "codeValue" types to follow ACAS's standards.

Changed the following values from "stringValue" to "codeValue", and set the "codeType", "codeKind", and "codeOrigin" attributes accordingly in Frontend Protocol/Experiment endpoint tables and Backend R logic (genericDataParser):

- column name
- column conc units
- column time units
- column units
- column type
- hide column
- condition column


## How Has This Been Tested?
- Used experiment loader to upload experiment to see if the experiment and new protocol values were stored as codeValues and if the values were displayed in the endpoint table
- Also tested by manually creating a new protocol 