### PR TITLE
ACAS-762: pin node version to resolve build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN   dnf install -y initscripts python3-psycopg2
 
 # node
 ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 18.x
+ENV NODE_VERSION 18.19.1
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
   dnf install -y nodejs
 


### PR DESCRIPTION
## Description
Pinning node version to try to resolve the multi-arch build issue seen on builds like this: https://github.com/mcneilco/acas/actions/runs/8474716596/job/23244535748

`release/2024.1.x` is the earliest release branch w/ Node 18 so I'm planning to merge this, confirm it, then upmerge to `release/2024.2.x`

## Related Issue
ACAS-762

## How Has This Been Tested?
- Ran a docker build locally after this change and confirmed it built successfully