### PR TITLE
Mismatch between load experiment instructions and browse select behavior

### DIFF
--- a/modules/Components/src/client/BasicFileValidateAndSave.coffee
+++ b/modules/Components/src/client/BasicFileValidateAndSave.coffee
@@ -112,32 +112,20 @@ class BasicFileValidateAndSaveController extends Backbone.View
 		@imagesFileNameOnServer = null
 
 	validateParseFile: =>
-		
-		# check the number of files uploaded by checking the number of rows in the table of uploaded files
-		# if it is more than one, we want to block the validation 
-		filesUploaded = @$(".files tr.template-download").length
-
-		if filesUploaded == 1
-			if @parseFileUploaded and not @$(".bv_next").attr('disabled')
-				@notificationController.clearAllNotificiations()
-				@$('.bv_validateStatusDropDown').modal
-					backdrop: "static"
-				@$('.bv_validateStatusDropDown').modal "show"
-				dataToPost = @prepareDataToPost(true)
-				$.ajax
-					type: 'POST'
-					url: @fileProcessorURL
-					data: dataToPost
-					success: @handleValidationReturnSuccess
-					error: (err) =>
-						@$('.bv_validateStatusDropDown').modal("hide")
-					dataType: 'json',
-		else
-			# if there are multiple files show warning, clear the table, bring back the upload button
-			@$(".bv_multipleFileWarning").show()
-			@$('.bv_manualFileSelect').css("display", "block")
-			@$(".files").html ""
-	
+		if @parseFileUploaded and not @$(".bv_next").attr('disabled')
+			@notificationController.clearAllNotificiations()
+			@$('.bv_validateStatusDropDown').modal
+				backdrop: "static"
+			@$('.bv_validateStatusDropDown').modal "show"
+			dataToPost = @prepareDataToPost(true)
+			$.ajax
+				type: 'POST'
+				url: @fileProcessorURL
+				data: dataToPost
+				success: @handleValidationReturnSuccess
+				error: (err) =>
+					@$('.bv_validateStatusDropDown').modal("hide")
+				dataType: 'json',
 
 	parseAndSave: =>
 		if @parseFileUploaded and @filePassedValidation

--- a/modules/Components/src/client/BasicFileValidateAndSave.coffee
+++ b/modules/Components/src/client/BasicFileValidateAndSave.coffee
@@ -20,7 +20,7 @@ class BasicFileValidateAndSaveController extends Backbone.View
 	template: _.template($("#BasicFileValidateAndSaveView").html())
 
 	events:
-		'click .bv_next' : 'validateParseFile'
+		'click .bv_next' : 'validateParseFile' 
 		'click .bv_save' : 'parseAndSave'
 		'click .bv_back' : 'backToUpload'
 		'click .bv_loadAnother' : 'loadAnother'
@@ -112,22 +112,32 @@ class BasicFileValidateAndSaveController extends Backbone.View
 		@imagesFileNameOnServer = null
 
 	validateParseFile: =>
-		if @parseFileUploaded and not @$(".bv_next").attr('disabled')
-			@notificationController.clearAllNotificiations()
-			@$('.bv_validateStatusDropDown').modal
-				backdrop: "static"
-			@$('.bv_validateStatusDropDown').modal "show"
-			dataToPost = @prepareDataToPost(true)
-			$.ajax
-				type: 'POST'
-				url: @fileProcessorURL
-				data: dataToPost
-				success: @handleValidationReturnSuccess
-				error: (err) =>
-					@$('.bv_validateStatusDropDown').modal("hide")
-				dataType: 'json',
+		
+		# check the number of files uploaded by checking the number of rows in the table of uploaded files
+		# if it is more than one, we want to block the validation 
+		filesUploaded = @$(".files tr.template-download").length
 
