### PR TITLE
ACAS-574: Enable endpoint manager by default

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -474,8 +474,8 @@ client.entity.status.default=created
 #Config for whether to display concentration and time endpoint columns in the protocol browser
 client.protocol.endpointManager.showConcentration=false
 client.protocol.endpointManager.showTime=false
-client.protocol.strictEndpointMatchingDefault=true
-client.protocol.endpointManager.enabled=false
+client.protocol.strictEndpointMatchingDefault=false
+client.protocol.endpointManager.enabled=true
 
 # Protocols and experiments which should be hidden (to non-admin users) in the protocol/expt browser when the status is in the config below
 client.entity.hideStatuses=["deleted"]


### PR DESCRIPTION
## Description
The endpoint manager feature is ready for prime time testing, so it should be on by default.
For current python tests to pass, strict matching default must be false. This is also the "least breaking change" behavior, so it is a sensible default.

## Related Issue

## How Has This Been Tested?
Local unit tests, will also be watching the CI tests on this PR