### PR TITLE
ACAS-736: Append new experiment endpoints to protocol endpoints

### DIFF
--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -3674,13 +3674,13 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
   }
 
   # Validate Experiment Columns against Protocol Endpoints when using existing protocol and endpoint manager is enabled
-  expProtocolEndpointValiation <- list(passed = FALSE, nonMatchingRows = data.frame()) 
+  expProtocolEndpointValidation <- list(passed = FALSE, nonMatchingRows = data.frame()) 
 
   if (!newProtocol && racas::applicationSettings$client.protocol.endpointManager.enabled) {
     # extract the endpoint data from the protocol object to check against
     protocolEndpointData <- getProtocolEndpointData(protocol)
     # Check the experiment columns against the protocolEndpointData
-    expProtocolEndpointValiation <- validateExperimentColumns(selColumnOrderInfo, protocolEndpointData, getProtocolStrictEndpointMatching(protocol), protocol$lsLabels[[1]]$labelText)
+    expProtocolEndpointValidation <- validateExperimentColumns(selColumnOrderInfo, protocolEndpointData, getProtocolStrictEndpointMatching(protocol), protocol$lsLabels[[1]]$labelText)
   }
   
   # If there are errors, do not allow an upload
@@ -3718,8 +3718,8 @@ runMain <- function(pathToGenericDataFormatExcelFile, reportFilePath=NULL,
       protocol <- createNewProtocol(metaData = validatedMetaData, lsTransaction, recordedBy, columnOrderStates)
     } else {
       # If the protocol has passed endpoint validation and we are not in a dry run, update the protocol with any new endpoints
-      if (expProtocolEndpointValiation$passed && nrow(expProtocolEndpointValiation$nonMatchingRows) > 0) {
-        protocol <- updateColumnOrderStates(protocol, "protocols", expProtocolEndpointValiation$nonMatchingRows, errorEnv, recordedBy, lsTransaction)
+      if (expProtocolEndpointValidation$passed && nrow(expProtocolEndpointValidation$nonMatchingRows) > 0) {
+        protocol <- updateColumnOrderStates(protocol, "protocols", expProtocolEndpointValidation$nonMatchingRows, errorEnv, recordedBy, lsTransaction)
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Returns a list of non-matching endpoints when comparing protocol and experiment endpoints and then adds new endpoints to the protocol by adding additional `metadata_column order` states.

## Related Issue
ACAS-736

## How Has This Been Tested?

 - Manually uploaded an experiment
 - Changed an endpoint name and re-uploaded the experiment and verified the endpoint was added to the protocol and upon subsequent uploads did not receive a warning about the endpoint.
 