-
+		if filesUploaded == 1
+			if @parseFileUploaded and not @$(".bv_next").attr('disabled')
+				@notificationController.clearAllNotificiations()
+				@$('.bv_validateStatusDropDown').modal
+					backdrop: "static"
+				@$('.bv_validateStatusDropDown').modal "show"
+				dataToPost = @prepareDataToPost(true)
+				$.ajax
+					type: 'POST'
+					url: @fileProcessorURL
+					data: dataToPost
+					success: @handleValidationReturnSuccess
+					error: (err) =>
+						@$('.bv_validateStatusDropDown').modal("hide")
+					dataType: 'json',
+		else
+			# if there are multiple files show warning, clear the table, bring back the upload button
+			@$(".bv_multipleFileWarning").show()
+			@$('.bv_manualFileSelect').css("display", "block")
+			@$(".files").html ""
+	
 
 	parseAndSave: =>
 		if @parseFileUploaded and @filePassedValidation

--- a/modules/Components/src/client/LSFileChooser.coffee
+++ b/modules/Components/src/client/LSFileChooser.coffee
@@ -148,6 +148,7 @@ class LSFileChooserController extends Backbone.View
 			acceptFileTypes: RegExp('(\\.|\\/)(' + @allowedFileTypes.join('|') + ')$', 'i')
 			autoUpload: self.autoUpload
 			dropZone:  @$('.' + self.dropZoneClassId)
+			maxNumberOfFiles: @maxNumberOfFiles
 		})
 		
 		@$('.' + @dropZoneClassId).bind('mouseover', (e) -> @mouseIsInDropField = true)
@@ -162,5 +163,8 @@ class LSFileChooserController extends Backbone.View
 		@$('.fileupload').bind('fileUploadFailed', @fileUploadComplete)
 		@$('.fileupload').bind('fileuploaddestroyed', @handleDeleteFileUIChanges)
 		#@$('.fileupload').bind('fileuploadstopped', @handleDeleteFileUIChanges)
+
+		if @maxNumberOfFiles == 1
+			@$(".fileinput-button input").attr("multiple", false)
 
 		

--- a/modules/Components/src/client/LSFileChooserView.html
+++ b/modules/Components/src/client/LSFileChooserView.html
@@ -6,9 +6,6 @@
 					<span>Browse Files...</span>
 					<input type="file" name="files[]" multiple>
 				</span>
-                <br/>
-                <br/>
-                <div class="bv_multipleFileWarning hide" style="color: red; font-size: 12px; text-align: left;">Sorry, you can only upload one file at a time. Please choose one file and try again.</div>
 			</div>
 			<div class="span7 well <%- dropZoneClassId %>" style="display: none; text-align: center">
 				<h4 class='bv_dragOverMessage'><%- dragOverMessage %></h4>

--- a/modules/Components/src/client/LSFileChooserView.html
+++ b/modules/Components/src/client/LSFileChooserView.html
@@ -4,7 +4,7 @@
 			<div class="span7 bv_manualFileSelect" style="padding-left:50px;">
 				<span class="btn fileinput-button">
 					<span>Browse Files...</span>
-					<input type="file" name="files[]">
+					<input type="file" name="files[]" multiple>
 				</span>
                 <br/>
                 <br/>

--- a/modules/Components/src/client/LSFileChooserView.html
+++ b/modules/Components/src/client/LSFileChooserView.html
@@ -6,6 +6,9 @@
 					<span>Browse Files...</span>
 					<input type="file" name="files[]">
 				</span>
+                <br/>
+                <br/>
+                <div class="bv_multipleFileWarning hide" style="color: red; font-size: 12px; text-align: left;">Sorry, you can only upload one file at a time. Please choose one file and try again.</div>
 			</div>
 			<div class="span7 well <%- dropZoneClassId %>" style="display: none; text-align: center">
 				<h4 class='bv_dragOverMessage'><%- dragOverMessage %></h4>

--- a/modules/Components/src/client/LSFileChooserView.html
+++ b/modules/Components/src/client/LSFileChooserView.html
@@ -4,7 +4,7 @@
 			<div class="span7 bv_manualFileSelect" style="padding-left:50px;">
 				<span class="btn fileinput-button">
 					<span>Browse Files...</span>
-					<input type="file" name="files[]" multiple>
+					<input type="file" name="files[]">
 				</span>
 			</div>
 			<div class="span7 well <%- dropZoneClassId %>" style="display: none; text-align: center">

--- a/modules/GenericDataParser/src/client/GenericDataParser.coffee
+++ b/modules/GenericDataParser/src/client/GenericDataParser.coffee
@@ -8,3 +8,30 @@ class GenericDataParserController extends BasicFileValidateAndSaveController
 		@loadImagesFile = true
 		super()
 		@$('.bv_moduleTitle').html("Simple #{window.conf.experiment.label} Loader")
