### PR TITLE
ACAS-712: HRP project type support

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -637,6 +637,9 @@ server.systemTest.runDestructive=false
 # Behavior without this config set to true is to give all users access to all projects
 server.project.roles.enable=true
 
+# Require project type to be returned by project customer specific CustomerSpecificFunctions
+server.project.type.required=false
+
 #Controls whether to try to sync projects list from ACAS to CmpdReg
 server.project.sync.cmpdReg=true
 

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -637,7 +637,7 @@ server.systemTest.runDestructive=false
 # Behavior without this config set to true is to give all users access to all projects
 server.project.roles.enable=true
 
-# Require project type to be returned by project customer specific CustomerSpecificFunctions
+# Require project type to be returned by project CustomerSpecificFunctions
 server.project.type.required=false
 
 #Controls whether to try to sync projects list from ACAS to CmpdReg

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -733,7 +733,7 @@ validateCalculatedResults <- function(calculatedResults, dryRun, curveNames, tes
             switch(projectType,
                     "RESTRICTED" =  !isRestricted | code == projectCode,
                     "HYPER_RESTRICTED" = code == projectCode,
-                    "UNRESTRICTED" = TRUE,
+                    "UNRESTRICTED" = ifelse(identical(type, "HYPER_RESTRICTED"), FALSE, TRUE),
                     "GLOBAL" = ifelse(identical(type, "HYPER_RESTRICTED"), FALSE, TRUE),
                     stopUser(paste0("Project '",projectCode,"' has an invalid type. Please contact your system administrator."))
             )

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -723,7 +723,7 @@ validateCalculatedResults <- function(calculatedResults, dryRun, curveNames, tes
         # Here we are annotating each of the projects with a boolean as to whether it can be used in the experiment if its used by a lot     
         projectsDT[ , projectAllowedForExperiment := {
           # projectType and projectCode are referring to the experiment project
-          # code and isRestricted are referring to the batch project
+          # type, code, and isRestricted are referring to the batch project
           if(is.na(projectType)) {
             # If the project type is na then this is not a system with project type
             # so we just check if the project is restricted and if the lot project is the same as the experiment project

--- a/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
+++ b/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
@@ -369,7 +369,7 @@ exports.getProjectStubsInternal = (callback) ->
 		_.each acasGroupsAndProjects.projects, (project) ->
 			delete project.groups
 			# ACAS-754: Adding project type to project object
-			# For testing purposes only
+			# This is for testing experiment loader with different project types explained in ACAS-754
 			# if project.name == "Global"
 			# 	project.type = "GLOBAL"
 			# else if project.isRestricted

--- a/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
+++ b/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
@@ -368,6 +368,14 @@ exports.getProjectStubsInternal = (callback) ->
 		#remove groups attribute
 		_.each acasGroupsAndProjects.projects, (project) ->
 			delete project.groups
+			# ACAS-754: Adding project type to project object
+			# For testing purposes only
+			# if project.code == "Global"
+			# 	project.type = "GLOBAL"
+			# else if project.isRestricted
+			# 	project.type = "HYPER_RESTRICTED"
+			# else
+			# 	project.type = "UNRESTRICTED"
 		callback response.statusCode, acasGroupsAndProjects.projects
 
 exports.makeServiceRequestHeaders = (user) ->

--- a/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
+++ b/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
@@ -370,7 +370,7 @@ exports.getProjectStubsInternal = (callback) ->
 			delete project.groups
 			# ACAS-754: Adding project type to project object
 			# For testing purposes only
-			# if project.code == "Global"
+			# if project.name == "Global"
 			# 	project.type = "GLOBAL"
 			# else if project.isRestricted
 			# 	project.type = "HYPER_RESTRICTED"

--- a/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
+++ b/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
@@ -276,6 +276,7 @@ def ld_project_to_acas(ld_project):
         'active': True if ld_project.active == "Y" else False,
         'ignored': False if ld_project.active == "Y" else True,
         'isRestricted': ld_project.project_type not in (ProjectType.GLOBAL, ProjectType.UNRESTRICTED),
+        'type': ld_project.project_type,
         'name': ld_project.name
     }
     return acas_project


### PR DESCRIPTION
## Description
 - Support for hyper restricted project "types" returned by some project services
 - Adds config for requiring that project services return project.type when when uploading experiments

## Related Issue
ACAS-712

## How Has This Been Tested?
Ran new acasclient tests with base ACAS system.

To HRP project types, modified the default CustomerSpecificServerFunctions.coffee to include a "type" field.
I also modified the acasclient test messages to match those produced when project types are enabled
Finally, I verified that the final test in acasclient `(Allowed) Unrestricted experiment proj1 with lot restricted proj2` becomes a fail because the lot project is hyper restricted.
