### PR TITLE
ACAS-770: Additional project grants configuration

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -652,6 +652,11 @@ client.roles.crossProjectLoaderRole=ROLE_ACAS-CROSS-PROJECT-LOADER
 # e.g. server.projects.filterList = ["SomeProject"]
 server.projects.filterList = []
 
+# Grant access to additionalProjectGrants to users with access to projects
+# e.g. server.projects.additionalProjectGrants = {"PROJ-00000001": ["PROJ-00000002", "PROJ-00000003"]}
+# This would grant access to PROJ-00000002 and PROJ-00000003 to users with access to PROJ-00000001
+server.projects.additionalProjectGrants = {}
+
 # For whether protocols and experiments should have sequential user defined corpName labels
 client.entity.saveInitialsCorpName=false
 


### PR DESCRIPTION
## Description
 - Add new configuration `server.projects.additionalProjectGrants` which confers access to an additional list of projects if the user has access to the project in the key of the configuration.

Example:

```
server.projects.additionalProjectGrants = {"PROJ-00000001": ["PROJ-00000002", "PROJ-00000003"]}
```

This would grant access to PROJ-00000002 and PROJ-00000003 to users with access to PROJ-00000001

## Related Issue
ACAS-770

## How Has This Been Tested?
Test1) Basic test
- Patched the code change onto a server and granted myself only access to PROJ-00000001 through a CustomerSpecificServerFunction configuration.
- I set this config:
`server.projects.additionalProjectGrants =  {"PROJ-00000001": ["PROJ-00000002"]}`

Result:
I could access both "PROJ-00000001" and "PROJ-00000002" 

Test2) Same as test 1 but also verify this works when using the projects.filterList configuration
- I added this config in addition to those in Test1
`server.projects.filterList = ["PROJ-00000001"]`

Result:
I could no longer access "PROJ-00000001" but could still access "PROJ-00000002"
