### PR TITLE
ACAS-723: Revert edit parents acls

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -42,8 +42,8 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/cmpdReg/api/v1/structureServices/hydrogenizer', loginRoutes.ensureAuthenticated, exports.genericStructureService
 	app.post '/cmpdReg/api/v1/structureServices/cipStereoInfo', loginRoutes.ensureAuthenticated, exports.genericStructureService
 	app.post '/cmpdReg/export/searchResults', loginRoutes.ensureAuthenticated, exports.exportSearchResults
-	app.post '/cmpdReg/validateParent', loginRoutes.ensureAuthenticated, loginRoutes.ensureCmpdRegAdmin, exports.validateParent
-	app.post '/cmpdReg/updateParent', loginRoutes.ensureAuthenticated, loginRoutes.ensureCmpdRegAdmin, exports.updateParent
+	app.post '/cmpdReg/validateParent', loginRoutes.ensureAuthenticated, exports.validateParent
+	app.post '/cmpdReg/updateParent', loginRoutes.ensureAuthenticated, exports.updateParent
 	app.post '/cmpdReg/swapParentStructures', loginRoutes.ensureAuthenticated, loginRoutes.ensureCmpdRegAdmin, exports.swapParentStructures
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata', loginRoutes.ensureAuthenticated, exports.updateLotMetadata
 	app.post '/cmpdReg/api/v1/lotServices/update/lot/metadata/jsonArray', loginRoutes.ensureAuthenticated, exports.updateLotsMetadata


### PR DESCRIPTION
## Description
 - Partially reverting #1047 until we get acls right to edit parent structures
 - No changes to acasclient were required because we commented out a number of the tests previously due to flakiness

## Related Issue
ACAS-723

## How Has This Been Tested?
 - Ran acasclient tests for edit parent
 - Verified I could login as a Creg user (non admin) and edit a parent if I could edit the lot.