### PR TITLE
ACAS-739: Open in LiveDesign fails fails for image uploads experiments

### DIFF
--- a/modules/ServerAPI/src/server/python/createLiveDesignLiveReportForACAS/create_lr_for_acas.py
+++ b/modules/ServerAPI/src/server/python/createLiveDesignLiveReportForACAS/create_lr_for_acas.py
@@ -372,6 +372,11 @@ def main():
 
     compound_ids=args['input']['compounds']
     assays_to_add=args['input']['assays']
+
+    # Remove the inlineFileValue_ prefix from the resultType
+    for assay_to_add in assays_to_add:
+        assay_to_add['resultType'] = re.sub(r'^inlineFileValue_', '', assay_to_add['resultType'])
+
     experiment_code=args['input']['experimentCode']
     try:
         project=args['input']['project']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the prefix 'inlineFileValue_' from assays_to_add -> resultType

## Related Issue
[ACAS-739](https://schrodinger.atlassian.net/browse/ACAS-739)

## How Has This Been Tested?
Directly edited the code on cluster and the error is no longer on the log stream