### PR TITLE
Bug Fix: Adding New Lot Copies Lot Corp Name and Causes Error in Subsequent Search Query 

### DIFF
--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -433,7 +433,7 @@ $(function() {
 
 	    newLot: function () {
 			corpName = this.model.get('parent').get('corpName');
-		    window.open("#register/" + corpName);
+			window.open("#register/" + corpName);
 	    },
 
 	    downloadLot: function() {

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -431,7 +431,12 @@ $(function() {
 	    },
 
 	    newLot: function () {
-		    window.open("#register/" + this.lotController.model.get('corpName'));
+			// Need to strip away lot suffix to prevent error on Cmpd ID search 
+			corpName = this.lotController.model.get('corpName'); 
+			corpNameArr = corpName.split("-");
+			corpNameArr.pop(); // Removes lot suffix from array 
+			corpName = corpNameArr.join("-");
+		    window.open("#register/" + corpName);
 	    },
 
 	    downloadLot: function() {

--- a/modules/CmpdReg/src/client/src/MetaLot.js
+++ b/modules/CmpdReg/src/client/src/MetaLot.js
@@ -365,6 +365,7 @@ $(function() {
 				var newLotSuccessController = new NewLotSuccessController({
 					el: this.$('.NewLotSuccessView'),
 					corpName: message.metalot.lot.corpName,
+					parentCorpName: message.metalot.lot.parent.corpName, 
 					buid: message.metalot.lot.buid
 				});
 				newLotSuccessController.render();
@@ -431,11 +432,7 @@ $(function() {
 	    },
 
 	    newLot: function () {
-			// Need to strip away lot suffix to prevent error on Cmpd ID search 
-			corpName = this.lotController.model.get('corpName'); 
-			corpNameArr = corpName.split("-");
-			corpNameArr.pop(); // Removes lot suffix from array 
-			corpName = corpNameArr.join("-");
+			corpName = this.model.get('parent').get('corpName');
 		    window.open("#register/" + corpName);
 	    },
 

--- a/modules/CmpdReg/src/client/src/NewLotSuccess.js
+++ b/modules/CmpdReg/src/client/src/NewLotSuccess.js
@@ -36,7 +36,7 @@ $(function() {
         
         newLot: function() {
             corpName = this.options.parentCorpName;
-	        window.open("#register/"+corpName, '_blank');
+            window.open("#register/"+corpName, '_blank');
             this.closeLot();
             // if(appController) {appController.router.navigate('register/'+this.options.corpName,true);}
         },

--- a/modules/CmpdReg/src/client/src/NewLotSuccess.js
+++ b/modules/CmpdReg/src/client/src/NewLotSuccess.js
@@ -35,7 +35,12 @@ $(function() {
         },
         
         newLot: function() {
-	        window.open("#register/"+this.options.corpName, '_blank');
+            // Need to strip away lot suffix to prevent error on Cmpd ID search 
+            corpName = this.options.corpName;
+			corpNameArr = corpName.split("-");
+			corpNameArr.pop(); // Removes lot suffix 
+			corpName = corpNameArr.join("-");
+	        window.open("#register/"+corpName, '_blank');
             this.closeLot();
             // if(appController) {appController.router.navigate('register/'+this.options.corpName,true);}
         },

--- a/modules/CmpdReg/src/client/src/NewLotSuccess.js
+++ b/modules/CmpdReg/src/client/src/NewLotSuccess.js
@@ -35,11 +35,7 @@ $(function() {
         },
         
         newLot: function() {
-            // Need to strip away lot suffix to prevent error on Cmpd ID search 
-            corpName = this.options.corpName;
-			corpNameArr = corpName.split("-");
-			corpNameArr.pop(); // Removes lot suffix 
-			corpName = corpNameArr.join("-");
+            corpName = this.options.parentCorpName;
 	        window.open("#register/"+corpName, '_blank');
             this.closeLot();
             // if(appController) {appController.router.navigate('register/'+this.options.corpName,true);}

--- a/modules/CmpdReg/src/client/src/Search.js
+++ b/modules/CmpdReg/src/client/src/Search.js
@@ -119,7 +119,7 @@ $(function () {
             window.open("#lot/"+corpName);
         },
         newLot: function(corpName) {
-		    window.open("#register/" + corpName);
+            window.open("#register/" + corpName);
         },
         registerNewLot: function(id) {
 

--- a/modules/CmpdReg/src/client/src/Search.js
+++ b/modules/CmpdReg/src/client/src/Search.js
@@ -119,10 +119,6 @@ $(function () {
             window.open("#lot/"+corpName);
         },
         newLot: function(corpName) {
-            // Need to strip away lot suffix to prevent error on Cmpd ID search 
-			corpNameArr = corpName.split("-");
-			corpNameArr.pop(); // Removes lot suffix 
-			corpName = corpNameArr.join("-");
 		    window.open("#register/" + corpName);
         },
         registerNewLot: function(id) {

--- a/modules/CmpdReg/src/client/src/Search.js
+++ b/modules/CmpdReg/src/client/src/Search.js
@@ -119,8 +119,11 @@ $(function () {
             window.open("#lot/"+corpName);
         },
         newLot: function(corpName) {
-
-            window.open("#register/"+corpName);
+            // Need to strip away lot suffix to prevent error on Cmpd ID search 
+			corpNameArr = corpName.split("-");
+			corpNameArr.pop(); // Removes lot suffix 
+			corpName = corpNameArr.join("-");
+		    window.open("#register/" + corpName);
         },
         registerNewLot: function(id) {
 

--- a/modules/CmpdReg/src/client/src/SearchResults.js
+++ b/modules/CmpdReg/src/client/src/SearchResults.js
@@ -74,7 +74,7 @@ $(function() {
 
         newLot: function() {
 	        if ( !window.configuration.metaLot.saltBeforeLot && this.model.get('lotIDs').length==1) {
-		        this.trigger('newLot', this.model.get('lotIDs')[0].corpName);
+		        this.trigger('newLot', this.model.get('corpName'));
 	        } else {
 		        this.trigger('newLot', this.$('.lotSelect').val());
 	        }


### PR DESCRIPTION
## Description

When adding a new lot, the  compound ID that gets copied over includes the lot suffix which results in the 'Next Step' failing (see screenshot).

<img width="960" alt="Screen Shot 2023-01-25 at 10 56 34 AM" src="https://user-images.githubusercontent.com/97194463/214611599-39dab291-bdd2-4964-b62f-78af07d638aa.png">


If the lot suffix is dropped then the subsequents steps function as normal. 

This fix includes code to drop the lot suffix and prevents it from being copied over whenever a "New Lot" button is utilized. 

<img width="689" alt="Screen Shot 2023-01-25 at 10 57 57 AM" src="https://user-images.githubusercontent.com/97194463/214611968-fdc36c00-dda4-4b6e-b802-c578ef28ce28.png">

The second step now is successful. 

<img width="634" alt="Screen Shot 2023-01-25 at 10 59 11 AM" src="https://user-images.githubusercontent.com/97194463/214612370-85455023-4c24-4a7e-81a4-b3e0b87ee1b2.png">

NOTE: This previously worked on an environment where ACASLabelSequences is not utilized. 

## How Has This Been Tested?
Manually 