### PR TITLE
ACAS-744: Switch to vault.centos.org as a workaround for stream8 EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ ENV ACAS_CLIENT_ABOUT_ACAS_VERSION=${VERSION}
 ARG REVISION=UNKNOWN
 ENV ACAS_CLIENT_ABOUT_ACAS_REVISION=${REVISION}
 
+# EOL for Centos8-Stream workaround 
+RUN sed -i 's/^mirrorlist=/#&/' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/*.repo && \ 
+    sed -i 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo 
+
 # Update
 RUN \
   dnf update -y && \


### PR DESCRIPTION
## Description
Backporting patch from #1166 to earlier release branch