### PR TITLE
ACAS-710: Code value picklists type ahead search

### DIFF
--- a/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
+++ b/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
@@ -41,7 +41,7 @@ exports.validateCodeTablesEntityBeforeSave = (req, resp) ->
 	config = require '../conf/compiled/conf.js'
 	codeTableServiceRoutes = require "./CodeTableServiceRoutes.js"
 	searchTerm = req.params.searchTerm
-	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, (results) ->
+	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, null, (results) ->
 		if !req.body.data?
 			data = req.body
 		else
@@ -105,15 +105,7 @@ exports.searchCodeTablesEntities = (req, resp) ->
 	request = require 'request'
 	config = require '../conf/compiled/conf.js'
 	codeTableServiceRoutes = require "./CodeTableServiceRoutes.js"
-	searchTerm = req.params.searchTerm.toLowerCase().trim()
-	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, (results) ->
-		searchResults = []
-		if searchTerm == "*" || searchTerm == ""
-			searchResults = results
-		else
-			for r in results
-				if (r.code? && r.code.toLowerCase().indexOf(searchTerm) >= 0) || (r.comments? && r.comments.toLowerCase().indexOf(searchTerm) >= 0) || (r.description? && r.description.toLowerCase().indexOf(searchTerm) >= 0) || (r.name? && r.name.toLowerCase().indexOf(searchTerm) >= 0) 
-					searchResults.push(r)
+	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, searchTerm, (results) ->
 		resp.json searchResults
 
 exports.getCodeTablesEntities = (req, resp) ->

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -399,9 +399,9 @@ class ACASFormLSCodeValueFieldController extends ACASFormAbstractFieldController
 			else
 				## Editable picklists can type ahead serch code tables
 				## we want to first populate with the matching value only by adding a shortName parameter
-				@pickList.url = "/api/codetables/#{mdl.get 'codeType'}/#{mdl.get 'codeKind'}/"
+				@pickList.url = "/api/codetables/#{mdl.get 'codeType'}/#{mdl.get 'codeKind'}/?maxHits=100"
 				if mdl.get('value')?
-					@pickList.url = "#{@pickList.url}?shortName=#{mdl.get('value')}"
+					@pickList.url = "#{@pickList.url}&shortName=#{mdl.get('value')}"
 			plOptions =
 				el: @$('.bv_editablePicklist')
 				collection: @pickList

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -439,9 +439,9 @@ class ACASFormLSCodeValueFieldController extends ACASFormAbstractFieldController
 		if @options.autoSavePickListItem? && !@options.autoSavePickListItem
 			plOptions.autoSave = false
 
-		plOptions.autoFetch = false
-		if @options.autoFetch? && @options.autoFetch
-			plOptions.autoFetch = true
+		plOptions.autoFetch = true
+		if @options.autoFetch?
+			plOptions.autoFetch = @options.autoFetch
 		@pickListController = new EditablePickListSelect2Controller plOptions
 		@pickListController.on('change', @handleInputChanged).bind(@)
 		@pickListController.render()

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -439,6 +439,9 @@ class ACASFormLSCodeValueFieldController extends ACASFormAbstractFieldController
 		if @options.autoSavePickListItem? && !@options.autoSavePickListItem
 			plOptions.autoSave = false
 
+		plOptions.autoFetch = false
+		if @options.autoFetch? && @options.autoFetch
+			plOptions.autoFetch = true
 		@pickListController = new EditablePickListSelect2Controller plOptions
 		@pickListController.on('change', @handleInputChanged).bind(@)
 		@pickListController.render()

--- a/modules/Components/src/client/ACASFormFields.coffee
+++ b/modules/Components/src/client/ACASFormFields.coffee
@@ -397,7 +397,11 @@ class ACASFormLSCodeValueFieldController extends ACASFormAbstractFieldController
 			if @url?
 				@pickList.url = @url
 			else
-				@pickList.url = "/api/codetables/#{mdl.get 'codeType'}/#{mdl.get 'codeKind'}"
+				## Editable picklists can type ahead serch code tables
+				## we want to first populate with the matching value only by adding a shortName parameter
+				@pickList.url = "/api/codetables/#{mdl.get 'codeType'}/#{mdl.get 'codeKind'}/"
+				if mdl.get('value')?
+					@pickList.url = "#{@pickList.url}?shortName=#{mdl.get('value')}"
 			plOptions =
 				el: @$('.bv_editablePicklist')
 				collection: @pickList

--- a/modules/Components/src/client/PickList.coffee
+++ b/modules/Components/src/client/PickList.coffee
@@ -372,6 +372,7 @@ class PickListSelect2Controller extends PickListSelectController
 					urlObj = new URL(@collection.url, "http://localhost")
 					searchParams = new URLSearchParams()
 					searchParams.set('labelTextSearchTerm', params.term)
+					searchParams.set('maxHits', "100")
 					urlStr = "#{urlObj.pathname}?#{searchParams.toString()}"
 					return urlStr
 				dataType: 'json'

--- a/modules/Components/src/client/PickList.coffee
+++ b/modules/Components/src/client/PickList.coffee
@@ -361,7 +361,27 @@ class PickListSelect2Controller extends PickListSelectController
 			openOnEnter: false
 			allowClear: true
 			width: @width
