### PR TITLE
Units in experiment endpoint table are not loading

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3595,14 +3595,17 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
  
   
   # when not on a dry run, create protocol and experiment if they do not exist
-  if (!dryRun && newProtocol && errorFree) {
-    protocol <- createNewProtocol(metaData = validatedMetaData, lsTransaction, recordedBy, columnOrderStates)
-
+  if (!dryRun && errorFree) {
+    
     # also save the new endpoints of the protocol 
     saveEndpointCodeTables(selColumnOrderInfo$Units, "column units")
     saveEndpointCodeTables(selColumnOrderInfo$valueKind, "column name")
     saveEndpointCodeTables(selColumnOrderInfo$concUnits, "concentration units")
     saveEndpointCodeTables(selColumnOrderInfo$timeUnit, "time units")
+
+    if (newProtocol) {
+      protocol <- createNewProtocol(metaData = validatedMetaData, lsTransaction, recordedBy, columnOrderStates)
+    }
   }
 
   useExistingExperiment <- inputFormat %in% c("Use Existing Experiment", "Precise For Existing Experiment")


### PR DESCRIPTION
## Description
When an experiment with new column units was uploaded and had an existing protocol, the units were not present in the endpoint table when the experiment was viewed in the experiment browser/editor. 

This was being caused because codetables for new column data were only saved to the database in the case that the experiment was associated with a new protocol. To fix, logic was moved so that codetables would be saved on any valid experiment load. 

## How Has This Been Tested?
Tested by loading an experiment with new column units against an existing protocol. Units were displayed in the experiment when viewed in the experiment browser/editor. 