### PR TITLE
Enable Docker build caching for ACAS

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -61,13 +61,15 @@ jobs:
           # Check out the branch specified by ACAS_CLIENT_REF
           ref: ${{ env.ACAS_CLIENT_REF }}
       - name: Build (no push)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: false
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ env.ACAS_TAG }}
@@ -111,7 +113,7 @@ jobs:
       - name: Run tests
         run: python -m unittest discover -s ./acasclient -p "test_*.py" -v
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           # Only push tags and release branches
           push: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}
@@ -119,6 +121,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile
           platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ env.ACAS_TAG }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,10 +3,10 @@ name: Docker Image CI
 on:
   push:
     branches: ["master", "release/*"]
+    tags:
+      - "*"
   pull_request:
     types: [opened, synchronize]
-  create:
-    tags: "**"
 jobs:
   acas:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -112,11 +112,12 @@ jobs:
           pip install ./acasclient
       - name: Run tests
         run: python -m unittest discover -s ./acasclient -p "test_*.py" -v
-      - name: Build and push
+      - name: Build multi-arch and push
+        # Only push tags and release branches
+        if: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}
         uses: docker/build-push-action@v5
         with:
-          # Only push tags and release branches
-          push: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile


### PR DESCRIPTION
## Description
ACAS builds take a while. It'd be nice to speed these up by caching docker layers.
I also threw in a change to the triggers of the CI workflow, as it seemed to be overeager and was triggering whenever a new branch was created and pushed, rather than only when tags (refs/tags) were pushed.

## Related Issue

## How Has This Been Tested?
It will be tested by the GHA runs on this PR