### PR TITLE
ACAS-768: Fix additional ACAS & CReg scientist module search

### DIFF
--- a/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
+++ b/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
@@ -106,7 +106,7 @@ exports.searchCodeTablesEntities = (req, resp) ->
 	config = require '../conf/compiled/conf.js'
 	codeTableServiceRoutes = require "./CodeTableServiceRoutes.js"
 	searchTerm = req.params.searchTerm.toLowerCase().trim()
-	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, (results) ->
+	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, '', (results) ->
 		searchResults = []
 		if searchTerm == "*" || searchTerm == ""
 			searchResults = results

--- a/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
+++ b/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
@@ -105,7 +105,15 @@ exports.searchCodeTablesEntities = (req, resp) ->
 	request = require 'request'
 	config = require '../conf/compiled/conf.js'
 	codeTableServiceRoutes = require "./CodeTableServiceRoutes.js"
-	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, searchTerm, (results) ->
+	searchTerm = req.params.searchTerm.toLowerCase().trim()
+	codeTableServiceRoutes.getCodeTableValuesInternal req.params.codeType, req.params.codeKind, (results) ->
+		searchResults = []
+		if searchTerm == "*" || searchTerm == ""
+			searchResults = results
+		else
+			for r in results
+				if (r.code? && r.code.toLowerCase().indexOf(searchTerm) >= 0) || (r.comments? && r.comments.toLowerCase().indexOf(searchTerm) >= 0) || (r.description? && r.description.toLowerCase().indexOf(searchTerm) >= 0) || (r.name? && r.name.toLowerCase().indexOf(searchTerm) >= 0) 
+					searchResults.push(r)
 		resp.json searchResults
 
 exports.getCodeTablesEntities = (req, resp) ->


### PR DESCRIPTION
## Description
The search behind the Additional ACAS & Additional CReg scientists admin modules was broken by the changes in #148.
This fix reverts the changes, then updates the function call to `getCodeTableValuesInternal` to match the new expected function signature.

## Related Issue
[ACAS-768](https://schrodinger.atlassian.net/browse/ACAS-768)

## How Has This Been Tested?
- Tested these modules in local dev environment and confirmed search behavior before & after fix