### PR TITLE
Bug Fix: Duplicate Parent Alias Errors Don't Bubble Up To UI

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -600,7 +600,9 @@ exports.saveMetaLot = (req, resp) ->
 	, (error, response, json) =>
 		if !error
 			console.log JSON.stringify json
-			if JSON.stringify(json).indexOf("Duplicate") != -1
+			if JSON.stringify(json).indexOf("Duplicate") != -1 
+				resp.statusCode = 409
+			else if JSON.stringify(json).indexOf("must be globally unique") != -1 
 				resp.statusCode = 409
 			else
 				resp.statusCode = response.statusCode


### PR DESCRIPTION
**Steps to Reproduce:**

With the setting to disallow duplicate aliases turned on. Try and edit a parent alias to match a parent alias that exists on another compound already.

**New Results:**

The UI displays an error to the user stating that:

Parent Aliases must be globally unique.

**Previous Results:**

No error is shown and the UI hangs


## How Has This Been Tested?
Manually checking steps provided in ticket. See Screenshot... 

<img width="1170" alt="Screen Shot 2022-11-09 at 11 42 15 AM" src="https://user-images.githubusercontent.com/97194463/200889665-87a8d8d2-b254-4203-a085-b4157c42f576.png">
