### PR TITLE
ACAS-525: Aggregate some dose respone warnings, high priority experiment reload warning

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -2259,7 +2259,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             userProjectDT <- rbindlist(lapply(projectList, rmNullObs), fill = TRUE)
             userHasAccess <- nrow(userProjectDT[code == protocolProject & ignored == FALSE]) > 0
             if(!userHasAccess) {
-              addError("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to.", errorEnv = errorEnv)
+              addError(paste0("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to."), errorEnv = errorEnv)
             }
           }
         }

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -1893,7 +1893,7 @@ getExperimentByNameCheck <- function(experimentName, protocol, configList, dupli
         warnUser(paste0(racas::applicationSettings$client.experiment.label," '",experimentName,
                         "' does not exist in the ",racas::applicationSettings$client.protocol.label," that you entered, but it does exist in '", 
                         getPreferredProtocolName(protocolOfExperiment), 
-                        "'. Reloading the file will update the data and change the ",racas::applicationSettings$client.protocol.label,"."))
+                        "'. Reloading the file will update the data and change the ",racas::applicationSettings$client.protocol.label,"."), highPriority = TRUE)
         experiment <- experimentList[[1]]
       }
     } else {

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3019,6 +3019,8 @@ getFitDataFromUploadOrganizedResults <- function(calculatedResults) {
 
             # Attach the message to the row so we can reuse it in dose response summary table
             dt[ , missingParametersMsg := missingParametersMessage]
+        } else {
+            dt[ , missingParametersMsg := NA_character_]
         }
       } else {
         fixedParams <- list()

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -1898,7 +1898,7 @@ getExperimentByNameCheck <- function(experimentName, protocol, configList, dupli
       }
     } else {
       warnUser(paste0(racas::applicationSettings$client.experiment.label," '",experimentName,"' already exists, so the loader will delete its current data and replace it with your new upload.",
-                     " If you do not intend to delete and reload data, enter a new ",racas::applicationSettings$client.experiment.label," Name."))
+                     " If you do not intend to delete and reload data, enter a new ",racas::applicationSettings$client.experiment.label," Name."), priority = "high")
       experiment <- experimentList[[1]]
     }
   }
@@ -2259,7 +2259,7 @@ validateProject <- function(projectName, configList, username, protocolName = NU
             userProjectDT <- rbindlist(lapply(projectList, rmNullObs), fill = TRUE)
             userHasAccess <- nrow(userProjectDT[code == protocolProject & ignored == FALSE]) > 0
             if(!userHasAccess) {
-              addError(paste0("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to."), errorEnv = errorEnv)
+              addError("The ",racas::applicationSettings$client.protocol.label," you entered is being used in a project that you do not have access to.", errorEnv = errorEnv)
             }
           }
         }
