### PR TITLE
ACAS-699: Pass list of projects to backend to filter projects by acls

### DIFF
--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -140,11 +140,11 @@ exports.experimentByName = (req, resp) ->
 		serverUtilityFunctions.getFromACASServer(baseurl, resp)
 
 exports.experimentsByProtocolCodename = (req, resp) ->
-	exports.experimentsByProtocolCodenameInternal req.params.code, req.query.testMode, (status, response) =>
+	exports.experimentsByProtocolCodenameInternal req.params.code, req.user, req.query.testMode, (status, response) =>
 		resp.statusCode = status
 		resp.json response 
 
-exports.experimentsByProtocolCodenameInternal = (code, testMode, callback) ->
+exports.experimentsByProtocolCodenameInternal = (code, user, testMode, callback) ->
 	console.log code
 	console.log testMode
 
@@ -155,8 +155,14 @@ exports.experimentsByProtocolCodenameInternal = (code, testMode, callback) ->
 		config = require '../conf/compiled/conf.js'
 		baseurl = config.all.client.service.persistence.fullpath+"experiments/protocol/"+code
 		serverUtilityFunctions = require './ServerUtilityFunctions.js'
-		serverUtilityFunctions.getFromACASServerInternal baseurl, (statusCode, value) ->
-			callback(statusCode, value)
+		authorRoutes = require './AuthorRoutes.js'
+		authorRoutes.allowedProjectsInternal user, (statusCode, allowedUserProjects) ->
+			_ = require "underscore"
+			allowedProjectCodes = _.pluck(allowedUserProjects, "code")
+			baseurl = "#{baseurl}?projects=#{encodeURIComponent(allowedProjectCodes.join(','))}"
+
+			serverUtilityFunctions.getFromACASServerInternal baseurl, (statusCode, value) ->
+				callback(statusCode, value)
 
 exports.experimentById = (req, resp) ->
 	console.log req.params.id


### PR DESCRIPTION
## Description
 - ACAS node changes for restricting `/api/experiments/protocolCodename/:code`
 - Pass allowed projects to the backend for filtering

## Bug description

**To reproduce**
Create an experiment in a restricted project and login as a user who does not have access to that project.
Go to the protocol browser window and search for the protocol 
Scroll down to the section titled: "Experiments using"
**Expectation**
Experiment in restricted project that the user does not have access to is not displayed
 
**Actual outcome**
Experiment in restricted project that the user does not have access to is displayed.


<img width="943" alt="Screenshot 2023-08-14 at 6 27 03 PM" src="https://github.com/mcneilco/acas/assets/868119/08bf902b-4378-425d-ae82-9a6857612b91">

**Technical details**
This feature relies on the ACAS route here https://github.com/mcneilco/acas/blob/b8719989a424da9ccbc571a84c118d213774eaf3/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee#L32:
	app.get '/api/experiments/protocolCodename/:code', loginRoutes.ensureAuthenticated, exports.experimentsByProtocolCodename
This route does not pay attention to acls and therefore experiments are not filtered.


## Related Issue
ACAS-699

## How Has This Been Tested?
Ran acasclient tests including new tests added here for this case: https://github.com/mcneilco/acasclient/pull/138
