### PR TITLE
ACAS-716: Change tag grep to look for release tag format

### DIFF
--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -24,7 +24,7 @@ jobs:
       # and 2022.1.1-dev9 will become 2022.1.1-dev10
       - name: Get next dev tag name
         run: |
-          LAST_TAG=$(git tag --sort=v:refname --merged ${{ env.BRANCH_NAME }} | grep -e '-dev' | tail -1)
+          LAST_TAG=$(git tag --sort=v:refname --merged ${{ env.BRANCH_NAME }} | grep -E '^[0-9]{4}\.[0-9]+\.[0-9]+-dev[0-9]+$' | tail -1)
           echo "NEXT_TAG=$(echo $LAST_TAG | awk -F-dev -v OFS=-dev '{$NF += 1 ; print}')" >> $GITHUB_ENV
       # Trigger the build
       - name: Trigger the tagger workflow with branch ${{env.BRANCH_NAME}} and tag ${{ env.NEXT_TAG }}


### PR DESCRIPTION
## Description
Updated the grep used to identify latest dev tag to be more selective and only look for ####.#.#-dev## formatted tags.

## Related Issue

## How Has This Been Tested?
Ran grep locally and on linux machine to confirm it gives the right result. Have not tested in GitHub actions as it requires this being merged.