### PR TITLE
Bulkloader purge timeouts after 30 seconds

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -1109,7 +1109,6 @@ class PurgeFilesController extends Backbone.View
 			url: "/api/cmpdRegBulkLoader/purgeFile"
 			data: fileInfo
 			dataType: 'json'
-			timeout: 30000
 			success: (response) =>
 				@$('.bv_purging').hide()
 				if response.success

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -1109,6 +1109,7 @@ class PurgeFilesController extends Backbone.View
 			url: "/api/cmpdRegBulkLoader/purgeFile"
 			data: fileInfo
 			dataType: 'json'
+			timeout: 0
 			success: (response) =>
 				@$('.bv_purging').hide()
 				if response.success

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -353,7 +353,7 @@
 		      <a href="#" class="btn btn-danger bv_confirmPurgeFileButton">Purge File</a>
 		      <a href="#" class="btn btn-primary bv_okay">OK</a>
 			  </span>
-            <span class="bv_purging hide" style="color:red;">Purging...</span>
+            <span class="bv_purging hide" style="color:red;">Purging...(this may take awhile for very large files)</span>
         </div>
     </div>
 

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -353,7 +353,7 @@
 		      <a href="#" class="btn btn-danger bv_confirmPurgeFileButton">Purge File</a>
 		      <a href="#" class="btn btn-primary bv_okay">OK</a>
 			  </span>
-            <span class="bv_purging hide" style="color:red;">Purging...(this may take awhile for very large files)</span>
+            <span class="bv_purging hide" style="color:red;">Purging...</span>
         </div>
     </div>
 


### PR DESCRIPTION
## Description
When trying to purge a very large CmpdReg bulk load file, the UI should wait until the file is purged but it has been reporting an error while the file is still purging. This is due to a timeout after 30 seconds. To fix, I set the ajax request timeout to zero so it would not timeout while purging. 

## How Has This Been Tested?
To recreate and test the issue:  
- Bulkloaded a small file
- Hooked up the debugger to roo and put a breakpoint here:
https://github.com/mcneilco/acas-roo-server/blob/d32a885cbee71d3099e1a8a9faaf4e941536e54c/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java#L2531
- In the UI, click purge
- Wait 30 seconds to reproduce the issue as the breakpoint pauses roo and mimics the long purge time.

Before the fix, an error was thrown after 30 seconds. Afterwards, it would hang for minutes and would complete purging after the breakpoint was toggled to resume the application. 