### PR TITLE
ACAS-701: Return status code 404 for get metalot route

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -508,7 +508,7 @@ exports.getMetaLotInternal = (lotCorpName, user, allowedProjects, getDeleteAcl=t
 		checkStatus response
 		metaLot = await response.json()
 		if Object.keys(metaLot).length == 0 || !metaLot.lot?
-			statusCode = 500
+			statusCode = 404
 			err =  "Could not find lot"
 		else
 			acls = await exports.getLotAcls(metaLot.lot, user, allowedProjects, getDeleteAcl)


### PR DESCRIPTION
## Description
 - ACAS should return 404, not 500 when a lot does not exist.  Currently it returns 500 and on certain nginx proxied servers, the 500 error is swallowed and the front end cannot check for the error as it's replaced with an html structure.  Then end result is that the UI hangs when a lot does not exist instead of showing "Lot does not exist" on the page.


## Related Issue
ACAS-702

## How Has This Been Tested?
Ran manual test in the UI to verify that the correct message is displayed.
Ran ACAS client tests and verified tests pass.