### PR TITLE
Fixed internal error when uploading some experiment files to ACAS

### DIFF
--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -1034,7 +1034,7 @@ class ACASFormLSBooleanFieldController extends ACASFormAbstractFieldController
 
 	renderModelContent: =>
 		# If value is anything other than true (i.e. null), then default to unchecked
-		if @getModel().get('value').toLowerCase() is "true"
+		if @getModel().get('value')? && @getModel().get('value').toLowerCase() is "true"
 			@$('input').attr 'checked', 'checked'
 		else
 			@$('input').removeAttr 'checked'

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -240,6 +240,9 @@ saveEndpointCodeTables <- function(codes, codeKind) {
   # Remove NAs from the codes
   codes <- codes[!is.na(codes)]
 
+  # Remove blanks from the codes
+  codes <- codes[codes != ""]
+
   # If there are no codes after removing NAs, end the script early
   if (length(codes) == 0) {
     return (NULL)


### PR DESCRIPTION
## Description
ACAS was giving the following error when uploading some experiment files. 
<img width="1075" alt="Screen Shot 2022-11-18 at 12 13 47 PM" src="https://user-images.githubusercontent.com/107148842/202762868-206e54a3-9b78-4785-82c5-df50e8263b51.png">

The error occurred in experiment files empty values for units that could not be saved when the codes were saved to the database. The issue was resolved by adding handling for empty values when saving codes. 

Also fixed an issue where some objects would not render since they had a null value. 

## How Has This Been Tested?
Reloaded the same files that were previously throwing the error and saved them successfully. Uploaded multiple times by editing protocol to include and not include the endpoints, and tried with strict endpoint enabled and disabled to make sure strict endpoint matching worked correctly. 

<img width="1195" alt="Screen Shot 2022-11-18 at 12 23 45 PM" src="https://user-images.githubusercontent.com/107148842/202765049-e6d50442-746d-4874-8346-b35e8f071ab7.png">
