### PR TITLE
ACAS-576: Adds projectCodes filter to cmpdreg search

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -153,6 +153,16 @@ exports.searchCmpds = (req, resp) ->
 	authorRoutes.allowedProjectsInternal req.user, (statusCode, allowedUserProjects) ->
 		_ = require "underscore"
 		allowedProjectCodes = _.pluck(allowedUserProjects, "code")
+
+		# If project codes are specified, filter the allowed projects by the requested projects
+		if req.body.projectCodes?
+			# Split by comma and remove any empty strings
+			requestedProjectCodes = _.filter(req.body.projectCodes, (code) -> code.length > 0)
+			console.log("Filtering by requested project codes #{requestedProjectCodes}")
+
+			# Filter the allowed projects by the requested projects
+			allowedProjectCodes = _.intersection(allowedProjectCodes, requestedProjectCodes)
+
 		req.body.projects = allowedProjectCodes
 		console.log req.body
 		cmpdRegCall = config.all.client.service.cmpdReg.persistence.fullpath + '/search/cmpds'


### PR DESCRIPTION
## Description
Checks for projectCodes body parameter in cmpdreg search route
Passes the intersections of allowed projects and requested projectCodes to persistence layer for filtering cmpds by project

## How Has This Been Tested?
acasclient tests