### PR TITLE
SEL template files not properly formatted

### DIFF
--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -799,7 +799,7 @@ exports.getTemplateSELFile = (req, resp) ->
 						csvContent = "data:text/csv;charset=utf-8," 
 
 						# adding the SEL content
-						csvContent = csvContent + "Experiment Metadata\nFormat,Generic\nProtocol Name," + protocolName + 
+						csvContent = csvContent + "Experiment Meta Data\nFormat,Generic\nProtocol Name," + protocolName + 
 						"\nExperiment Name,\nScientist," + protocolScientist + "\nNotebook,\nPage,\nAssay Date," + protocolDate +
 						"\nProject," + protocolProject + "\n\nCalculated Results,\n" + dataTypeRowString + "\n" + endpointNameRowString
 

--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -800,7 +800,7 @@ exports.getTemplateSELFile = (req, resp) ->
 
 						# adding the SEL content
 						csvContent = csvContent + "Experiment Metadata\nFormat,Generic\nProtocol Name," + protocolName + 
-						"\nExperiment Name,,\nScientist," + protocolScientist + "\nNotebook,,\nPage,,\nAssay Date," + protocolDate +
+						"\nExperiment Name,\nScientist," + protocolScientist + "\nNotebook,\nPage,\nAssay Date," + protocolDate +
 						"\nProject," + protocolProject + "\n\nCalculated Results,\n" + dataTypeRowString + "\n" + endpointNameRowString
 
 						resp.json csvContent


### PR DESCRIPTION
## Description
After downloading template SEL files in the protocol browser/editor, there are issues with loading the file into pandas since the .csv is formatted incorrectly due to extra commas that should not be there in the Experiment Meta Data section. Additionally, uploading the file to ACAS after editing would fail due to a typo where "Experiment Meta Data" was "Experiment Metadata". To fix, extra commas were removed and the typo was corrected. 

## How Has This Been Tested?
- Downloaded template SEL file, added data and re-uploaded it into ACAS in both .xlsx and .csv formats
- Used the following code to test if the .csv was formatted properly and both sections could be loaded into pandas: 

```python
import pandas as pd
filename = "download - 2023-02-15T130655.658.csv" # downloaded SEL template file 

# View Experiment Meta Data Table
df = pd.read_csv(filename, skiprows = [8, 9, 10, 11, 12, 13]) # skip the calculated results section and space, just two rows here
print(df)

# View Calculated Results Table 
df = pd.read_csv(filename, skiprows = 10) #skip the experiment metadata section
print(df)
```
