### PR TITLE
Download Template button in protocol browser/editor not working

### DIFF
--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -635,7 +635,12 @@ exports.getTemplateSELFile = (req, resp) ->
 			protocolName = _.where(json.lsLabels, {lsKind: "protocol name", ignored: false})[0].labelText
 			
 			protocolMetadata = _.where(json.lsStates, {lsKind: "protocol metadata", ignored: false})[0]
-			protocolProject = _.where(protocolMetadata.lsValues, {lsKind: "project", ignored: false})[0].codeValue
+
+			# get the protocol project if there is one
+			try
+				protocolProject = _.where(protocolMetadata.lsValues, {lsKind: "project", ignored: false})[0].codeValue
+			catch
+				protocolProject = ""
 			
 			# look up the projects and convert the project code to the actual project name
 			userObject={'user':'username':req.session.passport.user.username}


### PR DESCRIPTION
## Description
It was observed that the "Download Template" button in the protocol browser and protocol editor was not working. 

This was caused by logic when creating the .csv template file that could not handle instances where the protocol did not have a project assigned. To fix, logic was added to handle cases where there was no project for a protocol. 

## How Has This Been Tested?
Tested locally with protocols where the "Download Template" button was not previously working and now worked with the added logic. 