### PR TITLE
Download template does not fill endpoints when there are no experiments exist on the protocol

### DIFF
--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -798,7 +798,6 @@ class EndpointListController extends AbstractFormController
 		if @options.newProtocol == true
 			@$(".bv_downloadFiles").hide()
 			@$(".bv_endpointManagerInstructions").hide()
-			@endpointControllers = [] # initialize empty endpoint controller list since it won't be automatically made for new protocol 
 
 		#check whether or not to display time and concentration columns in the endpoint table
 		@showTimeAndConcentration()

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -1068,6 +1068,9 @@ class EndpointListController extends AbstractFormController
 		# Create a new EndpointController, which manages a row
 		# We get the row number from the state which was passed in
 		rowNumber = @getRowNumberForState(state)
+		# If there is a fresh protocol, we need to redefine @endpointControllers which is blank so that we can add controllers
+		if @endpointControllers == undefined
+			@endpointControllers = []
 		# Start tracking the controllers based on their row numbers
 		if @endpointControllers[rowNumber]?
 			@endpointControllers[rowNumber].remove()

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -798,6 +798,7 @@ class EndpointListController extends AbstractFormController
 		if @options.newProtocol == true
 			@$(".bv_downloadFiles").hide()
 			@$(".bv_endpointManagerInstructions").hide()
+			@endpointControllers = [] # initialize empty endpoint controller list since it won't be automatically made for new protocol 
 
 		#check whether or not to display time and concentration columns in the endpoint table
 		@showTimeAndConcentration()
@@ -1068,9 +1069,6 @@ class EndpointListController extends AbstractFormController
 		# Create a new EndpointController, which manages a row
 		# We get the row number from the state which was passed in
 		rowNumber = @getRowNumberForState(state)
-		# If there is a fresh protocol, we need to redefine @endpointControllers which is blank so that we can add controllers
-		if @endpointControllers == undefined
-			@endpointControllers = []
 		# Start tracking the controllers based on their row numbers
 		if @endpointControllers[rowNumber]?
 			@endpointControllers[rowNumber].remove()

--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -692,6 +692,9 @@ exports.getTemplateSELFile = (req, resp) ->
 
 						endpointStrings = []
 
+						# set the default value to true unless otherwise specified
+						protocolHasEndpoints = true
+						
 						# if the protocol has no experiments, use the defined endpoint information in the protocol 
 						if experiments.length == 0
 							protocolEndpoints = _.where(json.lsStates, {lsKind: "data column order", ignored: false})
@@ -699,7 +702,6 @@ exports.getTemplateSELFile = (req, resp) ->
 							if protocolEndpoints.length == 0
 								protocolHasEndpoints = false 
 							else
-								protocolHasEndpoints = true
 								# if it does, we want to extract them and format them for the template file
 								for i in protocolEndpoints
 									# create NAs for each entry in case we don't find a variable, we'll plug these in instead
@@ -714,23 +716,16 @@ exports.getTemplateSELFile = (req, resp) ->
 
 									for j in i.lsValues
 										# only looking at the data that is not ignored
-										# TODO - add try/catch 
-										if j.lsKind == "column name" and j.ignored == false
-											endpointNamesEntry = j.codeValue
-										if j.lsKind == "column units" and j.ignored == false
-											endpointUnitsEntry = j.codeValue
-										if j.lsKind == "column type" and j.ignored == false
-											endpointDataTypeEntry = j.codeValue
-										if j.lsKind == "column concentration" and j.ignored == false
-											endpointConcEntry = j.numericValue
-										if j.lsKind == "column conc units" and j.ignored == false
-											endpointConcUnitsEntry = j.codeValue
-										if j.lsKind = "column time" and j.ignored == false
-											endpointTimeEntry = j.numericValue
-										if j.lsKind == "column time units" and j.ignored == false
-											endpointTimeUnitsEntry = j.codeValue
-										if j.lsTypeAndKind == "codeValue_hide column" and j.ignored == false
-											endpointHiddenEntry = j.codeValue
+										if not j.ignored
+											switch j.lsKind
+												when "column name" then endpointNamesEntry = j.codeValue
+												when "column units" then endpointUnitsEntry = j.codeValue
+												when "column type" then endpointDataTypeEntry = j.codeValue
+												when "column concentration" then endpointConcEntry = j.numericValue
+												when "column conc units" then endpointConcUnitsEntry = j.codeValue
+												when "column time" then endpointTimeEntry = j.numericValue
+												when "column time units" then endpointTimeUnitsEntry = j.codeValue
+												when "codeValue_hide column" then endpointHiddenEntry = j.codeValue
 
 									# create a string of all the different sections put together to identify duplicates
 									endpointString = endpointNamesEntry + endpointUnitsEntry + endpointDataTypeEntry + String(endpointConcEntry) + endpointConcUnitsEntry + String(endpointTimeEntry) + endpointTimeUnitsEntry
@@ -751,7 +746,6 @@ exports.getTemplateSELFile = (req, resp) ->
 
 						# if the protocol has experiments, collect all the endpoint information available
 						else 
-							protocolHasEndpoints = true
 							for experiment in experiments
 								for i in experiment.lsStates
 									#go through the experiment data to check if the endpoint data is there
@@ -769,23 +763,16 @@ exports.getTemplateSELFile = (req, resp) ->
 
 										for j in i.lsValues
 											# only looking at the data that is not ignored
