### PR TITLE
Endpoint manager breaks upload of experiment files with concentration

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -256,7 +256,7 @@ saveEndpointCodeTables <- function(codes, codeKind) {
   }
 
   # we don't want to work with other codeKinds (this is set up for endpoint manager only right now... )
-  validCodeKinds = c("column name", "column units", "concentration units", "time units")
+  validCodeKinds = c("column name", "column units", "column conc units", "time units")
 
   #Before we save the incoming code, we need to check if the code/codeKind pair already exists... 
   #get relevant ddict data
@@ -3664,7 +3664,7 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
     # also save the new endpoints of the protocol 
     saveEndpointCodeTables(selColumnOrderInfo$Units, "column units")
     saveEndpointCodeTables(selColumnOrderInfo$valueKind, "column name")
-    saveEndpointCodeTables(selColumnOrderInfo$concUnits, "concentration units")
+    saveEndpointCodeTables(selColumnOrderInfo$concUnits, "column conc units")
     saveEndpointCodeTables(selColumnOrderInfo$timeUnit, "time units")
 
     if (newProtocol) {


### PR DESCRIPTION
## Description

### Initial Ticket:
Steps to Reproduce:
On a system with endpoint manager turned on
Upload a file that contains a concentration in the column header e.g. "CYP3A4 % Inhibition [10 uM]"

Expected Results:
The file uploads successfully

Actual Results:
ACAS produced this error to the user:
"Internal Error: The loader was unable to save your data. Check the log racas. log at 2023-11-17 21:42:10"

### Cause:
The issue was coming from renaming ```concentration units``` to ```column conc units```, but there was an mistake where not all variables were renamed. 

### Fix:
Renamed ```concentration units``` to ```column conc units```

## How Has This Been Tested?
Tested locally. Tried uploading an experiment file with concentration units and reproduced the initial error , "Internal Error: The loader was unable to save your data". After making the changes, the error was resolved and experiment files could be uploaded again. 


