### PR TITLE
ACAS-704: Use project_type to determine if project is restricted

### DIFF
--- a/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
+++ b/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
@@ -5,6 +5,7 @@ import re
 from ldclient.client import LDClient
 from ldclient.api.requester import SUPPORTED_SERVER_VERSION
 from ldclient.base import version_str_as_tuple
+from ldclient.enums import ProjectType
 
 import argparse
 import json
@@ -274,7 +275,7 @@ def ld_project_to_acas(ld_project):
         'alias': ld_project.name,
         'active': True if ld_project.active == "Y" else False,
         'ignored': False if ld_project.active == "Y" else True,
-        'isRestricted': ld_project.restricted,
+        'isRestricted': ld_project.project_type not in (ProjectType.GLOBAL, ProjectType.UNRESTRICTED),
         'name': ld_project.name
     }
     return acas_project


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
LiveDesign is deprecating the boolean [Project.restricted](https://opengrok.schrodinger.com/xref/livedesign-client/ldclient/models.py?r=8124826#91) attribute in favour of [Project.project_type](https://opengrok.schrodinger.com/xref/livedesign-client/ldclient/models.py?r=8124826#81) enum attribute to support feature of allowing projects to support the feature of marking projects as "hyper restricted" where the project will not have access to data from unrestricted projects.

I don't have complete context of how ACAS uses the restricted aspect of the project but @brianbolt mentioned that ACAS doesn't really need to differentiate between LiveDesign concept of restricted and hyper restricted.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-704](https://jira.schrodinger.com/browse/ACAS-704)
[SS-39969](https://jira.schrodinger.com/browse/SS-39969) & [SS-43269](https://jira.schrodinger.com/browse/SS-43269) are targeted for `2024.1.0` and so we would also need to publish these changes in `2024.1.x` release once the branch is created.

## How Has This Been Tested?
<!--- Describe how this has been tested -->
I have verified manually by applying the changes on https://hyper-restricted-project-v5.k8s.dev.bb.schrodinger.com/ and uploading an experiment.