### PR TITLE
ACAS-507: Lock down edit parent and swap structures endpoints to CReg Admins

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -42,9 +42,9 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/cmpdReg/api/v1/structureServices/hydrogenizer', loginRoutes.ensureAuthenticated, exports.genericStructureService
 	app.post '/cmpdReg/api/v1/structureServices/cipStereoInfo', loginRoutes.ensureAuthenticated, exports.genericStructureService
 	app.post '/cmpdReg/export/searchResults', loginRoutes.ensureAuthenticated, exports.exportSearchResults
-	app.post '/cmpdReg/validateParent', loginRoutes.ensureAuthenticated, exports.validateParent
-	app.post '/cmpdReg/updateParent', loginRoutes.ensureAuthenticated, exports.updateParent
-	app.post '/cmpdReg/swapParentStructures', loginRoutes.ensureAuthenticated, exports.swapParentStructures
+	app.post '/cmpdReg/validateParent', loginRoutes.ensureAuthenticated, loginRoutes.ensureCmpdRegAdmin, exports.validateParent
+	app.post '/cmpdReg/updateParent', loginRoutes.ensureAuthenticated, loginRoutes.ensureCmpdRegAdmin, exports.updateParent
+	app.post '/cmpdReg/swapParentStructures', loginRoutes.ensureAuthenticated, loginRoutes.ensureCmpdRegAdmin, exports.swapParentStructures
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata', loginRoutes.ensureAuthenticated, exports.updateLotMetadata
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata/jsonArray', loginRoutes.ensureAuthenticated, exports.updateLotsMetadata
 	app.post '/cmpdReg/api/v1/parentServices/update/parent/metadata', loginRoutes.ensureAuthenticated, exports.updateParentMetadata


### PR DESCRIPTION
## Description
ACAS-507 is meant to open the "Edit Parent" workflow up via acasclient. While doing so, I realized that the two routes used in edit parent, as well as the swapParentStructures endpoints are accessible to any CReg user. Both Edit Parent and Swap Structures should only be accessible to CReg admins. This PR makes this the case.

## Related Issue

## How Has This Been Tested?
ACASClient testing in this PR: https://github.com/mcneilco/acasclient/pull/104