### PR TITLE
Endpoints are editable under Experiment Editor when Experiment is in "In Process" status

### DIFF
--- a/modules/ServerAPI/src/client/Experiment.coffee
+++ b/modules/ServerAPI/src/client/Experiment.coffee
@@ -369,6 +369,7 @@ class ExperimentBaseController extends BaseEntityController
 			"click .bv_closeDeleteExperimentModal": "handleCloseExperimentModal"
 			"click .bv_confirmDeleteExperimentButton": "handleConfirmDeleteExperimentClicked"
 			"click .bv_cancelDelete": "handleCancelDeleteClicked"
+			"change .bv_status": "handleStatusChanged"
 		)
 
 	initialize: ->
@@ -809,3 +810,23 @@ class ExperimentBaseController extends BaseEntityController
 			model: @model
 			readOnly: true
 			view: "experiment"
+	
+	handleStatusChanged: =>
+		value = @statusListController.getSelectedCode()
+		if (value is "approved" or value is "rejected") and !@isValid()
+			value = value.charAt(0).toUpperCase() + value.substring(1);
+			alert 'All fields must be valid before changing the status to "'+ value + '"'
+			@statusListController.setSelectedCode @model.getStatus().get('codeValue')
+		else if value is "deleted"
+			@handleDeleteStatusChosen()
+		else
+			@handleValueChanged "Status", value
+			# this is required in addition to model change event watcher only for spec. real app works without it
+			@updateEditable()
+			@model.trigger 'change'
+			@model.trigger 'statusChanged'
+		
+		# always disable the endpoint controller fields when status is changed
+		$(".bv_endpointTable input").attr("disabled", true) 
+		$(".bv_endpointTable .bv_parameterSelectList").attr("disabled", true)
+		$(".bv_endpointTable .bv_addOptionBtn").attr("disabled", true)


### PR DESCRIPTION
## Description
When the experiment status in the experiment editor was changed from "Approved" or "Rejected" to "Created"/"In Process"/"Complete", the fields in the endpoint table were editable when they should not be editable in the experiment editor. 

This was being caused by logic that would enable or disable all fields in the page when the status was changed from a locked status ("Approved"/"Rejected") to an unlocked status ("Created"/"In Process"/"Complete"). 

To fix this, I added some lines to the function that handles when the status is changed that will always disable the endpoint table fields (I brought a copy of the function from BaseEntityController so that I wouldn't change anything universally). 

## How Has This Been Tested?
Tested it by toggling between the different statuses of an experiment. 
[<!--- Describe how this has been tested -->](https://user-images.githubusercontent.com/107148842/213209873-6f9f1957-6b85-4ed7-a15f-d5233e4c0898.mov)