@@ -3015,8 +3015,7 @@ getFitDataFromUploadOrganizedResults <- function(calculatedResults) {
         # We decided not to throw errors as this would be a breaking change for some workflows
         if(length(missing) > 0) {
             dt[ , missingParameters := TRUE]
-            missingParametersMessage <- paste0("The following numeric parameters were not found for curve id '", dt$curveId, "': ",paste(reportedParamLsKinds[missing], collapse = ", "), ". Please provide numeric values for these parameters so that curves are drawn properly.")
-            warnUser(missingParametersMessage)
+            missingParametersMessage <- paste0("The following numeric parameters were not found: ",paste(reportedParamLsKinds[missing], collapse = ", "), ". Please provide numeric values for these parameters so that curves are drawn properly.")
 
             # Attach the message to the row so we can reuse it in dose response summary table
             dt[ , missingParametersMsg := missingParametersMessage]
@@ -3048,6 +3047,16 @@ getFitDataFromUploadOrganizedResults <- function(calculatedResults) {
   # but it is required if we want to fit this data as part of validation so we just set it here now.
   parameters[, model.synced := FALSE]
   parameters$recordedDate <- date()
+
+  # Combing all missingParametersMessage into a single message with curve ids
+  parameters[ !is.na(missingParametersMsg), {
+    if(.N > 0) {
+      curveAgg <- paste0("'",paste(name, collapse = "','"), "'")
+      message <- paste0("For curve ids: ", curveAgg, ". ", missingParametersMsg)
+      warnUser(message)
+    }
+  }, by = missingParametersMsg]
+
   return(parameters)
 }
 subjectDataToDoseResponsePoints <- function(subjectData, modelFitTransformation) {
@@ -3134,7 +3143,7 @@ validateGoodnessOfFits <- function(fitData, protocol, defaultRenderingParams) {
   # Get the stats to show in the summary
   
   # Calculate the goodness of fit stats, plot curves, categorize and return an html row for each curve
-  fitData[ ,  c("SSE", "SST", "SSR", "rSquared", "errorLevel", "TR") := {
+  fitData[ ,  c("SSE", "SST", "SSR", "rSquared", "errorLevel", "TR", "errors", "warnings") := {
       fitData <- copy(.SD)
 
       # When looping by a variable it's removed from .SD so we need to add it back in for the plotCurve function to use
@@ -3205,11 +3214,11 @@ validateGoodnessOfFits <- function(fitData, protocol, defaultRenderingParams) {
               # Class tells us what error level this should invoke in the UI and therefore if we should block the user from submitting the data
               class <- names(statThresholds)[r]
 
-              # If the values are filled in then we proceed but if they are empty, then there is no googness of fit to evaluate
+              # If the values are filled in then we proceed but if they are empty, then there is no goodness of fit to evaluate
               if(!is.na(threshold$value) && !is.na(threshold$operator)) {
                 # If the stat value is empty but we don't have missing parameters then something is wrong
                 if(is.na(statValue)) {
-                    msg <- paste0("The ", statName, " for curve id '", name, "' could not be calculated. Please check the curve data.")
+                    msg <- paste0("The ", statName, " could not be calculated. Please check the curve data.")
                     if(class == "error") {
                       errors[[length(errors)+1]] <- msg
                     } else {
@@ -3223,12 +3232,12 @@ validateGoodnessOfFits <- function(fitData, protocol, defaultRenderingParams) {
                     if(tdStyleClass == "" && class == "warning") {
                       # If the curve is missing parameters then the error or warning was captured elsewhere so lets just style the class
                       if(length(missingParameters) == 0) {
-                        warnings[[length(warnings)+1]] <- paste0("The ", statName, " for curve id '", name, "' is ", statValueText, " which is ", threshold$operator, " than the threshold value of ", threshold$value, ".")
+                        warnings[[length(warnings)+1]] <- paste0("The ", statName, " is ", threshold$operator, " than the threshold value of ", threshold$value, ".")
                         titles <- c(titles, paste0(statName," value of ",statValueText, " is ", threshold$operator, " than threshold value ", threshold$value))
                       }
                     } else if(class == "error") {
                       if(length(missingParameters) == 0) {
-                        errors[[length(errors)+1]] <- paste0("The ", statName, " for curve id '", name, "' is ", statValueText, " which is ", threshold$operator, " than the threshold value of ", threshold$value, ".")
+                        errors[[length(errors)+1]] <- paste0("The ", statName, " is ", threshold$operator, " than the threshold value of ", threshold$value, ".")
                         titles <- c(titles, paste0(statName," value of ",statValueText, " is ", threshold$operator, " than threshold value ", threshold$value))
                       }
                     }
@@ -3240,20 +3249,10 @@ validateGoodnessOfFits <- function(fitData, protocol, defaultRenderingParams) {
           if(length(errors) > 0) {
             tdStyleClass <- "error"
             errorLevel <- "error"
-            for(e in errors) {
-              if(!is.na(e)) {
-                addError(e)
-              }
-            }
           } else if(length(warnings) > 0) {
             tdStyleClass <- "warning"
             if(errorLevel == "") {
               errorLevel <- "warning"
-            }
-            for(w in warnings) {
-              if(!is.na(w)) {
-                warnUser(w)
-              }
             }
           }
           title <- ""
@@ -3278,9 +3277,33 @@ validateGoodnessOfFits <- function(fitData, protocol, defaultRenderingParams) {
       tr <- paste0(sprintf('<tr class="%s">', errorLevel), tr)
       tr <- paste0(tr,"</tr>" )
 
-      c(calculatedGoodnessOfFitParameters, errorLevel = errorLevel, tr = tr)
+      warnings <- warnings[!is.na(warnings)]
+      warnings <- ifelse(length(warnings) > 0, paste0(warnings, collapse = " "), NA_character_)
+      errors <- errors[!is.na(errors)]
+      errors <- ifelse(length(errors) > 0, paste0(errors, collapse = " "), NA_character_)
+      c(calculatedGoodnessOfFitParameters, errorLevel = errorLevel, tr = tr, errors = errors, warnings = warnings)
 
   }, by = c("curveId", "batchCode")]
+
+  # Add warnings if any returned
+  fitData[ !is.na(warnings), {
+    if(.N > 0) {
+      curveAgg <- paste0("'",paste(name, collapse = "','"), "'")
+      message <- paste0("For curve ids: ", curveAgg, ". ", warnings)
+      warnUser(message)
+    }
+  }, by = warnings]
+
+  # Add errors if any returned
+  fitData[ !is.na(errors), {
+    if(.N > 0) {
+      curveAgg <- paste0("'",paste(name, collapse = "','"), "'")
+      message <- paste0("For curve ids: ", curveAgg, ". ", errors)
+      addError(message)
+    }
+  }, by = errors]
+
+  
   return(fitData)
 }
 runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -1898,7 +1898,7 @@ getExperimentByNameCheck <- function(experimentName, protocol, configList, dupli
       }
     } else {
       warnUser(paste0(racas::applicationSettings$client.experiment.label," '",experimentName,"' already exists, so the loader will delete its current data and replace it with your new upload.",
-                     " If you do not intend to delete and reload data, enter a new ",racas::applicationSettings$client.experiment.label," Name."), priority = "high")
+                     " If you do not intend to delete and reload data, enter a new ",racas::applicationSettings$client.experiment.label," Name."), highPriority = TRUE)
       experiment <- experimentList[[1]]
     }
   }


### PR DESCRIPTION
## Description
 - Aggregate identical stat threshold warnings and missing parameters warnings
    - I removed the actual value of the stat violation but that stat value and highlighted yellow warning can also be viewed in the dose response table
 - Add high priority warnings which move the warning to the top of the list

<img width="988" alt="Screen Shot 2022-11-23 at 1 58 52 PM" src="https://user-images.githubusercontent.com/868119/203653824-8d733c77-d105-435c-bd2f-9ee28c825267.png">

<img width="910" alt="Screen Shot 2022-11-23 at 2 06 17 PM" src="https://user-images.githubusercontent.com/868119/203653948-2dc75667-91f5-4b75-84d0-2bcfee9da282.png">
 
## Related Issue
ACAS-525

## How Has This Been Tested?
Ran acas client tests and UI test