### PR TITLE
ACAS-674: Bump db version to use the one with pg_trgm extension.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - logs:/home/runner/logs
     command: ["bin/acas.sh", "run", "rservices"]
   db:
-    image: mcneilco/acas-postgres:release-1.13.7
+    image: mcneilco/acas-postgres:release-2023.3.x
     restart: always
     volumes:
      - dbstore:/var/lib/postgresql/data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
See https://github.com/mcneilco/acas-roo-server/pull/445 & https://github.com/mcneilco/acas-postgres/pull/5.

## Description
<!--- Describe your changes in detail -->
Update db image tag to use the one with "pg_trgm" installed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-674](https://jira.schrodinger.com/browse/ACAS-674)

## How Has This Been Tested?
<!--- Describe how this has been tested -->
Verified the new image works with the changes in https://github.com/mcneilco/acas-roo-server/pull/445 without having to manually install pg_trgm extension.