### PR TITLE
ACAS-593 URL Encode the reason for standardization when passing to persist layer

### DIFF
--- a/modules/Standardization/src/server/routes/StandardizationRoutes.coffee
+++ b/modules/Standardization/src/server/routes/StandardizationRoutes.coffee
@@ -262,7 +262,7 @@ exports.standardizationExecution = (req, resp) ->
 			resp.json standardizationExecutionInternalResp
 
 exports.standardizationExecutionInternal = (username, reason, callback) ->
-	url = config.all.client.service.cmpdReg.persistence.fullpath + "/standardization/execute?username=#{username}&reason=#{reason}"
+	url = config.all.client.service.cmpdReg.persistence.fullpath + "/standardization/execute?username=#{username}&reason=#{encodeURIComponent(reason)}"
 	console.log url
 	request(
 		method: 'GET'


### PR DESCRIPTION
## Description
 - Fixes passing invalid characters in URL to roo

roo gave this error before:
```
acas-roo-1  | 25-Jan-2023 19:13:24.479 INFO [http-nio-8080-exec-1] org.apache.coyote.http11.Http11Processor.service Error parsing HTTP request header
acas-roo-1  |  Note: further occurrences of HTTP request parsing errors will be logged at DEBUG level.
acas-roo-1  |   java.lang.IllegalArgumentException: Invalid character found in the request target [/acas/api/v1//standardization/execute?username=bob&reason=[] ]. The valid characters are defined in RFC 7230 and RFC 3986
acas-roo-1  |           at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:494)
acas-roo-1  |           at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:271)
acas-roo-1  |           at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
acas-roo-1  |           at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:890)
acas-roo-1  |           at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1743)
acas-roo-1  |           at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
acas-roo-1  |           at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
acas-roo-1  |           at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
acas-roo-1  |           at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
acas-roo-1  |           at java.base/java.lang.Thread.run(Unknown Source)
acas
```

## Related Issue
ACAS-593

## How Has This Been Tested?
Executed standardization with `[]` characters as the reason and verified the error
Updated with the new code and verified the error is not thrown
Verified in the database that the `[]` was stored correctly:

```
acas=> select standardization_reason from standardization_history order by id desc limit 1;
 standardization_reason 
------------------------
 []
(1 row)

```