### PR TITLE
Adding description/explanation to Experiment Endpoint table

### DIFF
--- a/modules/ServerAPI/src/client/Experiment.coffee
+++ b/modules/ServerAPI/src/client/Experiment.coffee
@@ -489,6 +489,8 @@ class ExperimentBaseController extends BaseEntityController
 			#we also only want to load it if it is enabled
 			if window.conf.protocol.endpointManager.enabled == true
 				@endpointListController.render()
+				# we want to hide the associated experiment section to avoid excessive spacing
+				@$(".bv_associatedExperimentSection").hide()
 		@
 
 	modelSyncCallback: =>

--- a/modules/ServerAPI/src/client/Experiment.html
+++ b/modules/ServerAPI/src/client/Experiment.html
@@ -90,6 +90,10 @@
         </div>
 
     </div>
+    <br>
+    <br>
+    <h3>Endpoints</h3>
+    <p><i>The columns shown below are the columns that were uploaded with this experiment. They are not editable, but will be updated if the experiment is reloaded.</i></p>
     <div class="bv_endpointTable"></div>
 
     <div class="span12 bv_group_shortDescription" style="margin-left:0px;">

--- a/modules/ServerAPI/src/client/Protocol.html
+++ b/modules/ServerAPI/src/client/Protocol.html
@@ -293,21 +293,23 @@
         <div class="bv_selectTest"></div>
         
     </table>
+    <div class="bv_associatedExperimentSection">
+        <br/>
+        <br/>
+        <span class="" style="margin-bottom:15px;margin-left:60px;">
+            <button type="button" class="btn bv_addEndpoint pull-right">Add Endpoint</button>
+        </span>
+        <br/>
+        <br/>
+        <br/>
+        <br/>
+        <h5 class="bv_experimentTableControllerTitle"></h5>
+        <button class="btn bv_downloadFiles" style="float: right; margin-top: auto; margin-bottom: auto;">Download All Files</button>
+        <div class="bv_downloadWarning hide" style="color: red; font-size: 12px; text-align: right;">Could not download files</div>
+        <div class="bv_downloadSuccess hide" style="color: green; font-size: 12px; text-align: right;">Downloaded successfully</div>
+        <div class="bv_experimentTableController hide" style="margin:0px; padding:10px; overflow: auto; overflow: auto;"></div>
+    </div>
     <br/>
     <br/>
-    <span class="" style="margin-bottom:15px;margin-left:60px;">
-        <button type="button" class="btn bv_addEndpoint pull-right">Add Endpoint</button>
-    </span>
-    <br/>
-    <br/>
-    <br/>
-    <br/>
-    <h5 class="bv_experimentTableControllerTitle"></h5>
-    <button class="btn bv_downloadFiles" style="float: right; margin-top: auto; margin-bottom: auto;">Download All Files</button>
-    <br/>
-    <br/>
-    <div class="bv_downloadWarning hide" style="color: red; font-size: 12px; text-align: right;">Could not download files</div>
-    <div class="bv_downloadSuccess hide" style="color: green; font-size: 12px; text-align: right;">Downloaded successfully</div>
-    <div class="bv_experimentTableController hide" style="margin:0px; padding:10px; overflow: auto; overflow: auto;"></div>
 </script>
 


### PR DESCRIPTION
## MISLABELED (SHOULD BE ACAS-513 INSTEAD OF ACAS-512)

## Description
The endpoint table in the Experiment editor did not have an explanation. Added text and formatting for explaining the endpoint table.

## How Has This Been Tested?
Tested locally. 

<img width="1251" alt="Screen Shot 2022-11-18 at 10 44 54 AM" src="https://user-images.githubusercontent.com/107148842/202744415-f1917a98-d06b-4616-8881-79ff3c73a974.png">
