### PR TITLE
Add special character handling to SEL template file download

### DIFF
--- a/modules/ProtocolBrowser/src/client/ProtocolBrowser.coffee
+++ b/modules/ProtocolBrowser/src/client/ProtocolBrowser.coffee
@@ -459,23 +459,35 @@ class ProtocolBrowserController extends Backbone.View
 				#Since we can't directly send the .csv file to download it...
 				#...we create a hidden link with the download path and automatically click on it
 				# exporting and downloading the file to the user
-				encodedUri = encodeURI(response)
-				a = document.createElement('a');
-				a.style.display = 'none';
-				a.href = encodedUri;
-				a.setAttribute('target', '_blank')
-				document.body.appendChild(a);
-				a.click();
 
-				#Update GUI to indicate succesful download
-				$(".bv_downloadWarning").hide()
-				$(".bv_downloadSuccess").show()
+				# create a Blob object from the CSV string in response
+				csvBlob = new Blob([response], { type: 'text/csv;charset=utf-8;' })
+
+				# create a temporary URL for the Blob object
+				csvUrl = URL.createObjectURL(csvBlob)
+
+				# create a temporary link element to trigger the download
+				downloadLink = document.createElement('a')
+				downloadLink.href = csvUrl
+				downloadLink.download = @protocolController.model.escape('codeName') + "_template.csv"
+
+				# trigger the download by programmatically clicking the link
+				document.body.appendChild(downloadLink)
+				downloadLink.click()
+
+				# clean up by revoking the URL and removing the link element
+				URL.revokeObjectURL(csvUrl)
+				document.body.removeChild(downloadLink)
+
+				# update GUI to indicate succesful download
+				$(".bv_downloadTemplateWarning").hide()
+				$(".bv_downloadTemplateSuccess").show()
 			error: (err) =>
 				console.log "getTemplateSELFile() error:" + err
 				
 				#Update GUI to indicate files could not be downloaded
-				$(".bv_downloadSuccess").hide()
-				$(".bv_downloadWarning").show()
+				$(".bv_downloadTemplateSuccess").hide()
+				$(".bv_downloadTemplateWarning").show()
 
 	
 

--- a/modules/ProtocolBrowser/src/client/ProtocolBrowser.html
+++ b/modules/ProtocolBrowser/src/client/ProtocolBrowser.html
@@ -111,8 +111,8 @@
             <button class="btn bv_editProtocol pull-right" style="margin-left: 0.5em;">Edit</button>
             <button class="btn bv_downloadSELFile pull-right">Download Template</button>
             <br/>
-            <div class="bv_downloadWarning hide" style="color: red; font-size: 12px; text-align: right;">Could not download template file</div>
-            <div class="bv_downloadSuccess hide" style="color: green; font-size: 12px; text-align: right;">Template file downloaded successfully</div>
+            <div class="bv_downloadTemplateWarning hide" style="color: red; font-size: 12px; text-align: right;">Could not download template file</div>
+            <div class="bv_downloadTemplateSuccess hide" style="color: green; font-size: 12px; text-align: right;">Template file downloaded successfully</div>
         </div>
         <hr />
         <div class="">

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -1312,13 +1312,25 @@ class EndpointListController extends AbstractFormController
 				#Since we can't directly send the .csv file to download it...
 				#...we create a hidden link with the download path and automatically click on it
 				# exporting and downloading the file to the user
