### PR TITLE
ACAS-482: Fix misspelled registeredBy

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -486,13 +486,13 @@ exports.getLotAcls = (lot, user, allowedProjects, checkDelete=true) ->
 			lotAcls.setWrite(false)
 		else
 			# If the user is not a cmpd reg admin, then they can only write the lot if disableEditMyLots is false
-			# and they are either the chemist or the lot registerdBy
+			# and they are either the chemist or the lot registeredBy
 			if config.all.client.cmpdreg.metaLot.disableEditMyLots == false
-				canWrite = (lot.chemist? && lot.chemist == user.username) || (lot.registerdBy? && lot.registerdBy == user.username)
+				canWrite = (lot.chemist? && lot.chemist == user.username) || (lot.registeredBy? && lot.registeredBy == user.username)
 				if canWrite
 					lotAcls.setWrite(true)
 				else
-					console.log "User #{user.username} does not have permission to edit lot #{lot.corpName} which is not their lot (registerdBy: #{lot.registerdBy}, chemist: #{lot.chemist})"
+					console.log "User #{user.username} does not have permission to edit lot #{lot.corpName} which is not their lot (registeredBy: #{lot.registeredBy}, chemist: #{lot.chemist})"
 					lotAcls.setWrite(false)
 
 	if lotAcls.getRead() && lotAcls.getWrite() && checkDelete


### PR DESCRIPTION
## Description
 - Fix misspelled registeredBy
 - This is a fix for the already closed out https://github.com/mcneilco/acas/pull/1038 which had the name misspelled.

## Related Issue
ACAS-482


## How Has This Been Tested?
Configured a lot and permissions such that I reproduced the bug and could not edit a lot that was registeredBy me.
Updated the code and refreshed the page and verified I could not edit the lot.
Switched the registedBy user to another user and verified I could no longer edit the lot. (negative case test).