### PR TITLE
ACAS-678: Use sketcher_clear API to clear structure in MaestroChemicalStructureController.

### DIFF
--- a/modules/Components/src/client/ACASFormChemicalStructure.coffee
+++ b/modules/Components/src/client/ACASFormChemicalStructure.coffee
@@ -111,7 +111,7 @@ class MaestroChemicalStructureController extends Backbone.View
 			@maestro.sketcherImportText(molStr)
 
 	clear: ->
-		@maestro.clearSketcher()
+		@maestro.sketcher_clear
 
 	isEmptyMol: (molStr) ->
 		if (molStr.indexOf("M  V30 COUNTS 0 0 0 0 0") > -1)

--- a/modules/Components/src/client/ACASFormChemicalStructure.coffee
+++ b/modules/Components/src/client/ACASFormChemicalStructure.coffee
@@ -111,7 +111,7 @@ class MaestroChemicalStructureController extends Backbone.View
 			@maestro.sketcherImportText(molStr)
 
 	clear: ->
-		@maestro.sketcher_clear()
+		@maestro?.sketcher_clear()
 
 	isEmptyMol: (molStr) ->
 		if (molStr.indexOf("M  V30 COUNTS 0 0 0 0 0") > -1)

--- a/modules/Components/src/client/ACASFormChemicalStructure.coffee
+++ b/modules/Components/src/client/ACASFormChemicalStructure.coffee
@@ -111,7 +111,7 @@ class MaestroChemicalStructureController extends Backbone.View
 			@maestro.sketcherImportText(molStr)
 
 	clear: ->
-		@maestro.sketcher_clear
+		@maestro.sketcher_clear()
 
 	isEmptyMol: (molStr) ->
 		if (molStr.indexOf("M  V30 COUNTS 0 0 0 0 0") > -1)


### PR DESCRIPTION
In the ACAS Compound Registration clicking on "New Salt" button produces the following traceback,
```tb
Uncaught TypeError: this.maestro.clearSketcher is not a function
    at MaestroChemicalStructureController.clear (ACASFormChemicalStructure.js:131:27)
    at child.show (Salt.js:174:37)
    at child.showAddSaltPanel (SaltForm.js:229:27)
    at HTMLDivElement.dispatch (jquery-1.7.2.min.js:3:4816)
    at HTMLDivElement.i (jquery-1.7.2.min.js:3:709)
```
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Maestro sketcher has the [clear_sketcher](https://opengrok.schrodinger.com/xref/mmshare/src/wasm/sketcher_app/main.cpp?r=7deab4cd&mo=3452&fi=113#113) API to clear the sketcher. Here, we replace the usage with the correct API. We also clear the sketcher for showing, but I ran into the situation where `maestro` was still not defined, so for now I have added logic to only clear the sketcher if it's available.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACSAS-678](https://jira.schrodinger.com/browse/ACAS-678)

## How Has This Been Tested?
<!--- Describe how this has been tested -->
I was able to reproduce the error on qa-demo-23-2 and then verified after the changes the error is no longer seen. I was able to save a salt and then reopen the sketcher and the sketcher state was clear.
