### PR TITLE
ACAS-687: Fix getUrlForNewLiveDesignReportForExperiment API

### DIFF
--- a/modules/ServerAPI/src/server/routes/CreateLiveDesignLiveReportForACAS.coffee
+++ b/modules/ServerAPI/src/server/routes/CreateLiveDesignLiveReportForACAS.coffee
@@ -34,7 +34,7 @@ exports.redirectToNewLiveDesignLiveReportForExperiment = (req, resp) ->
 exports.getUrlForNewLiveDesignLiveReportForExperiment = (req, resp) ->
   exptCode = req.params.experimentCode
   username = req.session.passport.user.username
-  exports.getUrlForNewLiveDesignLiveReportForExperimentInternal exptCode, (status_code, url) ->
+  exports.getUrlForNewLiveDesignLiveReportForExperimentInternal exptCode, username, (status_code, url) ->
     if status_code != 200
       resp.statusCode = status_code
       resp.end url


### PR DESCRIPTION
## Description
- One-liner fix for "username" attribute not being passed to function
Without this fix, the stacktrace is:
```
[ACAS] 2023-06-22T20:39:55.026Z error: 'Caught exception: TypeError: callback is not a function\n' +
--
'    at ChildProcess.<anonymous> (/home/runner/build/routes/CreateLiveDesignLiveReportForACAS.js:109:16)\n' +
'    at ChildProcess.emit (events.js:400:28)\n' +
'    at maybeClose (internal/child_process.js:1088:16)\n' +
'    at Socket.<anonymous> (internal/child_process.js:446:11)\n' +
'    at Socket.emit (events.js:400:28)\n' +
'    at Pipe.<anonymous> (net.js:686:12)'
```

## Related Issue
N/A

## How Has This Been Tested?
I have not tested this, but I have tested that the adjacent route `redirectToNewLiveDesignLiveReportForExperiment` works fine, and this is really the only difference.