### PR TITLE
ACAS-536: Upgrade Github Actions dependencies to fix node16 deprecation warnings

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -23,11 +23,11 @@ jobs:
       - name: Set ACAS_TAG to ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
         run: echo "ACAS_TAG=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
           echo "ACAS_CLIENT_REF=main" >> $GITHUB_ENV
         if: github.ref == 'refs/heads/master'
       - name: Checkout acasclient
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: mcneilco/acasclient
           path: acasclient
@@ -101,7 +101,7 @@ jobs:
           echo "password=secret" >> ~/.acas/credentials
           echo "url=http://localhost:3000" >> ~/.acas/credentials
       - name: Set Up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
       - name: Display Python version

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -101,7 +101,7 @@ jobs:
           echo "password=secret" >> ~/.acas/credentials
           echo "url=http://localhost:3000" >> ~/.acas/credentials
       - name: Set Up Python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Display Python version

--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -30,7 +30,7 @@ jobs:
             echo "ACAS_REF=$(echo $INPUT_BRANCH_NAME)" >> $GITHUB_ENV
           fi 
       - name: Get the latest commit of ${{ env.ACAS_REF }} and apply tag ${{ github.event.inputs.tag-name }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ACAS_WORKFLOWS_TOKEN }}
           script: |

--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # Checkout this repo
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       # Get branch name

--- a/.github/workflows/trigger-tag.yml
+++ b/.github/workflows/trigger-tag.yml
@@ -28,7 +28,7 @@ jobs:
           echo "NEXT_TAG=$(echo $LAST_TAG | awk -F-dev -v OFS=-dev '{$NF += 1 ; print}')" >> $GITHUB_ENV
       # Trigger the build
       - name: Trigger the tagger workflow with branch ${{env.BRANCH_NAME}} and tag ${{ env.NEXT_TAG }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ACAS_WORKFLOWS_TOKEN }}
           script: |

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -21,7 +21,7 @@ jobs:
         owner: [ mcneilco ]
     steps:
       - name: Create pull requests to upmerge branches to main
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ACAS_WORKFLOWS_TOKEN }}
           script: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Fixes deprecation warning by bumping GitHub actions dependencies which use node 20 https://github.com/actions/github-script?tab=readme-ov-file#v7
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, docker/metadata-action@v4, docker/setup-qemu-action@v2, docker/setup-buildx-action@v2, docker/login-action@v2, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

## Related Issue
ACAS-536

## How Has This Been Tested?
 - `Create Upmerge pull requests` https://github.com/mcneilco/acas/actions/runs/9421080099
 - `Docker Image CI` triggered by this PR  - Gets past important GitHub action steps but failing because its testing 2024-1 but falling back to 2024-3 images https://github.com/mcneilco/acas/actions/runs/9421484929/job/25955662782
  - Trigger dev tag only triggers on release/** branches so not tested but pretty confident it will work
 - `Tag ACAS Repos` https://github.com/mcneilco/acas/actions/runs/9421216747
<img width="465" alt="Screenshot 2024-06-07 at 11 01 45 AM" src="https://github.com/mcneilco/acas/assets/868119/9cce9428-e242-4a65-9682-228881962f20">