-
+			ajax:
+				url: (params) =>
+					if !params.term?
+						params.term = @selectedCode
+					# The URL parameter on for the code service may have e.g. shortName
+					# as a a parameter, so we need to remove it from the URL
+					# we use relative paths url in acas currently so we need to add the full path
+					# to parse the url correctly
+					urlObj = new URL(@collection.url, "http://localhost")
+					searchParams = new URLSearchParams()
+					searchParams.set('labelTextSearchTerm', params.term)
+					urlStr = "#{urlObj.pathname}?#{searchParams.toString()}"
+					return urlStr
+				dataType: 'json'
+				delay: 250
+				processResults: (data, params) =>
+					@latestData = data
+					results = for option in data
+						{id: option.code, text: option.name}
+					return {results: results}
+		
 		@setSelectedCode @selectedCode
 		@rendered = true
 		@

--- a/modules/Components/src/client/PickList.coffee
+++ b/modules/Components/src/client/PickList.coffee
@@ -364,7 +364,7 @@ class PickListSelect2Controller extends PickListSelectController
 			ajax:
 				url: (params) =>
 					if !params.term?
-						params.term = @selectedCode
+						params.term = ''
 					# The URL parameter on for the code service may have e.g. shortName
 					# as a a parameter, so we need to remove it from the URL
 					# we use relative paths url in acas currently so we need to add the full path
@@ -705,6 +705,7 @@ class EditablePickListSelect2Controller extends EditablePickListSelectController
 			collection: @collection
 			selectedCode: @options.selectedCode
 			filters: filters
+			autoFetch: @options.autoFetch
 		if @options.insertFirstOption
 			plOptions.insertFirstOption = @options.insertFirstOption
 		else if @options.parameter?

--- a/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
+++ b/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
@@ -409,7 +409,7 @@ exports.getAllAuthors = (opts, callback) ->
 		# This is was added for the purpose of allowing additional non-authors to show up in picklists throughout ACAS and Creg
 		if opts.additionalCodeType? and opts.additionalCodeKind?
 			codeTableServiceRoutes = require "#{ACAS_HOME}/routes/CodeTableServiceRoutes.js"
-			codeTableServiceRoutes.getCodeTableValuesInternal opts.additionalCodeType, opts.additionalCodeKind, (codes) ->
+			codeTableServiceRoutes.getCodeTableValuesInternal opts.additionalCodeType, opts.additionalCodeKind, null, (codes) ->
 				Array::push.apply json, codes
 				callback statusCode, json
 		else

--- a/modules/ServerAPI/src/server/routes/InventoryServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/InventoryServiceRoutes.coffee
@@ -3034,7 +3034,7 @@ createDaughterVialFileEntryArray = (csvFileName, callback) =>
 	)
 
 dealiasPhysicalStates = (fileEntryArray, callback) ->
-	codeTableRoutes.getCodeTableValuesInternal 'container status', 'physical state', (configuredPhysicalStates) ->
+	codeTableRoutes.getCodeTableValuesInternal 'container status', 'physical state', null, (configuredPhysicalStates) ->
 		cleanedFileEntryArray = _.map fileEntryArray, (entry) ->
 			foundPhysicalState = _.findWhere configuredPhysicalStates, {code: entry.physicalState}
 			if !foundPhysicalState?
@@ -3061,7 +3061,7 @@ checkRequiredAttributes = (fileEntryArray, callback) ->
 	callback requiredAttributeErrors
 
 checkDataTypeErrors = (fileEntryArray, callback) ->
-	codeTableRoutes.getCodeTableValuesInternal 'container status', 'physical state', (configuredPhysicalStates) ->
+	codeTableRoutes.getCodeTableValuesInternal 'container status', 'physical state', null, (configuredPhysicalStates) ->
 		dataTypeErrors = []
 		_.each fileEntryArray, (entry) ->
 			foundPhysicalState = _.findWhere configuredPhysicalStates, {code: entry.physicalState}
@@ -3356,7 +3356,7 @@ updateWellContentSerial = (wellsToUpdate, currentIndex, outerCallback) ->
 			return
 
 prepareSummaryInfo = (fileEntryArray, cb) ->
-	codeTableRoutes.getCodeTableValuesInternal 'container status', 'physical state', (configuredPhysicalStates) ->
+	codeTableRoutes.getCodeTableValuesInternal 'container status', 'physical state', null, (configuredPhysicalStates) ->
 		summaryInfo =
 			totalNumberOfVials: fileEntryArray.length
 			totalsByStates: {}


### PR DESCRIPTION
## Description
 - See related acas-roo-server changes https://github.com/mcneilco/acas/pull/1148
 - Updated code table acas form widget to type ahead search rather than pre-fetch all picklist items.
 - In the case that there is a selected value, it will fetch the selected value only so that the intial value will be set. 

## Related Issue
ACAS-710

## How Has This Been Tested?
- Ran acasclient tests to verify compatability.
- Uploaded thousands of data column/ column tree ls_type / ls_kind values to ddict value and verified the code table fields behaved properly in Experiment editor and protocol editor as well as those in each of the endpoint manage fields.

Demo video
![demo](https://github.com/mcneilco/acas/assets/868119/f1bf345f-39ac-454b-beee-d7bc1be824c3)
