### PR TITLE
Endpoint manager breaks creating new protocols

### DIFF
--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -798,6 +798,7 @@ class EndpointListController extends AbstractFormController
 		if @options.newProtocol == true
 			@$(".bv_downloadFiles").hide()
 			@$(".bv_endpointManagerInstructions").hide()
+			@endpointControllers = [] # initialize empty endpoint controller list since it won't be automatically made for new protocol 
 
 		#check whether or not to display time and concentration columns in the endpoint table
 		@showTimeAndConcentration()


### PR DESCRIPTION
## Description
When making a new protocol with the Protocol Editor, users were unable to add new endpoints and save the protocol. When users clicked on the "Add Endpoint" button, nothing would happen. This was due to an issue where the @endpointControllers object that is part of adding, removing, and editing endpoint rows was not being initialized for new protocols. To fix, added logic specific for new protocols to initialize this. 

## How Has This Been Tested?
After making the change, successfully created and saved new protocols with endpoints using the endpoint editor. 