### PR TITLE
ACAS-702: Include analysis group values parameter for faster depedency checks

### DIFF
--- a/modules/CmpdRegAdmin/src/server/routes/CmpdRegAdminRoutes.coffee
+++ b/modules/CmpdRegAdmin/src/server/routes/CmpdRegAdminRoutes.coffee
@@ -322,12 +322,14 @@ exports.reparentLot = (req, resp) ->
 		if !error && response.statusCode == 200
 			if json?.newLot?
 				# Fetch the new lot dependencies and attach it to the json
+				# We don't want to include the analysis group values in the dependencies because this could be a lot of data and be slow
+				includeAnalysisGroupValues = false
 				if dryRun
 					console.log "Dry run is true, returning dependencies for original lot corp name #{json.originalLotCorpName}"
-					dependencies = await cmpdRegRoutes.getLotDependenciesByCorpNameInternal(json.originalLotCorpName, req.session.passport.user, null, true)
+					dependencies = await cmpdRegRoutes.getLotDependenciesByCorpNameInternal(json.originalLotCorpName, req.session.passport.user, null, true, includeAnalysisGroupValues)
 				else
-					console.log "Dry run is false, returning dependencies for original lot corp name #{json.originalLotCorpName}"
-					dependencies = await cmpdRegRoutes.getLotDependenciesInternal(json.newLot, req.session.passport.user, null, true)
+					console.log "Dry run is false, returning dependencies for new lot corp name #{json.newLot}"
+					dependencies = await cmpdRegRoutes.getLotDependenciesInternal(json.newLot, req.session.passport.user, null, true, includeAnalysisGroupValues)
 
 				json.dependencies = dependencies
 			resp.json json


### PR DESCRIPTION
## Description
 - As part of ACAS-307 (https://github.com/mcneilco/acas/pull/1079) we started including analysis group values when fetching lot dependencies which can be very slow if there are a lot of experimental results.
 - The lot details page check lot dependencies when loading the page and therefore the loading of some lot details pages slowed significantly with ACAS-307.
 - This change adds a "include_analysis_group_values" parameter to the python ACAS client `get_lot_dependencies` method and defaults it true for backwards compatibility.
 - This default for the actual acas route is false so the lot details page and any other page which loads dependencies of the lots sees a significant increase in speed.

## Related Issue
ACAS-702

## How Has This Been Tested?
Ran acas client tests
Manually loaded a large 50K line experiment all to the same lot.  Witnessed the very slow lot details page load before the code change.  Applied the code change and verified the lot details page loaded almost instantly.