### PR TITLE
Add protocol and analysis group codes to experiments linked to a lot.

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -327,9 +327,7 @@ exports.getLotExperimentDependencies = (lot, user, allowedProjects) ->
 			# This returns the acls (read, write, delete of the experiment for the user and allowed project the user has)
 			acls = await experimentServiceRoutes.getExperimentACL(experiment.experiment, user, allowedProjects)
 			idx = _.findIndex(dependencies.linkedExperiments, { code: experiment.experiment.codeName })
-			
-			# The experiment is not readable by the user, then just return the acls in the array of experiments
-			# This way it'know there are experiments linked that aren't readable
+
 			if !acls.getRead()
 				console.log "Experiment #{experiment.experiment.codeName} is not readable by user #{user.username}"
 				# If the experiment is not readable we just want to include the acls but not the experiment code table

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -308,7 +308,7 @@ exports.getAnalysisGroupValues = (analysisGroups) ->
 						value: value
 					})
 		analysisGroupValues.push {
-			codeName: analysisGroup.codeName
+			code: analysisGroup.codeName
 			values: values
 		}
 	return analysisGroupValues

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -284,13 +284,13 @@ exports.getLotDependenciesByCorpNameInternal = (lotCorpName, user, allowedProjec
 
 ###*
 # Get the dependencies for the lot. Dependencies will account for user ACLs.
-# @param {string} lotCorpName - Lot corporate name.
+# @param {object} lot - Lot object.
 # @param {object} user - User object.
-# @param {array} allowedProjects - Array of projects the user has access to.
+# @param {array} allowedProjects - Projects the user has access to.
 ###
-getLotExperimentDependencies = (lot, user, allowedProjects) ->
+exports.getLotExperimentDependencies = (lot, user, allowedProjects) ->
 	lotCorpName = lot.corpName
-	# Get the depdencies from the service which does not cover user ACLS
+	# Get the dependencies from the service which does not cover user ACLS
 	response = await exports.fetchMetaLotDependencies(lotCorpName)
 
 	checkStatus response
@@ -363,7 +363,7 @@ exports.getLotDependenciesInternal = (lot, user, allowedProjects, includeLinkedL
 
 	lotCorpName = lot.corpName
 
-	dependencies = getLotExperimentDependencies lot, user, allowedProjects
+	dependencies = exports.getLotExperimentDependencies lot, user, allowedProjects
 
 	# Look up and attach the acls of the linked lots
 	# Don't show any information except acls if the user cannot read the lot

--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -454,8 +454,7 @@ exports.getLotDependenciesInternal = (lot, user, allowedProjects, includeLinkedL
 
 	lotCorpName = lot.corpName
 
-	dependencies = exports.getLotExperimentDependencies lot, user, allowedProjects
-
+	dependencies = await exports.getLotExperimentDependencies lot, user, allowedProjects
 	# Look up and attach the acls of the linked lots
 	# Don't show any information except acls if the user cannot read the lot
 	# This data is purely informational when considering the dependencies of a lot

--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -817,12 +817,11 @@ exports.experimentsByCodeNamesArrayInternal = (codeNamesArray, returnOption, tes
 		callback "Bulk get experiments saveFailed: " + JSON.stringify error, 500
 
 exports.fetchExperimentsByCodeNames = (codeNamesArray, returnOption) ->
-	url = config.all.client.service.persistence.fullpath+"experiments/codename/jsonArray"
+	url = new URL(config.all.client.service.persistence.fullpath + "experiments/codename/jsonArray")
 	# Add params to fetch
-	urlParams = new URLSearchParams()
 	if returnOption?
-		urlParams.append("with", returnOption)
-	response = await fetch(url + urlParams, method: 'POST', body: JSON.stringify(codeNamesArray), headers: {'Content-Type': 'application/json'})
+		url.searchParams.set("with", returnOption)
+	response = await fetch(url.toString(), method: 'POST', body: JSON.stringify(codeNamesArray), headers: {'Content-Type': 'application/json'})
 	return response
 	
 exports.getExperimentACL = (experiment, user, allowedProjects) ->

--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -555,9 +555,8 @@ exports.getProtocolByLabelInternal = (label, callback) ->
 	)
 
 exports.protocolsByCodeNamesArray = (req, resp) ->
-	exports.protocolsByCodeNamesArrayInternal req.body.data, req.query.option, req.query.testMode, (returnedProts) ->
-		if returnedProts.indexOf("Failed") > -1
-			resp.statusCode = 500
+	exports.protocolsByCodeNamesArrayInternal req.body.data, req.query.option, req.query.testMode, (status, returnedProts) ->
+		resp.statusCode = statusCode
 		resp.json returnedProts
 
 
@@ -584,11 +583,12 @@ exports.protocolsByCodeNamesArrayInternal = (codeNamesArray, returnOption, testM
 			console.log "response.statusCode"
 			console.log response.statusCode
 			console.log response
+
 			if !error && response.statusCode == 200
-				callback json
+				callback 200, json
 			else
 				console.log "Failed: got error in bulk get of protocols"
-				callback "Bulk get protocols saveFailed: " + JSON.stringify error
+				callback 500, "Bulk get protocols saveFailed: " + JSON.stringify error
 		)
 
 exports.bulkPutProtocols= (req, resp) ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have [acas-roo-server: PR](https://github.com/mcneilco/acas-roo-server/pull/422) and [acas: PR](https://github.com/mcneilco/acas/pull/1078) to add more experiment information to the linked experiments of a Lot but I think I could have done it more simply by querying and adding the fields in the acas layer instead of writing specific SQL queries and creating DTO for the data format.

Note:
If we would want the same information to be available across all usages of the `CmpdRegBatchCodeDTO` then it would be reasonable to add all the information in the acas-roo layer but I thought of trying this and getting feedback.

- I have refactored the code to create a separate function that handles ACLs and adds protocol and analysis group information to the experiment object.
- I fixed a bug with `fetchExperimentsByCodeNames` where the URL wasn't getting formatted correctly because of missing "?" between the host and the query params.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-307](https://jira.schrodinger.com/browse/ACAS-307)
## How Has This Been Tested?
<!--- Describe how this has been tested -->

```json
"linkedExperiments": [
    {
        "code": "EXPT-00000001",
        "comments": "CMPD-0000001-001",
        "description": "60 results and 280 raw results",
        "ignored": false,
        "name": "4 parameter D-R - 2018-05-08",
        "acls": {
            "read": true,
            "write": true,
            "delete": true
        },
        "analysisGroups": [
            {
                "codeName": "AG-00000006",
                "values": [
                    {
                        "id": 190,
                        "lsKind": "Key",
                        "lsType": "numericValue",
                        "value": 6
                    },
                    {
                        "id": 193,
                        "lsKind": "Rendering Hint",
                        "lsType": "stringValue",
                        "value": "4 parameter D-R"
                    },
                    {
                        "id": 191,
                        "lsKind": "Max",
                        "lsType": "numericValue",
                        "value": 98.6500950200081
                    },
                    {
                        "id": 194,
                        "lsKind": "Slope",
                        "lsType": "numericValue",
                        "value": -0.821450639331544
                    },
                    {
                        "id": 192,
                        "lsKind": "Min",
                        "lsType": "numericValue",
                        "value": 1.50788601214144
                    },
                    {
                        "id": 189,
                        "lsKind": "EC50",
                        "lsType": "numericValue",
                        "value": 0.562143112495009
                    },
                    {
                        "id": 195,
                        "lsKind": "curve id",
                        "lsType": "stringValue",
                        "value": "f_AG-00000006"
                    }
                ]
            }
        ],
        "protocol": {
            "code": "PROT-00000001",
            "name": "Dose Response Protocol"
        }
    }
]
```

## TODO:
~Add acasclient tests.~