-											# TODO - add try/catch 
-											if j.lsKind == "column name" and j.ignored == false
-												endpointNamesEntry = j.codeValue
-											if j.lsKind == "column units" and j.ignored == false
-												endpointUnitsEntry = j.codeValue
-											if j.lsKind == "column type" and j.ignored == false
-												endpointDataTypeEntry = j.codeValue
-											if j.lsKind == "column concentration" and j.ignored == false
-												endpointConcEntry = j.numericValue
-											if j.lsKind == "column conc units" and j.ignored == false
-												endpointConcUnitsEntry = j.codeValue
-											if j.lsKind = "column time" and j.ignored == false
-												endpointTimeEntry = j.numericValue
-											if j.lsKind == "column time units" and j.ignored == false
-												endpointTimeUnitsEntry = j.codeValue
-											if j.lsTypeAndKind == "codeValue_hide column" and j.ignored == false
-												endpointHiddenEntry = j.codeValue
+											if not j.ignored
+												switch j.lsKind
+													when "column name" then endpointNamesEntry = j.codeValue
+													when "column units" then endpointUnitsEntry = j.codeValue
+													when "column type" then endpointDataTypeEntry = j.codeValue
+													when "column concentration" then endpointConcEntry = j.numericValue
+													when "column conc units" then endpointConcUnitsEntry = j.codeValue
+													when "column time" then endpointTimeEntry = j.numericValue
+													when "column time units" then endpointTimeUnitsEntry = j.codeValue
+													when "codeValue_hide column" then endpointHiddenEntry = j.codeValue
 
 										# create a string of all the different sections put together to identify duplicates
 										endpointString = endpointNamesEntry + endpointUnitsEntry + endpointDataTypeEntry + String(endpointConcEntry) + endpointConcUnitsEntry + String(endpointTimeEntry) + endpointTimeUnitsEntry

--- a/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ProtocolServiceRoutes.coffee
@@ -692,9 +692,62 @@ exports.getTemplateSELFile = (req, resp) ->
 
 						endpointStrings = []
 
-						# if the protocol has no experiments, use the endpoint information in the protocol 
+						# if the protocol has no experiments, use the defined endpoint information in the protocol 
 						if experiments.length == 0
-							protocolHasEndpoints = false 
+							protocolEndpoints = _.where(json.lsStates, {lsKind: "data column order", ignored: false})
+							# if the protocol has no endpoints saved in it, pass
+							if protocolEndpoints.length == 0
+								protocolHasEndpoints = false 
+							else
+								protocolHasEndpoints = true
+								# if it does, we want to extract them and format them for the template file
+								for i in protocolEndpoints
+									# create NAs for each entry in case we don't find a variable, we'll plug these in instead
+									endpointNamesEntry = "NA"
+									endpointUnitsEntry = "NA"
+									endpointDataTypeEntry = "NA"
+									endpointConcEntry = "NA"
+									endpointConcUnitsEntry = "NA"
+									endpointTimeEntry = "NA"
+									endpointTimeUnitsEntry = "NA"
+									endpointHiddenEntry = "NA"
+
+									for j in i.lsValues
+										# only looking at the data that is not ignored
+										# TODO - add try/catch 
+										if j.lsKind == "column name" and j.ignored == false
+											endpointNamesEntry = j.codeValue
+										if j.lsKind == "column units" and j.ignored == false
+											endpointUnitsEntry = j.codeValue
+										if j.lsKind == "column type" and j.ignored == false
+											endpointDataTypeEntry = j.codeValue
+										if j.lsKind == "column concentration" and j.ignored == false
+											endpointConcEntry = j.numericValue
+										if j.lsKind == "column conc units" and j.ignored == false
+											endpointConcUnitsEntry = j.codeValue
+										if j.lsKind = "column time" and j.ignored == false
+											endpointTimeEntry = j.numericValue
+										if j.lsKind == "column time units" and j.ignored == false
+											endpointTimeUnitsEntry = j.codeValue
+										if j.lsTypeAndKind == "codeValue_hide column" and j.ignored == false
+											endpointHiddenEntry = j.codeValue
+
+									# create a string of all the different sections put together to identify duplicates
+									endpointString = endpointNamesEntry + endpointUnitsEntry + endpointDataTypeEntry + String(endpointConcEntry) + endpointConcUnitsEntry + String(endpointTimeEntry) + endpointTimeUnitsEntry
+
+									# if the endpoint is not already in there, record it
+									if endpointString not in endpointStrings
+										endpointStrings.push endpointString							
+
+										# record the endpoint data
+										endpointNames.push endpointNamesEntry
+										endpointUnits.push endpointUnitsEntry
+										endpointDataTypes.push endpointDataTypeEntry
+										endpointConcs.push endpointConcEntry
+										endpointConcUnits.push endpointConcUnitsEntry
+										endpointTimes.push endpointTimeEntry
+										endpointTimeUnits.push endpointTimeUnitsEntry
+										endpointHiddens.push endpointHiddenEntry
 
 						# if the protocol has experiments, collect all the endpoint information available
 						else 


### PR DESCRIPTION
## Description
When users would try to download template files when a protocol had no experiments associated with it, the download would fail. This is because to generate the template file, the backend logic finds all the endpoints associated with each experiment and compiles them to create the file. It doesn't look at the protocol's saved endpoints, and couldn't handle if there were no endpoints at all.

To fix, implemented new logic:

- Check if the protocol has experiments, if it does - extract the endpoints from the experiments and display them in the file
-  If the protocol doesn't have experiments, use the endpoints defined in the protocol
- If the protocol doesn't have any endpoints, don't add the section to the .csv when creating it


## How Has This Been Tested?
Created three protocols: one with experiments uploaded associated with it, one with no experiments and no endpoints, and one with no experiments but several endpoints. 

Tested downloading template files for each. The first protocol with experiments showed all endpoints in all experiments (expected behavior). The second one with no experiments and no endpoints had experiment metadata but no endpoints in the template file (expected behavior). The third protocol with no experiments but endpoints defined in the protocol showed the endpoints defined in the protocol (expected behavior). 