### PR TITLE
ACAS-304: enable protocol endpoint manager by default.

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -475,7 +475,7 @@ client.entity.status.default=created
 client.protocol.endpointManager.showConcentration=false
 client.protocol.endpointManager.showTime=false
 client.protocol.strictEndpointMatchingDefault=true
-client.protocol.endpointManager.enabled=false
+client.protocol.endpointManager.enabled=true
 
 # Protocols and experiments which should be hidden (to non-admin users) in the protocol/expt browser when the status is in the config below
 client.entity.hideStatuses=["deleted"]


### PR DESCRIPTION
## Description
The major new feature of protocol endpoint management was feature flagged / disabled by default, but it is now ready enough that it should be enabled by default.

## Related Issue

## How Has This Been Tested?
N/A