### PR TITLE
ACAS-631: Fix wait for persistence in acas.sh

### DIFF
--- a/bin/acas.sh
+++ b/bin/acas.sh
@@ -406,7 +406,7 @@ if [ "$PREPARE_MODULE_CONF_JSON" = "true" ]; then
         persistence_service_url=$client_service_persistence_fullpath/protocoltypes
         wait_between_retries=1
         while true; do
-            # Wait until the backend is up: curl --output /dev/null --silent --head --fail http://${client_service_persistence_host}:${client_service_persistence_port}
+            # Wait until the persistence_service_url returns a non failure status code
             if ! curl --output /dev/null --silent --head --fail $persistence_service_url; then
                 echo "PrepareModuleConfJSON.js: Waiting for $persistence_service_url to be available"
             else

--- a/bin/acas.sh
+++ b/bin/acas.sh
@@ -408,7 +408,7 @@ if [ "$PREPARE_MODULE_CONF_JSON" = "true" ]; then
         while true; do
             # Wait until the persistence_service_url returns a non failure status code
             if ! curl --output /dev/null --silent --head --fail $persistence_service_url; then
-                echo "PrepareModuleConfJSON.js: Waiting for $persistence_service_url to be available"
+                echo "PrepareModuleConfJSON.js: Persistence service url $persistence_service_url unavailable, waiting $wait_between_retries seconds before retrying"
             else
                 echo "PrepareModuleConfJSON.js: Running PrepareModuleConfJSON.js"
                 node $ACAS_HOME/src/javascripts/BuildUtilities/PrepareModuleConfJSON.js
@@ -419,7 +419,6 @@ if [ "$PREPARE_MODULE_CONF_JSON" = "true" ]; then
                     echo "PrepareModuleConfJSON.js: Failed"
                 fi
             fi
-            echo "PrepareModuleConfJSON.js: Waiting $wait_between_retries seconds before retrying"
             sleep $wait_between_retries
         done
     ) &

--- a/bin/acas.sh
+++ b/bin/acas.sh
@@ -399,26 +399,29 @@ until [ -f $ACAS_HOME/conf/compiled/conf.properties  ] || [ $counter == $wait ];
 done
 source /dev/stdin <<< "$(cat $ACAS_HOME/conf/compiled/conf.properties | awk -f $ACAS_HOME/bin/readproperties.awk)"
 
-#Once tomcat is available then try and run prepare module conf json if in environment
+# Once the script is available and the persistence service is up, run PrepareModuleConfJSON.js
 if [ "$PREPARE_MODULE_CONF_JSON" = "true" ]; then
     (
-    cd src/javascripts/BuildUtilities
-    if [ $? -eq 0 ];then
-        counter=0
-        wait=1000
-        until $(curl --output /dev/null --silent --head --fail http://${client_service_persistence_host}:${client_service_persistence_port}) || [ $counter == $wait ]; do
-            sleep 1
-            counter=$((counter+1))
+        # Run this until it succeeds
+        persistence_service_url=$client_service_persistence_fullpath/protocoltypes
+        wait_between_retries=1
+        while true; do
+            # Wait until the backend is up: curl --output /dev/null --silent --head --fail http://${client_service_persistence_host}:${client_service_persistence_port}
+            if ! curl --output /dev/null --silent --head --fail $persistence_service_url; then
+                echo "PrepareModuleConfJSON.js: Waiting for $persistence_service_url to be available"
+            else
+                echo "PrepareModuleConfJSON.js: Running PrepareModuleConfJSON.js"
+                node $ACAS_HOME/src/javascripts/BuildUtilities/PrepareModuleConfJSON.js
+                if [ $? -eq 0 ]; then
+                    echo "PrepareModuleConfJSON.js: Success"
+                    break
+                else
+                    echo "PrepareModuleConfJSON.js: Failed"
+                fi
+            fi
+            echo "PrepareModuleConfJSON.js: Waiting $wait_between_retries seconds before retrying"
+            sleep $wait_between_retries
         done
-        if [ $counter == $wait ]; then
-            echo "waited $wait seconds for acas to start, giving up on prepare module conf json"
-        else
-            node PrepareModuleConfJSON.js
-        fi
-    else
-        echo "${client_service_persistence_host} not available, not waiting for roo to start and not running prepare module conf json"
-    fi
-    cd ../../..
     ) &
 fi
 


### PR DESCRIPTION
## Description
 - At some point the check to see if persistence layer was up started failing i.e. `curl --output /dev/null --silent --head --fail http://${client_service_persistence_host}:${client_service_persistence_port}` returned a fail (status code over 404).  I believe this was when roo was removed
 - This led to intermittent failures of ACAS login on a fresh system as `PrepareModuleConfJSON.js` wouldn't run
 - The fix was to:
   - Have the curl call the protocol types endpoint in the persistence layer to check it is up (returns 200 code)
   - Don't have a wait timeout and just keep running the loop while roo is not up
   - Print to the logs the current status of the script to make it more obvious when it is failing

## Related Issue
ACAS-638

## How Has This Been Tested?
 - Started up a fresh instance and verified the logs looked correct:

```
[acas] PrepareModuleConfJSON.js: Persistence service url http://localhost:8080/acas/api/v1//protocoltypes, waiting 1 seconds before retrying"
[acas] PrepareModuleConfJSON.js: Persistence service url http://localhost:8080/acas/api/v1//protocoltypes, waiting 1 seconds before retrying"
[acas] PrepareModuleConfJSON.js: Running PrepareModuleConfJSON.js
[acas] PrepareModuleConfJSON.js: Success
````

 - Started up a fresh instance and purposefully broke roo:

And verified that script continue to run:
```
[acas] PrepareModuleConfJSON.js: Persistence service url http://localhost:8080/acas/api/v1//protocoltypes, waiting 1 seconds before retrying"
```
