### PR TITLE
Textbox alignment in endpoint manager

### DIFF
--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -1034,7 +1034,7 @@ class ACASFormLSBooleanFieldController extends ACASFormAbstractFieldController
 
 	renderModelContent: =>
 		# If value is anything other than true (i.e. null), then default to unchecked
-		if @getModel().get('value').toLowerCase() is "true"
+		if @getModel().get('value')? && @getModel().get('value').toLowerCase() is "true"
 			@$('input').attr 'checked', 'checked'
 		else
 			@$('input').removeAttr 'checked'

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -240,6 +240,9 @@ saveEndpointCodeTables <- function(codes, codeKind) {
   # Remove NAs from the codes
   codes <- codes[!is.na(codes)]
 
+  # Remove blanks from the codes
+  codes <- codes[codes != ""]
+
   # If there are no codes after removing NAs, end the script early
   if (length(codes) == 0) {
     return (NULL)

--- a/modules/ServerAPI/src/client/Protocol.css
+++ b/modules/ServerAPI/src/client/Protocol.css
@@ -5,3 +5,11 @@
 .bv_endpointTable .bv_number {
     width: 50px !important;
 }
+
+.bv_endpointTable .bv_editablePicklist {
+    display: flex !important;
+}
+
+.bv_endpointTable span.help-inline {
+    position: absolute !important;
+}


### PR DESCRIPTION
## Description

Fixed fields in the endpoint manager that were not aligned. 
<img width="1072" alt="Screen Shot 2022-11-18 at 12 10 24 PM" src="https://user-images.githubusercontent.com/107148842/202762230-2b9b04ff-e2f0-40f6-8120-77909ae231f3.png">

## How Has This Been Tested?
Tested on endpoint table to see if fields were aligned. 

After:
<img width="826" alt="Screen Shot 2022-11-18 at 12 03 54 PM" src="https://user-images.githubusercontent.com/107148842/202762090-fe834888-cdf7-447a-b8eb-e3b177ae0c0f.png">
