### PR TITLE
ACAS-725: Configurable sel created protocol/experiment text default to null

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -506,6 +506,12 @@ server.sel.protocolStatus=created
 server.sel.assayStage=unassigned
 server.sel.validateDoseResponseCurves=true
 
+# Default protocol/experiment description when loaded through experiment loader
+# server.sel.protocolDescription=${client.protocol.label} created by generic data parser
+# server.sel.experimentDescription=${client.experiment.label} created by generic data parser
+server.sel.protocolDescription=
+server.sel.experimentDescription=
+
 # Cron- change to "false" to not start cron jobs on startup
 server.service.cron.startOnRestart=true
 server.service.cron.enable=true

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -2106,7 +2106,7 @@ createNewProtocol <- function(metaData, lsTransaction, recordedBy, columnOrderSt
   
   # Create the protocol
   protocol <- createProtocol(lsTransaction = lsTransaction,
-                             shortDescription=paste0(racas::applicationSettings$client.protocol.label," created by generic data parser"),  
+                             shortDescription=racas::applicationSettings$server.sel.protocolDescription,  
                              recordedBy=recordedBy, 
                              protocolLabels=protocolLabels,
                              protocolStates=protocolStates)
@@ -2273,7 +2273,7 @@ createNewExperiment <- function(metaData, protocol, lsTransaction, pathToGeneric
                                  shortDescription = if(!is.null(metaData$"Short Description"[1])) {
                                    metaData$"Short Description"[1]
                                      } else {
-                                   paste0(racas::applicationSettings$client.experiment.label," created by generic data parser")
+                                   racas::applicationSettings$server.sel.experimentDescription
                                      },  
                                  recordedBy=recordedBy, 
                                  experimentLabels=experimentLabels,


### PR DESCRIPTION
## Description
 - Changes the default short descriptions of protocol/experiments to null
 - Makes configurable the default short descriptions of protocols/experiments
 - This does not automatically set all protocols and experiments previously created to the default settings. This can be accomplished by running the following sqls:

```
update protocol set short_description = null where short_description like '%created by generic data parser';
update experiment set short_description = null where short_description like '%created by generic data parser';
```
## Related Issue
ACAS-725

## How Has This Been Tested?
- Verified in the GUI that the protocol and experiments both had empty descriptions by default
 
<img width="649" alt="Screenshot 2023-11-28 at 10 51 24 AM" src="https://github.com/mcneilco/acas/assets/868119/54b3c66c-5e92-4ba0-a805-c558331bbd91">
<img width="626" alt="Screenshot 2023-11-28 at 10 52 35 AM" src="https://github.com/mcneilco/acas/assets/868119/53015331-1f6a-4bf6-a7d9-802398565a39">
  

- Verified in the database that the protocol and experiments both had empty descriptions by default

```
acas=> select short_description from protocol where short_description is null;
 short_description 
-------------------
 
(1 row)

acas=> select short_description from experiment where short_description is null;
 short_description 
-------------------
 
(1 row)
```

- I then set the configs to the following to restore the default to their previous defaults:
```
server.sel.protocolDescription=${client.protocol.label} created by generic data parser
server.sel.experimentDescription=${client.experiment.label} created by generic data parser
```

- Verified in the GUI that the protocol and experiments both had these values set properly on creation
<img width="648" alt="Screenshot 2023-11-28 at 10 56 39 AM" src="https://github.com/mcneilco/acas/assets/868119/d1c44c75-0fc2-46c8-9194-b8780e579b8d">
<img width="614" alt="Screenshot 2023-11-28 at 10 56 49 AM" src="https://github.com/mcneilco/acas/assets/868119/074f8821-2141-4d5a-b4ed-5bf6791c18ee">

- Verified in the Database that the protocol and experiments both had these values set properly on creation (but didn't grab the text to post here)

- Verified that the sql in the description would set the values to null correctly and that the GUI reflected those changes.
