### PR TITLE
Bug Fix: Open in Livedesign Button Broken in Curve Curator

### DIFF
--- a/modules/CurveAnalysis/src/client/CurveCuratorAppController.coffee
+++ b/modules/CurveAnalysis/src/client/CurveCuratorAppController.coffee
@@ -37,11 +37,11 @@ class CurveCuratorAppController extends Backbone.View
 	loadCurvesForExptCode: (exptCode, curveID) =>
 		UtilityFunctions::showProgressModal @$('.bv_loadCurvesModal')
 		@ccc.setupCurator(exptCode, curveID)
-		resultViewerURL = "/openExptInQueryTool?experiment="+exptCode
-		@$('.bv_resultViewerBtn').attr('href',resultViewerURL)
-		@$('.bv_resultViewerBtn').html('Open in '+window.conf.service.result.viewer.displayName)
-		@$('.bv_resultViewerBtn').show()
 
+		@openExperimentInQueryToolController = new OpenExperimentInQueryToolController
+			code: exptCode 
+			experimentStatus: 'approved'
+		$('.bv_openExperimentInQueryToolPlaceholder').html @openExperimentInQueryToolController.render().el
 
 	hideLoadCurvesModal: =>
 		UtilityFunctions::hideProgressModal @$('.bv_loadCurvesModal')

--- a/modules/CurveAnalysis/src/client/CurveCuratorAppView.html
+++ b/modules/CurveAnalysis/src/client/CurveCuratorAppView.html
@@ -6,9 +6,7 @@
         <div class="navbar-inner">
             <div class="container" style="margin-left:20px;">
                 <a class="brand" href="#">ACAS: Curve Curator</a>
-                <div class="bv_resultViewer" style="min-width:1372px;margin-left:-100;">
-                    <a class="btn bv_resultViewerBtn pull-left hide" href="#" target="_blank" style="margin-top: 5px;">Open in Seurat</a>
-                </div>
+                <div class="bv_openExperimentInQueryToolPlaceholder pull-right" style="margin-right: 5px;"></div>
             </div><!--/.nav-collapse -->
         </div>
     </div>

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -2243,7 +2243,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             projectCode <- systemProjectsDT[name == projectName]$code
             if(nrow(protocolProjectMatches) == 0) {
               protocolProjectExists <- FALSE
-              addError(paste0("The project that this ",racas::applicationSettings$client.protocol.label," belongs to is no longer available please contact your administrator or if you have the appropriate privileges re-assign the ",racas::applicationSettings$client.protocol.label," to a new project"), errorEnv = errorEnv)
+              addError("The project that this ",racas::applicationSettings$client.protocol.label," belongs to is no longer available please contact your administrator or if you have the appropriate privileges re-assign the ",racas::applicationSettings$client.protocol.label," to a new project", errorEnv = errorEnv)
             } else {
               protocolProjectExists <- TRUE
             }
@@ -2259,7 +2259,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             userProjectDT <- rbindlist(lapply(projectList, rmNullObs), fill = TRUE)
             userHasAccess <- nrow(userProjectDT[code == protocolProject & ignored == FALSE]) > 0
             if(!userHasAccess) {
-              addError(paste0("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to."), errorEnv = errorEnv)
+              addError("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to.", errorEnv = errorEnv)
             }
           }
         }

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -2243,7 +2243,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             projectCode <- systemProjectsDT[name == projectName]$code
             if(nrow(protocolProjectMatches) == 0) {
               protocolProjectExists <- FALSE
-              addError("The project that this ",racas::applicationSettings$client.protocol.label," belongs to is no longer available please contact your administrator or if you have the appropriate privileges re-assign the ",racas::applicationSettings$client.protocol.label," to a new project", errorEnv = errorEnv)
+              addError(paste0("The project that this ",racas::applicationSettings$client.protocol.label," belongs to is no longer available please contact your administrator or if you have the appropriate privileges re-assign the ",racas::applicationSettings$client.protocol.label," to a new project"), errorEnv = errorEnv)
             } else {
               protocolProjectExists <- TRUE
             }
@@ -2259,7 +2259,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             userProjectDT <- rbindlist(lapply(projectList, rmNullObs), fill = TRUE)
             userHasAccess <- nrow(userProjectDT[code == protocolProject & ignored == FALSE]) > 0
             if(!userHasAccess) {
-              addError("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to.", errorEnv = errorEnv)
+              addError(paste0("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to."), errorEnv = errorEnv)
             }
           }
         }


### PR DESCRIPTION
**Extra Context** 

The efforts to DRY the "Open In" button feature with 
OpenExperimentInQueryTool was not applied to the button in Curve Curator. It was added to the Experiment Browser and the Experiment Loader but forgotten here. 

**Steps to Reproduce:**

Load a Dose Response formatted file into ACAS using the Dose Response module

Open the data set in Curve Curator

Click the Open In LiveDesign button

**Previous Bug Results:**

Browser opens a new tab but Live Design never opens

**Fix Results:**

LiveDesign opens to a Live Report with the expected data
