### PR TITLE
ACAS-650: Fix report/image file uploading

### DIFF
--- a/modules/GenericDataParser/src/client/GenericDataParser.coffee
+++ b/modules/GenericDataParser/src/client/GenericDataParser.coffee
@@ -8,27 +8,3 @@ class GenericDataParserController extends BasicFileValidateAndSaveController
 		@loadImagesFile = true
 		super()
 		@$('.bv_moduleTitle').html("Simple #{window.conf.experiment.label} Loader")
-
-	validateParseFile: =>
-		
-		# check the number of files uploaded by checking the number of rows in the table of uploaded files
-		# if it is more than one, we want to block the validation 
-		# it is possible for the user to upload more than one via drag and drop even if the button only allows one upload
-		filesUploaded = @$(".files tr").length
-
-		if filesUploaded == 1
-			if @parseFileUploaded and not @$(".bv_next").attr('disabled')
-				@notificationController.clearAllNotificiations()
-				@$('.bv_validateStatusDropDown').modal
-					backdrop: "static"
-				@$('.bv_validateStatusDropDown').modal "show"
-				dataToPost = @prepareDataToPost(true)
-				$.ajax
-					type: 'POST'
-					url: @fileProcessorURL
-					data: dataToPost
-					success: @handleValidationReturnSuccess
-					error: (err) =>
-						@$('.bv_validateStatusDropDown').modal("hide")
-					dataType: 'json',
-


### PR DESCRIPTION
## Description
  - Removed the logic in GenericDataParser around multiple file uploads.  The logic was wrong as it was counting report files and image files when preventing duplicate experiment files. It would then prevent the user from moving forward if they provided a report file or image file with their upload.
  - The reason I just removed the multiple experiment file logic is because the file widget already reports that the second file that was dragged and dropped is invalid, so the behavior that the UI stops the user from clicking next until they remove the invalid file seemed unnecessary. As long as the user knows that one file is valid and the second file uploaded is not valid, then the UI should allow the user to continue.
<img width="1132" alt="Screenshot 2023-04-13 at 10 57 37 AM" src="https://user-images.githubusercontent.com/868119/231844444-4de34bb6-d17d-4469-8c41-b07b34d48f38.png">

## Related Issue
ACAS-650

## How Has This Been Tested?
 - Validated report file and image file attachments work when uploading an experiment file
 - Validated that uploading and experiment file works and that subsequent uploads reports "Max number of files exceeded" but the next button is still enabled if they have one file
  - Validated clearing the experiment uploads allows you to upload a new experiment file

