### PR TITLE
ACAS-764: Clean up cmpdreg exported search results > 24 hours old

### DIFF
--- a/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
+++ b/modules/CmpdReg/src/server/routes/CmpdRegRoutes.coffee
@@ -993,16 +993,19 @@ exports.cleanUpExportedSearchResults = (exportedSearchResults) ->
 					if err?
 						console.log "Error getting stats for file: " + filePath
 					else
-						# Get the last modified time
-						lastModifiedTime = stats.mtime.getTime()
-						# If the file is over a day old then delete it
-						if currentTime - lastModifiedTime > 86400000 # 24 hours in milliseconds
-							fs.unlink(filePath, (err) ->
-								if err?
-									console.log "Error deleting file: " + filePath
-								else
-									console.log "Deleted file: " + filePath
-							)
+						if stats.isFile()
+							# Get the last modified time
+							lastModifiedTime = stats.mtime.getTime()
+							# If the file is over a day old then delete it
+							if currentTime - lastModifiedTime > 86400000 # 24 hours in milliseconds
+								fs.unlink(filePath, (err) ->
+									if err?
+										console.log "Error deleting file: " + filePath
+									else
+										console.log "Deleted file: " + filePath
+								)
+						else
+							console.warn "Skipping cleanup of nonfile: " + filePath
 				)
 	)
 


### PR DESCRIPTION
## Description
 - Delete exported search results that are > 24 hours since last modified after the export searchResults route is called

## Related Issue
ACAS-764

## How Has This Been Tested?
1. Basic
Exported some search results and then ran: `touch -d "25 hours ago" privateUploads/exportedSearchResults/*.sdf`
Verified the files were cleaned up

2. Folder
Added a folder to exportedSearchResults and verified this did not produce and error and was skipped

3. Added a purposeful error inside the `cleanUpExportedSearchResults` function and verified that the exportSearchResults function continue to work (just to make sure this doesn't break export if it happens to error for some reason.

4. Deployed this to a stage server with a lot of old exported search results and verified it cleaned up old files when I exported search results.
