### PR TITLE
ACAS-762-revert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_VERSION 18.x
 RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
   dnf install -y nodejs
-# ACAS-762 temporary fix for npm multi-arch build issue. Remove when Node is updated to > 18.20.1 and fix is confirmed
-RUN npm install npm@10.5.1 -g
 
 # ACAS
 RUN	    useradd -u 1000 -ms /bin/bash runner


### PR DESCRIPTION
## Description
 - Removes pinned npm version now that 18.20.1 has been released https://nodejs.org/en/blog/release/v18.20.1

## Related Issue
ACAS-762

## How Has This Been Tested?
TBD on merge since we don't do mule-arch builds on PRs