### PR TITLE
Update SaltBrowser.coffee to Provide Better Error Display to User

### DIFF
--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -333,7 +333,15 @@ class SaltBrowserController extends Backbone.View
 					console.log(errorMsg)
 					@$('.bv_createSalt').hide()
 					@$('.bv_errorCreatingSaltMessage').show()
-					@$('.bv_createSaltErrorMessageHolder') errorMsg
+					errorData = JSON.parse(errorMsg.responseText)
+					errorContainer = @$('.bv_createSaltErrorMessageHolder')
+					errorContainer.empty()
+					errorContainer.append("<p>Error(s):</p>")
+					errorList = $('<ul class="error-list"></ul>')
+					for error in errorData
+						errorMessage = error.message
+						errorList.append("<li>#{errorMessage}</li>")
+					errorContainer.append(errorList)
 			)
 
 	handleBackConfirmCreateClicked: => 
@@ -392,7 +400,15 @@ class SaltBrowserController extends Backbone.View
 					console.log(errorMsg)
 					@$('.bv_confirmCreateSalt').hide()
 					@$('.bv_errorCreatingSaltMessage').show()
-					@$('.bv_createSaltErrorMessageHolder') errorMsg
+					errorData = JSON.parse(errorMsg.responseText)
+					errorContainer = @$('.bv_createSaltErrorMessageHolder')
+					errorContainer.empty()
+					errorContainer.append("<p>Error(s):</p>")
+					errorList = $('<ul class="error-list"></ul>')
+					for error in errorData
+						errorMessage = error.message
+						errorList.append("<li>#{errorMessage}</li>")
+					errorContainer.append(errorList)
 					@$('.bv_createNotifications').hide()
 			)
 


### PR DESCRIPTION
The following was sourced from this GitHub issue filed by John McNeil: https://github.com/mcneilco/acas/issues/1117

**Expected Behavior**

When you open the CmpdReg Salts browser, click Create New Salt and enter a duplicate salt, you should receive an error that the salt exists


**Previous Behavior**

Follow the above steps, then the form clears and shows this
An error occured creating Salt . Please contact support for additional help.

The console shows:
Uncaught TypeError: this.$(...) is not a function
at Object.error (SaltBrowser.js:453:62)
at k (jquery.min.js:2:16920)
at Object.fireWith [as rejectWith] (jquery.min.js:2:17707)
at y (jquery.min.js:2:80829)
at XMLHttpRequest.d (jquery.min.js:2:86374)

<img width="967" alt="Screenshot 2023-10-19 at 2 14 21 PM" src="https://github.com/mcneilco/acas/assets/97194463/4ad8f68a-62be-445f-b15e-539485142e4f">


**Fix This PR Addresses** 

<img width="1049" alt="Screenshot 2023-10-19 at 2 23 37 PM" src="https://github.com/mcneilco/acas/assets/97194463/9bf51e8e-85e4-4d56-b559-51758d15ff4e">
