### PR TITLE
Unexpected time values showing up in downloaded SEL template files

### DIFF
--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -705,7 +705,7 @@ exports.getTemplateSELFile = (req, resp) ->
 											endpointConcEntry = j.numericValue
 										if j.lsKind == "column conc units" and j.ignored == false
 											endpointConcUnitsEntry = j.codeValue
-										if j.lsKind = "column time" and j.ignored == false
+										if j.lsKind == "column time" and j.ignored == false
 											endpointTimeEntry = j.numericValue
 										if j.lsKind == "column time units" and j.ignored == false
 											endpointTimeUnitsEntry = j.codeValue
@@ -728,7 +728,6 @@ exports.getTemplateSELFile = (req, resp) ->
 										endpointTimes.push endpointTimeEntry
 										endpointTimeUnits.push endpointTimeUnitsEntry
 										endpointHiddens.push endpointHiddenEntry
-
 						# Part 2: create a CSV file with the endpoints	
 						blankElements = ["NA", "undefined", "", null, undefined]
 


### PR DESCRIPTION
## Description
When downloading an SEL file for a protocol with multiple experiments, I observed that random time values were being inserted into the template that were not in any of the experiments or in the protocol endpoints. Even more strangely, the values would be associated with different endpoints and have different values each download. 

The error was coming from a line in the template file generating logic for endpoint time, where a single `=` was used instead of a `==`, so all arguments were being treated as true and random values that should not have passed the `if` criteria were being accepted and inserted. 

## How Has This Been Tested?
Tested downloading template files for the same protocol before and after the change several times and observed no more random values were being inserted in the time section. 