### PR TITLE
ACAS-646: Update CmpdReg bulkloader picklists to be type ahead (PicklistSelect2Controller) picklists.

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -254,7 +254,7 @@ class AssignedPropertyController extends AbstractFormController
 
 	setupDbPropertiesSelect: ->
 		formattedDbProperties = @formatDbSelectOptions()
-		@dbPropertiesListController = new PickListSelectController
+		@dbPropertiesListController = new PickListSelect2Controller
 			el: @$('.bv_dbProperty')
 			collection: formattedDbProperties
 			insertFirstOption: new PickList
@@ -412,7 +412,7 @@ class AssignSdfPropertiesController extends Backbone.View
 
 	setupTemplateSelect: (templatePickList)->
 		@templateList = templatePickList
-		@templateListController = new PickListSelectController
+		@templateListController = new PickListSelect2Controller
 			el: @$('.bv_useTemplate')
 			collection: @templateList
 			insertFirstOption: new PickList
@@ -424,7 +424,7 @@ class AssignSdfPropertiesController extends Backbone.View
 	setupProjectSelect: ->
 		@projectList = new PickListList()
 		@projectList.url = "/cmpdreg/projects"
-		@projectListController = new PickListSelectController
+		@projectListController = new PickListSelect2Controller
 			el: @$('.bv_dbProject')
 			collection: @projectList
 			insertFirstOption: new PickList
@@ -435,7 +435,7 @@ class AssignSdfPropertiesController extends Backbone.View
 	setupPrefixSelect: ->
 		@prefixList = new PickListList()
 		@prefixList.url = "/cmpdreg/labelPrefixes"
-		@prefixListController = new PickListSelectController
+		@prefixListController = new PickListSelect2Controller
 			el: @$('.bv_labelPrefix')
 			collection: @prefixList
 			insertFirstOption: new PickList

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.css
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.css
@@ -73,3 +73,23 @@
 .bv_browseSdfFile form.fileupload table.table.bv_fileInfo tbody.files tr.template-upload.fade.in td.cancel button.btn.btn-warning.bv_cancelFile i.icon-ban-circle.icon-white{
     display:none;
 }
+
+.bv_bulkReg .bv_configuration .select2 {
+    margin-left:6px;
+}
+
+.bv_bulkReg .bv_assignProperties .select2 {
+    margin-left:20px !important;
+    width: 307px !important;
+}
+
+.bv_bulkReg .error .select2-selection__rendered {
+    /* This is an error select2 so outline it red and color the text red*/
+    color: #b94a48;
+    background-color: #fbded9;
+    border-color: #fbded9;
+    border-style: solid;
+    border-width: 1px;
+}
+
+

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.css
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.css
@@ -84,12 +84,9 @@
 }
 
 .bv_bulkReg .error .select2-selection__rendered {
-    /* This is an error select2 so outline it red and color the text red*/
     color: #b94a48;
-    background-color: #fbded9;
-    border-color: #fbded9;
-    border-style: solid;
-    border-width: 1px;
 }
-
-
+.bv_bulkReg .error .select2-selection {
+    border-color: #b94a48;
+    border-style: solid;
+}

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -212,7 +212,7 @@
     <div class="form-inline" style="margin-bottom:10px;margin-left:0px;">
         <span class="bv_sdfProperty span2" style="margin-top:5px;margin-left:0px;text-align:right;">Corporate ID</span>
         <span class="control-group bv_group_dbProperty">
-            <select class="bv_dbProperty span3" style="margin-left:25px;width:307px;"></select>
+            <select class="bv_dbProperty span3"></select>
         </span>
         <span class="control-group bv_group_defaultVal">
             <input class="bv_defaultVal span2" style="margin-left:20px;width:270px;" type="text"/>

--- a/modules/ServerAPI/src/client/Protocol.css
+++ b/modules/ServerAPI/src/client/Protocol.css
@@ -1,4 +1,4 @@
-.bv_endpointTable .select2, .select2-container, .select2-container--default {
+.bv_endpointTable .select2.select2-container.select2-container--default {
     width: 150px !important;
 }
 


### PR DESCRIPTION
## Description
 - Changed CmpdReg BulkLoader PicklistController to PicklistSelect2Controllers
 - Updating the styling of errors, widths...etc. in the CSS

## Related Issue
ACAS-646

## How Has This Been Tested?
 - Validated and Registered compounds
 - Used the type ahead to narrow list and make selections (see screenshot below)

<img width="945" alt="Screenshot 2023-04-05 at 3 30 38 PM" src="https://user-images.githubusercontent.com/868119/230226684-b89d826f-a7ae-4f29-8d1e-b70dec556f90.png">

 - Verified each of the pick lists rendered the correct Red colors (see screenshot below) when in error states

<img width="974" alt="Screenshot 2023-04-05 at 3 30 30 PM" src="https://user-images.githubusercontent.com/868119/230226649-4b5dfae0-ea20-442d-804e-61c368a44eb5.png">