+
+	validateParseFile: =>
+		
+		# check the number of files uploaded by checking the number of rows in the table of uploaded files
+		# if it is more than one, we want to block the validation 
+		filesUploaded = @$(".files tr.template-download").length
+
+		if filesUploaded == 1
+			if @parseFileUploaded and not @$(".bv_next").attr('disabled')
+				@notificationController.clearAllNotificiations()
+				@$('.bv_validateStatusDropDown').modal
+					backdrop: "static"
+				@$('.bv_validateStatusDropDown').modal "show"
+				dataToPost = @prepareDataToPost(true)
+				$.ajax
+					type: 'POST'
+					url: @fileProcessorURL
+					data: dataToPost
+					success: @handleValidationReturnSuccess
+					error: (err) =>
+						@$('.bv_validateStatusDropDown').modal("hide")
+					dataType: 'json',
+		else
+			# if there are multiple files show warning, clear the table, bring back the upload button
+			@$(".bv_multipleFileWarning").show()
+			@$('.bv_manualFileSelect').css("display", "block")
+			@$(".files").html ""

--- a/modules/GenericDataParser/src/client/GenericDataParser.coffee
+++ b/modules/GenericDataParser/src/client/GenericDataParser.coffee
@@ -9,15 +9,12 @@ class GenericDataParserController extends BasicFileValidateAndSaveController
 		super()
 		@$('.bv_moduleTitle').html("Simple #{window.conf.experiment.label} Loader")
 
-		# set the number of uploads possible to one
-		@$(".fileinput-button input").attr("multiple", false)
-
 	validateParseFile: =>
 		
 		# check the number of files uploaded by checking the number of rows in the table of uploaded files
 		# if it is more than one, we want to block the validation 
 		# it is possible for the user to upload more than one via drag and drop even if the button only allows one upload
-		filesUploaded = @$(".files tr.template-download").length
+		filesUploaded = @$(".files tr").length
 
 		if filesUploaded == 1
 			if @parseFileUploaded and not @$(".bv_next").attr('disabled')
@@ -34,8 +31,4 @@ class GenericDataParserController extends BasicFileValidateAndSaveController
 					error: (err) =>
 						@$('.bv_validateStatusDropDown').modal("hide")
 					dataType: 'json',
-		else
-			# if there are multiple files show warning, clear the table, bring back the upload button
-			@$(".bv_multipleFileWarning").show()
-			@$('.bv_manualFileSelect').css("display", "block")
-			@$(".files").html ""
+

--- a/modules/GenericDataParser/src/client/GenericDataParser.coffee
+++ b/modules/GenericDataParser/src/client/GenericDataParser.coffee
@@ -9,10 +9,14 @@ class GenericDataParserController extends BasicFileValidateAndSaveController
 		super()
 		@$('.bv_moduleTitle').html("Simple #{window.conf.experiment.label} Loader")
 
+		# set the number of uploads possible to one
+		@$(".fileinput-button input").attr("multiple", false)
+
 	validateParseFile: =>
 		
 		# check the number of files uploaded by checking the number of rows in the table of uploaded files
 		# if it is more than one, we want to block the validation 
+		# it is possible for the user to upload more than one via drag and drop even if the button only allows one upload
 		filesUploaded = @$(".files tr.template-download").length
 
 		if filesUploaded == 1


### PR DESCRIPTION
## Description
Instructional text for 'Load Experiment' says to 'select a file', but the file-browser GUI is multi select. This has caused issues where users may think they are uploading many experiments but are only uploading one. 

To fix this, the "Browse Files..." button only allows users to select one file while uploading. Since users can also drag and drop multiple instead of using the "Browse Files..." button, logic was put in place to block validation when multiple files are trying to be uploaded. A error message explains that only one file can be uploaded at a time when this is attempted. 

## How Has This Been Tested?
Tried to use the "Browse Files..." button to select multiple files (no longer possible). Dragged and dropped multiple files and tried to upload them and saw that validation/upload was blocked. Subsequently tried with single files to ensure that the uploading and validation still worked. 
