### PR TITLE
ACAS-774: Support R-4.4.0 changes

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -1,7 +1,14 @@
 # Example:
 #export LD_LIBRARY_PATH=/usr/lib/oracle/11.2/client64/lib:$LD_LIBRARY_PATH
-LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8.0/jre/lib/amd64:/usr/lib/jvm/java-1.8.0/jre/lib/amd64/server/
-PATH=/usr/pgsql-9.4/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "x86_64" ]; then
+    LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8.0/jre/lib/amd64:/usr/lib/jvm/java-1.8.0/jre/lib/amd64/server/:/R-4.4.0/lib
+elif [ "$ARCH" = "aarch64" ]; then
+    LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8.0/jre/lib/aarch64:/usr/lib/jvm/java-1.8.0/jre/lib/aarch64/server/:/R-4.4.0/lib
+fi
+
+export LD_LIBRARY_PATH
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 R_LIBS=/home/runner/build/r_libs
 JAVA_HOME=/usr/lib/jvm/java-1.8.0
-if [ -e  "/opt/rh/rh-python36/enable" ]; then source /opt/rh/rh-python36/enable; fi;

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -4631,7 +4631,6 @@ validateSubjectData <- function(subjectData, dryRun) {
   if (is.null(subjectData)) {
     return(NULL)
   }
-  # subjectData is just list() with the new thing so why is it 
   uniqueDF <- unique(subjectData[, c("Class", "valueKind")])
   uniqueDF <- uniqueDF[!(uniqueDF$valueKind %in% c('flag cause', 'flag observation', 'flag status')), ]
   validateValueKinds(uniqueDF$valueKind, uniqueDF$Class, dryRun, reserved = NULL)

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -2005,7 +2005,7 @@ getExperimentByNameCheck <- function(experimentName, protocol, configList, dupli
     protocolOfExperiment <- getProtocolByCodeName(experimentList[[1]]$protocol$codeName)
 
     
-    if (is.na(protocol) || protocolOfExperiment$id != protocol$id) {
+    if (identical(protocol, NA) || protocolOfExperiment$id != protocol$id) {
       if (duplicateNamesAllowed) {
         experiment <- NA
       } else {
@@ -3567,7 +3567,7 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
   protocol <- NULL
   if (!useExisting) {
     protocol <- getProtocolByNameAndFormat(protocolName = validatedMetaData[,paste0(racas::applicationSettings$client.protocol.label," Name")][1], configList, inputFormat)
-    newProtocol <- is.na(protocol[[1]])
+    newProtocol <- identical(protocol[[1]], NA)
     if (!newProtocol) {
       validatedMetaData[,paste0(racas::applicationSettings$client.protocol.label," Name")][1] <- getPreferredProtocolName(protocol, validatedMetaData[,paste0(racas::applicationSettings$client.protocol.label," Name")][1])
     }
@@ -3728,7 +3728,7 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
   }
   
   # Checks if we have a new experiment
-  newExperiment <- class(experiment[[1]])!="list" && is.na(experiment[[1]])
+  newExperiment <- class(experiment[[1]])!="list" && identical(experiment[[1]], NA)
   
   # If there are errors, do not allow an upload (yes, this is needed a second time)
   errorFree <- length(messenger()$errors)==0
@@ -4628,6 +4628,10 @@ getSubjectAndTreatmentData <- function (precise, genericDataFileDataFrame, calcu
 validateSubjectData <- function(subjectData, dryRun) {
   # Validates Subject Data
   # For now, just passes information to validateValue Kinds
+  if (is.null(subjectData)) {
+    return(NULL)
+  }
+  # subjectData is just list() with the new thing so why is it 
   uniqueDF <- unique(subjectData[, c("Class", "valueKind")])
   uniqueDF <- uniqueDF[!(uniqueDF$valueKind %in% c('flag cause', 'flag observation', 'flag status')), ]
   validateValueKinds(uniqueDF$valueKind, uniqueDF$Class, dryRun, reserved = NULL)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - See related base R image changes here: https://github.com/mcneilco/racas/pull/93
 - This pull request includes changes to support R-4.4.0. The changes involve updating the LD_LIBRARY_PATH and PATH environment variables based on the architecture of the system. Additionally, there are updates to the getExperimentByNameCheck and runMain functions to handle NA values correctly following:

https://cran.r-project.org/bin/windows/base/old/4.2.0/NEWS.R-4.2.0.html
> Calling && or || with either argument of length greater than one now gives a warning (which it is intended will become an error).

In 4.3.0 this became an error: https://cran.r-project.org/bin/windows/base/old/4.3.0/NEWS.R-4.3.0.html
> Calling && or || with LHS or (if evaluated) RHS of length greater than one is now always an error, with a report of the form
    'length = 4' in coercion to 'logical(1)'

So now we get:

https://github.com/mcneilco/acas/blob/9d261eefd5600d3d650bc707c1476b788e346a6e/modules/GenericDataParser/src/server/generic_data_parser.R#L2008
```
Error in is.na(protocol) || protocolOfExperiment$id != protocol$id : 
  'length = 15' in coercion to 'logical(1)'
```


## Related Issue
ACAS-744

## How Has This Been Tested?
 - Ran acasclient tests
 - Ran manual load of dose response data and verified curves rendered and results were expected in the UI.  Ran curve curator and verified it functioned properly (this is some of the more complex R code we run).