### PR TITLE
ACAS-700: Make chemist, notebook page and synthesis date editable in the UI by authorized users after lot save.

### DIFF
--- a/modules/CmpdReg/src/client/custom/LotView_Custom.inc
+++ b/modules/CmpdReg/src/client/custom/LotView_Custom.inc
@@ -5,11 +5,11 @@
 		<div>
 			<div>
 				<label class="FormLabel">*Chemist:</label>
-				<select class="FormInput chemist" <%- saved ? 'disabled=true': '' %> ></select>
+				<select class="FormInput chemist" ></select>
 			</div>
 			<div>
 				<label class="FormLabel"><span class="notForVirtual">*</span>Notebook-Page:</label>
-				<input type="textfield" class="FormInput notebookPage" <%- saved ? 'disabled=true': '' %> value="<%- notebookPage %>" />
+				<input type="textfield" class="FormInput notebookPage" value="<%- notebookPage %>" />
 			</div>
 		</div>
 		
@@ -70,7 +70,7 @@
 			</div>
 			<div>
 				<label class="FormLabel"><span class="notForVirtual">*</span>Synthesis Date:</label>
-				<input type="textfield" class="FormInput synthesisDate" <%- saved ? 'disabled=true': '' %> value="<%- synthesisDate %>"/>
+				<input type="textfield" class="FormInput synthesisDate" value="<%- synthesisDate %>"/>
 			</div>
 		</div>
 		<div class="notForVirtual2 notForVirtual">

--- a/modules/CmpdReg/src/client/custom/Lot_Custom.js
+++ b/modules/CmpdReg/src/client/custom/Lot_Custom.js
@@ -361,9 +361,10 @@ $(function () {
         //                this.$('.notForVirtual3').hide();
       }
 
+      this.$('.synthesisDate').datepicker();
+      this.$('.synthesisDate').datepicker("option", "dateFormat", "mm/dd/yy");
+
       if (this.model.isNew()) {
-        this.$('.synthesisDate').datepicker();
-        this.$('.synthesisDate').datepicker("option", "dateFormat", "mm/dd/yy");
         this.$('.editAnalyticalFiles').hide();
         this.$('.analyticalFiles').html('Add analytical files by editing lot after it is saved');
         if (!this.model.get('isVirtual') && this.autoPopulateNextLotNumber) {
@@ -453,9 +454,6 @@ $(function () {
 
       if (this.model.isNew()) {
         this.model.set({
-          notebookPage: jQuery.trim(this.$('.notebookPage').val()),
-          synthesisDate: jQuery.trim(this.$('.synthesisDate').val()),
-          chemist: this.chemistCodeController.getSelectedModel(),
           lotNumber:
             (jQuery.trim(this.$('.lotNumber').val()) == '') ? null :
               parseInt(jQuery.trim(this.$('.lotNumber').val()))
@@ -524,6 +522,8 @@ $(function () {
         if (this.vendorCodeController.getSelectedModel().isNew()) vendor = null;
         else vendor = this.vendorCodeController.getSelectedModel();
         this.model.set({
+          notebookPage: jQuery.trim(this.$('.notebookPage').val()),
+          synthesisDate: jQuery.trim(this.$('.synthesisDate').val()),
           supplier: jQuery.trim(this.$('.supplier').val()),
           supplierID: jQuery.trim(this.$('.supplierID').val()),
           percentEE:


### PR DESCRIPTION
## Description
 - Allows editing of notebook, synthesis date and notebook page fields by users who are able to edit lots.  This is something that is already by the API but restricted via the GUI.

## Related Issue
ACAS-700

## How Has This Been Tested?
Created a lot via the GUI and verified these fields are all still required by the GUI when creating new.
Edited the lot and verified:
  - The fields are required still when editing lot
  - I could edit the lot chemist, synthesis and notebook pages now via the GUI
  - I could not edit these fields as a user a cmpdreg user which did not have access to edit the lot.
