### PR TITLE
ACAS-612: Provide delete_type and delete_url and noop delete file route

### DIFF
--- a/modules/ServerAPI/src/server/routes/FileServices.coffee
+++ b/modules/ServerAPI/src/server/routes/FileServices.coffee
@@ -92,10 +92,10 @@ setupRoutes = (app, loginRoutes, requireLogin) ->
 							"originalName": file.originalname,
 							"size": file.size,
 							"type": file.mimetype,
-							# Note, the delete_type and delete_url are required by the jquery file upload plugin
+							# Note: the "delete_type" and "delete_url" are required by the jquery file upload plugin
 							# They tell the plugin how to actually delete the file and adjust the maxNumberOfFiles
 							# https://github.com/mcneilco/acas/blob/36f3d6cea0fda97177863818a8ccbc15c60b35c4/public/lib/jqueryFileUpload/js/jquery.fileupload-ui.js#L297
-							# Without it the maxNumberOfFiles is not adjusted and the user can't upload more files
+							# Without it the maxNumberOfFiles is not adjusted and the user can't upload more files even after clicking the delete button on a file
 							"delete_type": "DELETE",
 							"delete_url": "/dataFiles/" + file.filename,
 							"url": "http://#{req.get('Host')}/dataFiles/" + file.filename,
@@ -206,6 +206,9 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.delete '/dataFiles/*', loginRoutes.ensureAuthenticated, exports.deleteFile
 
 exports.deleteFile = (req, resp) ->
+	# Not implemented currently. We added this route in order to fully support the jquery file upload plugin
+	# which requires a delete route in order to function correctly with maxNumberOfFiles.
+	# See details here: https://github.com/mcneilco/acas/pull/1085
 	console.log 'Got DELETE request for data file: ' + req.params[0] + ' from user: ' + req.user.username
 	console.log 'Not deleting file, just returning 200 OK'
 	resp.send 200

--- a/modules/ServerAPI/src/server/routes/FileServices.coffee
+++ b/modules/ServerAPI/src/server/routes/FileServices.coffee
@@ -92,6 +92,12 @@ setupRoutes = (app, loginRoutes, requireLogin) ->
 							"originalName": file.originalname,
 							"size": file.size,
 							"type": file.mimetype,
+							# Note, the delete_type and delete_url are required by the jquery file upload plugin
+							# They tell the plugin how to actually delete the file and adjust the maxNumberOfFiles
+							# https://github.com/mcneilco/acas/blob/36f3d6cea0fda97177863818a8ccbc15c60b35c4/public/lib/jqueryFileUpload/js/jquery.fileupload-ui.js#L297
+							# Without it the maxNumberOfFiles is not adjusted and the user can't upload more files
+							"delete_type": "DELETE",
+							"delete_url": "/dataFiles/" + file.filename,
 							"url": "http://#{req.get('Host')}/dataFiles/" + file.filename,
 							"filePath": file.path
 						}
@@ -193,7 +199,13 @@ setupRoutes = (app, loginRoutes, requireLogin) ->
 
 exports.setupAPIRoutes = (app, loginRoutes) ->
 	setupRoutes app, loginRoutes, false
+	app.delete '/dataFiles/*', exports.deleteFile
 
 exports.setupRoutes = (app, loginRoutes) ->
 	setupRoutes app, loginRoutes, true
+	app.delete '/dataFiles/*', loginRoutes.ensureAuthenticated, exports.deleteFile
 
+exports.deleteFile = (req, resp) ->
+	console.log 'Got DELETE request for data file: ' + req.params[0] + ' from user: ' + req.user.username
+	console.log 'Not deleting file, just returning 200 OK'
+	resp.send 200


### PR DESCRIPTION
## Description
 - Fixes: The "Browse Files..." button for the query-file-upload wasn't being re-enabled after we started setting maxNumberOfFiles in https://github.com/mcneilco/acas/pull/1072
 -   The jQuery file plugin (which we have customized) requires a `delete_type` and `delete_url` returned from the server when uploading a file or it will not reset the maxNumberOfFiles when you click delete.
 - To fix this I added:
   - The `delete_url` and `delete_type` to our upload route
   - A no-op delete route to data files (Didn't implement actual delete because there are lots of implications we have not fully though through yet.



## Related Issue
ACAS-612

## How Has This Been Tested?
Ran through the UI process for uploading an experiment file (refreshed between each bullet point)
   - Upload file, validate, save, load another, (had to click delete file but I think that's normal), upload new file, validate, save
   - Upload file, validate, back, delete file, upload new file, validate, save
   - Verified that I could not multi select
   - Verified that on each delete, I saw an Ajax request to delete the file which noop (logged in the expected message on the server)