### PR TITLE
ACAS-762 pin npm to get fix for too many connections issue 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_VERSION 18.x
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
   dnf install -y nodejs
+# ACAS-762 temporary fix for npm multi-arch build issue. Remove when Node is updated to > 18.20.1 and fix is confirmed
+RUN npm install npm@10.5.1 -g
 
 # ACAS
 RUN	    useradd -u 1000 -ms /bin/bash runner


### PR DESCRIPTION
## Description
The issue with our builds (ACAS-762) appears to be caused by this npm issue https://github.com/npm/cli/issues/7072 . That issue has been fixed in a new release of npm, but Node hasn't yet made a release. To get our builds unstuck I'd like to pin npm.

## Related Issue
[ACAS-762](https://schrodinger.atlassian.net/browse/ACAS-762)

## How Has This Been Tested?
- [x] Ran an arm build on my mac and confirmed the ACAS image is able to run and successfully starts up node
- [ ] Tried running a multi-arch build on my mac `docker buildx build --platform=linux/arm64,linux/amd64 .` but this got stuck and eventually I cancelled it (after ~8 hours) with this error:
```
=> [linux/amd64 11/19] RUN     npm install -g gulp@4.0.2 forever@3.0.4 coffeescript@2.5.1                       329.3s
 => => # npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokid
 => => # ar 3 with 15x fewer dependencies                                                                              
 => => # npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated     
 => => # npm WARN deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokid
 => => # ar 3 with 15x fewer dependencies                                                                              
 => => # qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

The real test will be running in our CI environment on GH actions.