### PR TITLE
Fix: ACAS gives confusing error when user does not have project access to protocol

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -2243,7 +2243,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             projectCode <- systemProjectsDT[name == projectName]$code
             if(nrow(protocolProjectMatches) == 0) {
               protocolProjectExists <- FALSE
-              addError("The project that this ",racas::applicationSettings$client.protocol.label," belongs to is no longer available please contact your administrator or if you have the appropriate privileges re-assign the ",racas::applicationSettings$client.protocol.label," to a new project", errorEnv = errorEnv)
+              addError(paste0("The project that this ",racas::applicationSettings$client.protocol.label," belongs to is no longer available please contact your administrator or if you have the appropriate privileges re-assign the ",racas::applicationSettings$client.protocol.label," to a new project"), errorEnv = errorEnv)
             } else {
               protocolProjectExists <- TRUE
             }
@@ -2259,7 +2259,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             userProjectDT <- rbindlist(lapply(projectList, rmNullObs), fill = TRUE)
             userHasAccess <- nrow(userProjectDT[code == protocolProject & ignored == FALSE]) > 0
             if(!userHasAccess) {
-              addError("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to.", errorEnv = errorEnv)
+              addError(paste0("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to."), errorEnv = errorEnv)
             }
           }
         }


### PR DESCRIPTION
**Steps to Reproduce**

As an ACAS user, attempt to upload an experiment to a protocol which is restricted to project you do not have access to.

**Fix Results**

ACAS produces a well-formatted, readable error message that is intelligible to the user.

("The [protocol name] you entered is being used in a project that you do not have access to.") 

**Previous Buggy Results**

ACAS produces the following message:
"unused arguments (racas::applicationSettings$client.protocol.label, " you entered is being used in a project that you do not have access to.")
