### PR TITLE
Endpoints should not be added during failed uploads to ACAS

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3544,22 +3544,18 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
     customExperimentMetaDataValues <- NULL
   }
   
-  # Save endpoint data codes if it passed validation OR if it is a new protocol
-  # (columns don't conflict with protocol endpoints when strict endpoint matching is enabled)
-  if (experimentPassedEndpointValidation == TRUE | newProtocol == TRUE) {
-    saveEndpointCodeTables(selColumnOrderInfo$Units, "column units")
-    saveEndpointCodeTables(selColumnOrderInfo$valueKind, "column name")
-    saveEndpointCodeTables(selColumnOrderInfo$concUnits, "concentration units")
-    saveEndpointCodeTables(selColumnOrderInfo$timeUnit, "time units")
-  }
-  
-
   columnOrderStates <- createColumnOrderStates(selColumnOrderInfo, errorEnv, recordedBy, lsTransaction)
  
   
   # when not on a dry run, create protocol and experiment if they do not exist
   if (!dryRun && newProtocol && errorFree) {
     protocol <- createNewProtocol(metaData = validatedMetaData, lsTransaction, recordedBy, columnOrderStates)
+
+    # also save the new endpoints of the protocol 
+    saveEndpointCodeTables(selColumnOrderInfo$Units, "column units")
+    saveEndpointCodeTables(selColumnOrderInfo$valueKind, "column name")
+    saveEndpointCodeTables(selColumnOrderInfo$concUnits, "concentration units")
+    saveEndpointCodeTables(selColumnOrderInfo$timeUnit, "time units")
   }
 
   useExistingExperiment <- inputFormat %in% c("Use Existing Experiment", "Precise For Existing Experiment")

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3512,11 +3512,16 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
   # Validate Experiment Columns against Protocol Endpoints
   # only proceed if it associated with an existing protocol (the protocol is not new)
   # also, only proceed if endpoint manager is enabled
+
+  # We create experimentPassedEndpointValidation holding variable in case it is a new protocol and it is not assigned
+  # (Since we can't check if an empty variable is true or false later)
+  experimentPassedEndpointValidation <- FALSE 
+
   if (!newProtocol && racas::applicationSettings$client.protocol.endpointManager.enabled) {
-    #extract the endpoint data from the protocol object to check against
+    # extract the endpoint data from the protocol object to check against
     protocolEndpointData <- getProtocolEndpointData(protocol)
-    #Check the experiment columns against the protocolEndpointData
-    validateExperimentColumns(selColumnOrderInfo, protocolEndpointData, getProtocolStrictEndpointMatching(protocol), protocol$lsLabels[[1]]$labelText)
+    # Check the experiment columns against the protocolEndpointData
+    experimentPassedEndpointValidation <- validateExperimentColumns(selColumnOrderInfo, protocolEndpointData, getProtocolStrictEndpointMatching(protocol), protocol$lsLabels[[1]]$labelText)
   }
   
   # If there are errors, do not allow an upload
@@ -3539,11 +3544,15 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
     customExperimentMetaDataValues <- NULL
   }
   
-  # Save endpoint data codes
-  saveEndpointCodeTables(selColumnOrderInfo$Units, "column units")
-  saveEndpointCodeTables(selColumnOrderInfo$valueKind, "column name")
-  saveEndpointCodeTables(selColumnOrderInfo$concUnits, "concentration units")
-  saveEndpointCodeTables(selColumnOrderInfo$timeUnit, "time units")
+  # Save endpoint data codes if it passed validation OR if it is a new protocol
+  # (columns don't conflict with protocol endpoints when strict endpoint matching is enabled)
+  if (experimentPassedEndpointValidation == TRUE | newProtocol == TRUE) {
+    saveEndpointCodeTables(selColumnOrderInfo$Units, "column units")
+    saveEndpointCodeTables(selColumnOrderInfo$valueKind, "column name")
+    saveEndpointCodeTables(selColumnOrderInfo$concUnits, "concentration units")
+    saveEndpointCodeTables(selColumnOrderInfo$timeUnit, "time units")
+  }
+  
 
   columnOrderStates <- createColumnOrderStates(selColumnOrderInfo, errorEnv, recordedBy, lsTransaction)
  
@@ -4169,6 +4178,9 @@ validateExperimentColumns <- function(selColumnOrderInfo, protocolEndpointDataFr
   # Checks if the experiment columns names/units/data type are found in the protocol endpoint data
   # Raises errors if an experiment column is not valid 
   # Only used for protocols with strict endpoint enabled
+  # Returns TRUE/FALSE (whether the experiment passed validation)
+
+  experimentPassedValidation = TRUE
 
   for (experimentRowNum in seq(1, nrow(selColumnOrderInfo))) {
     experimentRowData <- selColumnOrderInfo[experimentRowNum,]
@@ -4220,12 +4232,18 @@ validateExperimentColumns <- function(selColumnOrderInfo, protocolEndpointDataFr
       # If strict endpoint matching is enabled, we throw an error, otherwise we throw a warning
       if (protocolStrictEndpointMatchingEnabled == TRUE) {
         addError(paste0("The result type '", experimentRowName, "' with data type '", experimentRowDataType, "' and units '", experimentRowUnits, "' is not one of the allowed result types for this ", racas::applicationSettings$client.protocol.label, ". Please revise your file or contact an ACAS administrator to update the allowed result types for this ", racas::applicationSettings$client.protocol.label, "."))
+
+        # we also record that the experiment did not pass validation, so we know not to upload the codes to the database
+        experimentPassedValidation = FALSE
+
       } else if (protocolStrictEndpointMatchingEnabled == FALSE) {
         warnUser(paste0("The result type '", experimentRowName, "' with data type '", experimentRowDataType, "' and units '", experimentRowUnits, "' is not configured for this ", racas::applicationSettings$client.protocol.label, ". If this is expected, you may proceed with the upload. Otherwise contact an ACAS Administrator to update the configured result types for this ", racas::applicationSettings$client.protocol.label ,"."))
       } 
     }
       
   }
+
+  return(experimentPassedValidation)
 }
 
 getProtocolStrictEndpointMatching <- function(protocol) {


### PR DESCRIPTION

## Description

**Expected Results:**
ACAS errors and the endpoints never show up in the endpoints dropdown list because the experiment was never successfully loaded

**Actual Results:**
ACAS errors as expected, however the endpoints are listed in the endpoints dropdown

**Fix:**
- Added logic to the validateExperimentColumns() function so that it returns TRUE/FALSE if the experiment did not pass strict endpoint matching requirement. 
- Added logic so endpoints are only saved if the experiment is creating a new protocol or passes the strict endpoint matching requirement 

## How Has This Been Tested?
Tested with the files used in reporting the bug (file-1.csv, file-2.csv). 

**Before ("Clint Eastwood" endpoint saved when it should not be)**
<img width="149" alt="Screen Shot 2022-11-16 at 7 23 49 PM" src="https://user-images.githubusercontent.com/107148842/202324466-f82e9d29-61cb-463d-9cf7-2d28460a5e84.png">

**After (No "Clint Eastwood" endpoint saved)**
<img width="194" alt="Screen Shot 2022-11-16 at 7 22 18 PM" src="https://user-images.githubusercontent.com/107148842/202324497-eb193aed-9134-4a13-ab27-97443bcb8269.png">
