### PR TITLE
ACAS-734: Scope experiment table controller to this

### DIFF
--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -1122,10 +1122,10 @@ class EndpointListController extends AbstractFormController
 	#Function brought over from experiment.coffee 
 	setupExperimentSummaryTable: (experiments) =>
 		#@$(".bv_searchStatusIndicator").addClass "hide"
-		$(".bv_experimentTableController").removeClass "hide"
+		@$(".bv_experimentTableController").removeClass "hide"
 
 		@experimentSummaryTable = new ExperimentSummaryTableController
-			el: $(".bv_experimentTableController")
+			el: @$(".bv_experimentTableController")
 			collection: experiments
 
 		@experimentSummaryTable.on "selectedRowUpdated", @selectedExperimentUpdated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Fixes bug where clicking on rows in `Experiment Browser` an then rows in `Protocol Browser` with endpoint manager turned on would produce and alert `Cannot reinitialise DataTable.`
 
<img width="439" alt="Screenshot 2024-06-17 at 4 10 44 PM" src="https://github.com/mcneilco/acas/assets/868119/9c6ac86e-a0f4-4ffd-bcaa-9c7f68fb048d">


## Related Issue
ACAS-734

## How Has This Been Tested?
 - Reliably reproduced the problem by:
    - Searching for an experiment in Experiment Browser and clicking a row
    - Searching for a protocol in Protocol Browser and clicking a row
- Verified the alert went away using the same test
- Verified manually that both `Protocol Browser` and `Experiment Browser` functioned normally after the change.