### PR TITLE
ACAS-580: Fix for blocking registration in UI

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -1150,7 +1150,7 @@ exports.allowCmpdRegistration = (req, resp) ->
 					message: "Compounds can not be registered at this time due to an error getting current standardization settings. Please contact an administrator for help."
 				resp.json response
 			else
-				allowCmpdRegistration = !getStandardizationSettingsResp.needsStandardization && getStandardizationSettingsResp.valid
+				allowCmpdRegistration = !getStandardizationSettingsResp.needsRestandardization && getStandardizationSettingsResp.valid
 				if allowCmpdRegistration
 					message = "Compounds can be registered"
 				else
@@ -1158,7 +1158,7 @@ exports.allowCmpdRegistration = (req, resp) ->
 					reasons = []
 					if !getStandardizationSettingsResp.valid
 						reasons.push "the standardization settings are invalid"
-					if getStandardizationSettingsResp.needsStandardization
+					if getStandardizationSettingsResp.needsRestandardization
 						reasons.push "the registered compounds require standardization"
 					message += reasons.join(" and ")
 					message += ". Please contact an administrator for help."


### PR DESCRIPTION
## Description
 - Fix for blocking registration when system needs restandardization

## Related Issue
ACAS-580

## How Has This Been Tested?
Deployed updated code to a server which should have been blocking registration and verified this fixes the issue.  Ran standardization and verified the user message message and blocking went away.