### PR TITLE
ACAS-727: Update to nodejs 20 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN   dnf install -y initscripts python3-psycopg2
 
 # node
 ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 18.x
+ENV NODE_VERSION 20.x
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
   dnf install -y nodejs
 # ACAS-762 temporary fix for npm multi-arch build issue. Remove when Node is updated to > 18.20.1 and fix is confirmed


### PR DESCRIPTION
## Description
 - Bumped nodejs from 18.x to 20.x
 - See equivalent changes for races and acas-roo-server
   - https://github.com/mcneilco/racas/pull/92
   - https://github.com/mcneilco/acas-roo-server/pull/463

## Related Issue
ACAS-727

## How Has This Been Tested?
Ran acasclient tests after building all 3 branches of ACAS-727 locally
Poked around the UI and loaded all module menus, verified drop downs worked.