### PR TITLE
ACAS-761: Fix download urls for experiment files containing # special character

### DIFF
--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -872,9 +872,9 @@ class ACASFormLSFileValueFieldController extends ACASFormAbstractFieldController
 			if !displayText?
 				displayText = fileValue
 			if @displayInline
-				@$('.bv_file').html '<img src="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'" alt="'+ displayText+'">'
+				@$('.bv_file').html '<img src="'+window.conf.datafiles.downloadurl.prefix+encodeURIComponent(fileValue)+'" alt="'+ displayText+'">'
 			else
-				@$('.bv_file').html '<a href="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'">'+displayText+'</a>'
+				@$('.bv_file').html '<a href="'+window.conf.datafiles.downloadurl.prefix+encodeURIComponent(fileValue)+'">'+displayText+'</a>'
 			@$('.bv_deleteSavedFile').show()
 
 	createNewFileChooser: ->

--- a/modules/ServerAPI/src/client/AttachFile.coffee
+++ b/modules/ServerAPI/src/client/AttachFile.coffee
@@ -102,14 +102,14 @@ class BasicFileController extends AbstractFormController
 		$(@el).empty()
 		$(@el).html @template(@model.attributes)
 		fileValue = @model.escape('fileValue')
-		urlValue = @model.excape('urlValue')
+		urlValue = @model.escape('urlValue')
 		if ((fileValue is null or fileValue is "" or fileValue is undefined) and (urlValue is null or urlValue is "" or urlValue is undefined))
 			@createNewFileChooser()
 		else
 			if urlValue?
 				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+ encodeURI(urlValue)+'">'+urlValue+'</a></div>'
 			else
-				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'">'+@model.escape('comments')+'</a></div>'
+				@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+window.conf.datafiles.downloadurl.prefix+encodeURIComponent(fileValue)+'">'+@model.escape('comments')+'</a></div>'
 			@$('.bv_recordedBy').html @model.escape("recordedBy")
 			@$('.bv_recordedDate').html UtilityFunctions::convertMSToYMDDate @model.get("recordedDate")
 		@
@@ -249,7 +249,7 @@ class AttachFileController extends BasicFileController
 		if fileValue is null or fileValue is "" or fileValue is undefined
 			@createNewFileChooser()
 		else
-			@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+encodeURI(window.conf.datafiles.downloadurl.prefix+fileValue)+'" target="_blank">'+@model.get('comments')+'</a></div>'
+			@$('.bv_uploadFile').html '<div style="margin-top:5px;margin-left:4px;"> <a href="'+window.conf.datafiles.downloadurl.prefix+encodeURIComponent(fileValue)+'" target="_blank">'+@model.get('comments')+'</a></div>'
 
 		uneditableFileTypes = window.conf.experiment.uneditableFileTypes
 		unless uneditableFileTypes?


### PR DESCRIPTION
## Description
I dug into this a little more and found that there are some subtle differences between `encodeURI` which is meant to encode an entire URL / URI and `encodeURIComponent` which is meant to encode a query string or path component in a URL. For more info: https://stackoverflow.com/questions/75980/when-are-you-supposed-to-use-escape-instead-of-encodeuri-encodeuricomponent

I found that a simple switch to encoding only the `fileValue` with `encodeURIComponent` fixes the issue with `#` characters.

## Related Issue
https://schrodinger.atlassian.net/browse/ACAS-761

## How Has This Been Tested?
- Tested uploading an experiment file whose filename contained `#` and confirmed I could download it again
- Also tested a horrible file with name: `Generic Special Chars ! @ # $ % ^ & * ( ) - _ = + [ ] { } | \ / < > ' " ? ,.xlsx`. This filename gets clobbered during the upload, and gets saved to the ACAS filestore as ` : < > ' %22 ? ,.xlsx`, which is a related but separate bug. Before this fix, that file could not be downloaded from the experiment browser, and after the fix it can be downloaded successfully.