### PR TITLE
ACAS-318: Delete file on Load another

### DIFF
--- a/modules/Components/src/client/BasicFileValidateAndSave.coffee
+++ b/modules/Components/src/client/BasicFileValidateAndSave.coffee
@@ -219,7 +219,9 @@ class BasicFileValidateAndSaveController extends Backbone.View
 		@showFileSelectPhase()
 
 	loadAnother: =>
+		#TODO This is bad style, but the LSFileInputController has no API for deleting and resetting
 		@showFileSelectPhase()
+		@$('.bv_deleteFile').click()
 
 	showFileSelectPhase: ->
 		@$('.bv_resultStatus').hide()


### PR DESCRIPTION
## Description
 - Fixes issue where file is not deleted on "Load Another" by programmatically clicking the delete button.
 - This was kind of a deep issue and there was a previous "hack" found on other modules that did this exact same thing so I went with this solution.

## Related Issue
ACAS-318

## How Has This Been Tested?
![demo](https://github.com/mcneilco/acas/assets/868119/00b8f5e5-ce0b-4cba-9e09-f75b7e220cd1)

