### PR TITLE
Endpoint rows are still disabled after experiments are deleted

### DIFF
--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -835,12 +835,19 @@ class EndpointListController extends AbstractFormController
 			#url: "/api/experimentsForProtocol/#{protocolCode}" #ExperimentBrowserRoutes.coffee route
 			url: "/api/experiments/protocolCodename/#{protocolCode}" #ExperimentServiceRoutes.coffee route
 			success: (experiments) =>
+
+				# want to remove any ignored or deleted experiments
+				validExperiments = []
+				for experiment in experiments
+					if experiment.ignored == false && experiment.deleted == false
+						validExperiments.push experiment
+
 				#save the experiments so we don't have to retrieve them again 
 				if window.conf.experiment?.mainControllerClassName? and window.conf.experiment.mainControllerClassName is "EnhancedExperimentBaseController"
-					@protocolExperiments = new EnhancedExperimentList experiments
+					@protocolExperiments = new EnhancedExperimentList validExperiments
 				else
-					@protocolExperiments = new ExperimentList experiments
-
+					@protocolExperiments = new ExperimentList validExperiments
+				
 				# set up the initial experiment table 
 				@getExperimentSummaryTable()
 


### PR DESCRIPTION
## Description
In the protocol endpoint manager, endpoint rows are disabled whenever the endpoint is in use by an experiment to prevent discrepancies from occurring. However, it was noticed that the endpoint rows were still disabled when all experiments associated with the protocol using the endpoint were deleted.

This was because there were no steps to ensure that deleted and ignored experiment endpoints were not being considered by the logic that was used to disable the rows. To fix this, a step was added to filter out deleted and ignored experiments. 

## How Has This Been Tested?
Replicated the original issue locally by uploading a protocol, deleting the experiments and seeing if the rows in the protocol endpoint manager were now enabled (which they were). 