### PR TITLE
ACAS-769: Fix Bulkloader picklists by only using new type ahead when a url is provided to selection

### DIFF
--- a/modules/Components/src/client/PickList.coffee
+++ b/modules/Components/src/client/PickList.coffee
@@ -355,13 +355,17 @@ class PickListSelect2Controller extends PickListSelectController
 		if @options?.placeholder?
 			@placeholder = @options.placeholder
 
-		$(@el).select2
+		# Define the base options
+		select2Options = 
 			placeholder: @placeholder
 			data: mappedData
 			openOnEnter: false
 			allowClear: true
 			width: @width
-			ajax:
+
+		# Conditionally add the ajax property
+		if @collection.url?
+			select2Options.ajax = 
 				url: (params) =>
 					if !params.term?
 						params.term = ''
@@ -382,6 +386,9 @@ class PickListSelect2Controller extends PickListSelectController
 					results = for option in data
 						{id: option.code, text: option.name}
 					return {results: results}
+
+		# Initialize select2 with the options
+		$(@el).select2(select2Options)
 		
 		@setSelectedCode @selectedCode
 		@rendered = true


### PR DESCRIPTION
## Description
 - Fix for Bulkloader picklists not loading introduced by [ACAS-710](https://github.com/mcneilco/acas/pull/1148)
 - Bulkhead picklist collection does not provide a url so URLs are being formed like this:
   - `/undefined?labelTextSearchTerm=Lo&maxHits=100&term=Lo&q=Lo` and getting 404s
 - The fix is to only use the url if it is set on the collection model.

## Related Issue
ACAS-769

## How Has This Been Tested?
Using breakpoints verified that Protocol Endpoint manager picklists use the Ajax call and function properly.
Using breakpoints verified that CmpdReg bulkloader whose collection is preemptively fetched and does not have a URL, does not try to issue additional Ajax calls and the select2 widget is populated and. works correctly.