### PR TITLE
Improving Reporting of Overwritten Experiments 

### DIFF
--- a/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
+++ b/modules/ExperimentBrowser/src/client/ExperimentBrowser.coffee
@@ -295,7 +295,7 @@ class ExperimentSummaryTableController extends Backbone.View
 			$(".bv_noMatchingExperimentsFoundMessage"+@domSuffix).addClass "hide"
 			@collection.each (exp) =>
 				canViewDeleted = @canViewDeleted(exp)
-				if exp.getStatus().get('codeValue') is 'deleted'
+				if exp.getStatus().get('codeValue') is 'deleted' || exp.getStatus().get('codeValue') is 'overwritten'
 					if canViewDeleted
 						ersc = new ExperimentRowSummaryController
 							model: exp
@@ -492,7 +492,7 @@ class ExperimentBrowserController extends Backbone.View
 		$(".bv_experimentBaseController").removeClass("hide")
 		$(".bv_experimentBaseControllerContainer").removeClass("hide")
 		$('.bv_experimentBaseController').html @experimentController.render().el
-		if experiment.getStatus().get('codeValue') is "deleted"
+		if experiment.getStatus().get('codeValue') is "deleted" || experiment.getStatus().get('codeValue') is "overwritten"
 			@$('.bv_openInQueryTool').hide()
 			@$('.bv_deleteExperiment').hide()
 			@$('.bv_editExperiment').hide() #TODO for future releases, add in hiding duplicateExperiment

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3777,10 +3777,20 @@ deleteOldData <- function(experiment, useExistingExperiment) {
     deleteAnalysisGroupsByExperiment(experiment)
   } else {
     deletedExperimentCodes <- c(experiment$codeName, getPreviousExperimentCodes(experiment))
-    deleteExperiment(experiment)
+    selDeleteExperiment(experiment)
   }
   return(deletedExperimentCodes)
 }
+
+selDeleteExperiment <- function(experiment) {
+  url <- paste0(racas::applicationSettings$client.service.persistence.fullpath, "experiments/seldelete/", experiment$id)
+  response <- deleteURLcheckStatus(url, requireJSON = TRUE)
+  if(response!="") {
+    stopUser (paste0("The loader was unable to delete the ", racas::applicationSettings$client.experiment.label, ". Instead, it got this response: ", response))
+  }
+  return(response)
+}
+
 getPreviousExperimentCodes <- function(experiment) {
   metadataState <- getStatesByTypeAndKind(experiment, "metadata_experiment metadata")[[1]]
   previousCodeValues <- getValuesByTypeAndKind(metadataState, "codeValue_previous experiment code")

--- a/modules/ServerAPI/conf/ExperimentConfJSON.coffee
+++ b/modules/ServerAPI/conf/ExperimentConfJSON.coffee
@@ -330,6 +330,14 @@
 				ignored: false
 			,
 				codeType: "experiment"
+				codeKind: "status"
+				codeOrigin: "ACAS DDICT"
+				code: "overwritten"
+				name: "Overwritten"
+				displayOrder: 60
+				ignored: false
+			,
+				codeType: "experiment"
 				codeKind: "review status"
 				codeOrigin: "ACAS DDICT"
 				code: "in progress"

--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -529,7 +529,6 @@ exports.genericExperimentSearch = (req, res) ->
 				# Filter the allowed projects by the requested projects
 				allowedProjectCodes = _.intersection(allowedProjectCodes, requestedProjectCodes)
 
-			#baseurl = config.all.client.service.persistence.fullpath+"experiments/search?q="+req.params.searchTerm+"&projects=#{encodeURIComponent(allowedProjectCodes.join(','))}"
 			baseurl = config.all.client.service.persistence.fullpath+"experiments/search?q="+req.params.searchTerm+"&includeDeleted="+includeDeleted+"&projects=#{encodeURIComponent(allowedProjectCodes.join(','))}"
 			console.log "baseurl"
 			console.log baseurl

--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -487,7 +487,7 @@ exports.putExperiment = (req, resp) ->
 #			resp.json putExperimentResp
 
 exports.genericExperimentSearch = (req, res) ->
-	if global.specRunnerTestmode
+	if global.specRunnerTestmode 
 		experimentServiceTestJSON = require '../public/javascripts/spec/testFixtures/ExperimentServiceTestJSON.js'
 		if req.params.searchTerm == "no-match"
 			emptyResponse = []
@@ -502,6 +502,19 @@ exports.genericExperimentSearch = (req, res) ->
 			username = req.query.username
 		else
 			username = "none"
+
+		if config.all.client.entity?.viewDeletedRoles?
+			viewDeletedRoles = config.all.client.entity.viewDeletedRoles.split(",")
+		else
+			viewDeletedRoles = []
+		grantedRoles = _.map req.user.roles, (role) ->
+			role.roleEntry.roleName
+		includeDeleted = true
+		if viewDeletedRoles.length > 0
+			includeDeleted = ((_.intersection viewDeletedRoles, grantedRoles).length > 0)
+		else
+			includeDeleted = false
+		
 		authorRoutes = require './AuthorRoutes.js'
 		authorRoutes.allowedProjectsInternal req.user, (statusCode, allowedUserProjects) ->
 			_ = require "underscore"
@@ -516,7 +529,8 @@ exports.genericExperimentSearch = (req, res) ->
 				# Filter the allowed projects by the requested projects
 				allowedProjectCodes = _.intersection(allowedProjectCodes, requestedProjectCodes)
 
-			baseurl = config.all.client.service.persistence.fullpath+"experiments/search?q="+req.params.searchTerm+"&projects=#{encodeURIComponent(allowedProjectCodes.join(','))}"
+			#baseurl = config.all.client.service.persistence.fullpath+"experiments/search?q="+req.params.searchTerm+"&projects=#{encodeURIComponent(allowedProjectCodes.join(','))}"
+			baseurl = config.all.client.service.persistence.fullpath+"experiments/search?q="+req.params.searchTerm+"&includeDeleted="+includeDeleted+"&projects=#{encodeURIComponent(allowedProjectCodes.join(','))}"
 			console.log "baseurl"
 			console.log baseurl
 			serverUtilityFunctions = require './ServerUtilityFunctions.js'


### PR DESCRIPTION
Users often are hampered by apparent 'missing data' when a registrar fails to update the experiment name field.  A new experiment code is generated and the previous ACAS file-data is replaced (overwritten).  In most cases, the current behavior is desired, since it allows trivial adjustments to units, endpoint labels, etc.  But in wrong hands it leads to a confusing state.  Moreover, as registrars it is difficult to even discover such cases and troubleshoot.  Here we want to enhance the Experiment Browser table such that it can be used to recover from such registration failures. 

Scope of This Work 

- Adding "Overwritten" as an "Experiment Status"
- Show Overwritten Experiments in Experiment Browser if the user has client.entity.viewDeletedRoles
- Adding a route in the delete experiment logic that changes the status field 
- Make sure overwritten experiments aren't editable or deletable or openable 