-				encodedUri = encodeURI(response)
-				a = document.createElement('a');
-				a.style.display = 'none';
-				a.href = encodedUri;
-				a.setAttribute('target', '_blank')
-				document.body.appendChild(a);
-				a.click();
+
+				# create a Blob object from the CSV string in response
+				csvBlob = new Blob([response], { type: 'text/csv;charset=utf-8;' })
+
+				# create a temporary URL for the Blob object
+				csvUrl = URL.createObjectURL(csvBlob)
+
+				# create a temporary link element to trigger the download
+				downloadLink = document.createElement('a')
+				downloadLink.href = csvUrl
+				downloadLink.download = @model.escape('codeName') + "_template.csv"
+
+				# trigger the download by programmatically clicking the link
+				document.body.appendChild(downloadLink)
+				downloadLink.click()
+
+				# clean up by revoking the URL and removing the link element
+				URL.revokeObjectURL(csvUrl)
+				document.body.removeChild(downloadLink)
 
 				#Update GUI to indicate succesful download
 				$(".bv_downloadTemplateWarning").hide()

--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -625,6 +625,7 @@ exports.getTemplateSELFile = (req, resp) ->
 	experimentServiceRoutes = require './ExperimentServiceRoutes.js'
 	csUtilities = require '../src/javascripts/ServerAPI/CustomerSpecificServerFunctions.js'
 	request = require 'request'
+	csv = require 'csv-stringify/sync'
 
 	protocolCode = req.body.protocolCode
 
@@ -794,16 +795,26 @@ exports.getTemplateSELFile = (req, resp) ->
 
 								dataTypeRowString = dataTypeRowString + dataTypeRowEntry
 
+						# Create an array of data for the CSV file
+						data = [  ['Experiment Meta Data'],
+						['Format', 'Generic'],
+						['Protocol Name', protocolName],
+						['Experiment Name', ''],
+						['Scientist', protocolScientist],
+						['Notebook', ''],
+						['Page', ''],
+						['Assay Date', protocolDate],
+						['Project', protocolProject],
+						[''],
+						['Calculated Results'],
+						dataTypeRowString.split(','),
+						endpointNameRowString.split(',')
+						]
 
-						# marking the file as a .csv
-						csvContent = "data:text/csv;charset=utf-8," 
+						# Convert the data to a CSV string
+						csvString = csv.stringify(data, {header: false})
 
-						# adding the SEL content
-						csvContent = csvContent + "Experiment Meta Data\nFormat,Generic\nProtocol Name," + protocolName + 
-						"\nExperiment Name,\nScientist," + protocolScientist + "\nNotebook,\nPage,\nAssay Date," + protocolDate +
-						"\nProject," + protocolProject + "\n\nCalculated Results,\n" + dataTypeRowString + "\n" + endpointNameRowString
-
-						resp.json csvContent
+						resp.json csvString
 
 					else
 						console.log 'got ajax error'

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "url-loader": "4.1.1",
     "winston": "3.3.3",
     "winston-mongodb": "5.0.5",
-    "yamljs": "0.3.0"
+    "yamljs": "0.3.0",
+    "csv-stringify": "6.3.0"
   },
   "devDependencies": {
     "coffeescript": "2.5.1",


### PR DESCRIPTION
## Description
Users of the protocol endpoint manager asked how well the template download feature could handle special characters. To test it, a string of special characters (@"|!#$%&/()=?»«@£§€{}.-;'<>_,") was inserted in different parts of a protocol that was uploaded. When trying to download the template of this protocol, the file was truncated in the middle of the string: 

![image](https://user-images.githubusercontent.com/107148842/225698155-b5f00187-a28d-4945-8bcd-71c8cee7f881.png)

In order to fix, the template file .csv construction was refactored to use the csv-stringify library instead of manually constructing the .csv string. The frontend was also updated to handle the new format. 

A minor bug where the warning/success text for "Download All Files" would also show when hitting the "Download Template" button from the text divs sharing the same class name was fixed as well. 

## How Has This Been Tested?
Tested with the same protocol that was breaking with the original code. While it would no longer break from almost all special characters being included, it can not handle commas (would cause a new cell to appear). 

<img width="1074" alt="Screenshot 2023-03-16 at 1 06 26 PM" src="https://user-images.githubusercontent.com/107148842/225699298-efc55bda-4be9-4c3f-ba8a-bbf2826d9c39.png">

