### PR TITLE
Update code to experimentCode & name to experimentName

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -307,7 +307,7 @@ exports.getLotDependenciesInternal = (lot, user, allowedProjects, includeLinkedL
 		console.log "Found #{dependencies.linkedExperiments.length} linked experiments to #{lotCorpName}, checking user acls on each experiment"
 
 		# Get the codes and experiments from the server so we can look up project codes and scientist ownership of the experiments
-		experimentCodeList = _.pluck(dependencies.linkedExperiments, "code")
+		experimentCodeList = _.pluck(dependencies.linkedExperiments, "experimentCode")
 
 		# Unique the list just in case there are duplicates (there should not be)
 		experimentCodeList = _.uniq experimentCodeList
@@ -325,11 +325,11 @@ exports.getLotDependenciesInternal = (lot, user, allowedProjects, includeLinkedL
 
 		# Get the acls for the experiments
 		for experiment in experiments
-			console.log "Checking acls for experiment #{experiment.code}"
+			console.log "Checking acls for experiment #{experiment.experimentCodeName}"
 
 			# This returns the acls (read, write, delete of the experiment for the user and allowed project the user has)
 			acls = await experimentServiceRoutes.getExperimentACL(experiment.experiment, user, allowedProjects)
-			idx = _.findIndex(dependencies.linkedExperiments, { code: experiment.experiment.codeName })
+			idx = _.findIndex(dependencies.linkedExperiments, { experimentCode: experiment.experiment.codeName })
 			
 			# The experiment is not readable by the user, then just return the acls in the array of experiments
 			# This way it'know there are experiments linked that aren't readable
@@ -337,7 +337,7 @@ exports.getLotDependenciesInternal = (lot, user, allowedProjects, includeLinkedL
 				console.log "Experiment #{experiment.experiment.codeName} is not readable by user #{user.username}"
 				# If the experiiment is not readable we just want to include the acls but not the experiment code table
 				# We include the acls so that the user can see that there is an experiment linked that they can't read
-				dependencies.linkedExperiments[idx] = {acls: acls, code: null, name: null, ignored: false}
+				dependencies.linkedExperiments[idx] = {acls: acls, experimentCode: null, experimentName: null, ignored: false}
 			else
 				# The experiment is readable so includ the experiment and acls
 				dependencies.linkedExperiments[idx].acls = acls


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In [ACAS-307 | acas-roo-server](https://github.com/mcneilco/acas-roo-server/pull/422) the `/api/v1/metalots/checkDependencies/corpName/{corpName}` route has changed the keys in the `linkedExperiments`
- code > experimentCode
- name > experimentName

`getLotDependenciesInternal` is the function which fetches the lot dependencies and does post processing on the data. Here the code updates the key information across usages.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-307](https://jira.schrodinger.com/browse/ACAS-307)
## How Has This Been Tested?
<!--- Describe how this has been tested -->

- I ran all the acasclient tests
- I verified via the acasclient the API new updated values:
```json
    "batchCodes": [
        "CMPD-0000001-001"
    ],
    "linkedContainers": [],
    "linkedDataExists": true,
    "linkedExperiments": [
        {
            "comments": "CMPD-0000001-001",
            "description": "60 results and 280 raw results",
            "experimentCode": "EXPT-00000001",
            "experimentName": "4 parameter D-R - 2018-05-08",
            "protocolCode": "PROT-00000001",
            "protocolName": "Dose Response Protocol",
            "acls": {
                "read": true,
                "write": true,
                "delete": true
            }
        }
    ],
```