### PR TITLE
Regain debugger attachment on java 11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     environment:
      - ACAS_HOME=/home/runner/build
      - CATALINA_OPTS=-Xms512M -Xmx1024M -XX:MaxPermSize=512m -Dlisten.address=$${TOMCAT_LISTEN_ADDRESS}
-     - JAVA_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000
+     - JAVA_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000
      - TOMCAT_LISTEN_ADDRESS=0.0.0.0
     volumes_from:
      - acas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     environment:
      - ACAS_HOME=/home/runner/build
      - CATALINA_OPTS=-Xms512M -Xmx1024M -XX:MaxPermSize=512m -Dlisten.address=$${TOMCAT_LISTEN_ADDRESS}
-     - JAVA_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000
+     - JAVA_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$${TOMCAT_LISTEN_ADDRESS}:8000
      - TOMCAT_LISTEN_ADDRESS=0.0.0.0
     volumes_from:
      - acas


### PR DESCRIPTION
## Description
Local dev environment java debugging stopped working with Java 11 upgrade.
Found an easy fix: See https://www.baeldung.com/java-application-remote-debugging#from-java9

## Related Issue

## How Has This Been Tested?
- Confirmed I can attach a debugger after making this change