### PR TITLE
ACAS-565: Fix curve render color by

### DIFF
--- a/modules/CurveAnalysis/src/server/renderCurve.R
+++ b/modules/CurveAnalysis/src/server/renderCurve.R
@@ -28,18 +28,17 @@ renderCurve <- function(getParams, postData) {
   # Get protocol curve min and max
   protocol_display_values <- racas::get_protocol_curve_display_min_and_max_by_curve_id(parsedParams$curveIds[[1]])
 
-  output <- applyParsedParametersToFitData(fitData, parsedParams, protocol_display_values)
-  data <- output$data
-  parsedParams <- output$parsedParams
-
-  fitData[ , renderingOptions := list(list(get_rendering_hint_options(renderingHint))), by = renderingHint]
-
-  data <- list(parameters = as.data.frame(fitData), points = as.data.frame(rbindlist(fitData$points)))
-
   #Retrieve rendering hint parameters
   if(is.na(coalesce(fitData[1]$renderingHint))) {
     fitData[ , renderingHint := get_model_fit_classes()[1]$code]
   }
+  
+  # Get rendering for specific rendering hints
+  fitData[ , renderingOptions := list(list(get_rendering_hint_options(renderingHint))), by = renderingHint]
+
+  output <- applyParsedParametersToFitData(fitData, parsedParams, protocol_display_values)
+  data <- output$data
+  parsedParams <- output$parsedParams
   
   setContentType("image/png")
   setHeader("Content-Disposition", paste0("filename=\"",strtrim(getParams$curveIds,200),".png\""))

--- a/modules/CurveAnalysis/src/server/renderCurve.R
+++ b/modules/CurveAnalysis/src/server/renderCurve.R
@@ -32,8 +32,8 @@ renderCurve <- function(getParams, postData) {
   if(is.na(coalesce(fitData[1]$renderingHint))) {
     fitData[ , renderingHint := get_model_fit_classes()[1]$code]
   }
-  
-  # Get rendering for specific rendering hints
+
+  # Get rendering options for specific rendering hints
   fitData[ , renderingOptions := list(list(get_rendering_hint_options(renderingHint))), by = renderingHint]
 
   output <- applyParsedParametersToFitData(fitData, parsedParams, protocol_display_values)


### PR DESCRIPTION
## Description
**Steps to Reproduce:**

- Load a dose response file into ACAS
- Grab a curve id using the following query `select curveid from api_curve_params limit 1;`
- Render the curve URL:
http://localhost:3000/api/curve/render/dr?curveIds=AG-00000017_3&colorBy=protocol

**Expected Results:**
The plot renders with the protocol name like this:

![AG-00000017_3-1](https://user-images.githubusercontent.com/868119/207433708-36757aca-8f61-4deb-a370-ab911fb8c900.png)

**Actual Results:**
The plot renders but the curve ID (an random identifier) is shown in the plot

![AG-00000017_3](https://user-images.githubusercontent.com/868119/207433747-6ab227fd-de7c-4a8c-8526-116f42c6225a.png)

**Additional info:**
Also affected by this bug would be plotting flat curves for inactive or highly active curves when fit using the ACAS dose response fit (would not apply to curves just uploaded without an ACAS curve fit)

## Related Issue
ACAS-565

## How Has This Been Tested?
Verified that legend shows the correct text when set to batch, protocol or experiment and shows the curve id when colorBy is not given in the URL