### PR TITLE
ACAS-780: Fallback reviewers

### DIFF
--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -98,11 +98,19 @@ jobs:
               // Remove any duplicate reviewers
               const uniqueReviewers = [...new Set(reviewers)]
 
-             // If apiUser is a reviewer, remove them but tag them in the description
-              addApiUser = false
+              // If apiUser is a reviewer, remove them but tag them in the description
+              let addApiUser = false
               if (uniqueReviewers.includes(apiUser)) {
                 uniqueReviewers.splice(uniqueReviewers.indexOf(apiUser), 1)
                 addApiUser = true
+              }
+
+              // If the assignee is the pull request author, remove them from the reviewers list
+              if (assignee === apiUser) {
+                const index = uniqueReviewers.indexOf(assignee);
+                if (index !== -1) {
+                  uniqueReviewers.splice(index, 1);
+                }
               }
 
               // If the PR doesn't exist then create it

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -100,7 +100,10 @@ jobs:
 
               // If apiUser is a reviewer, remove them but tag them in the description
               let addApiUser = false
+              console.log(`API user: ${apiUser}`)
+              console.log(`Unique reviewers: ${uniqueReviewers.join(", ")}`)
               if (uniqueReviewers.includes(apiUser)) {
+                console.log(`API user is a reviewer. Removing them from the reviewers list`)
                 uniqueReviewers.splice(uniqueReviewers.indexOf(apiUser), 1)
                 addApiUser = true
               }

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -154,6 +154,7 @@ jobs:
 
               // Add the reviewers to the pull request if there are any
               if (uniqueReviewers.length > 0) {
+                console.log(`Adding reviewers to pull request ${pullRequest.number}: ${uniqueReviewers.join(", ")}`)
                 await github.rest.pulls.requestReviewers({
                   owner: "${{ matrix.owner }}",
                   repo: "${{ matrix.repo }}",

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         repo: [ acas, acas-roo-server, racas ]
         owner: [ mcneilco ]
+        fallbackReviewers: [ "brian.bolt@schrodinger.com", "brian.frost@schrodinger.com"]
     steps:
       - name: Create pull requests to upmerge branches to main
         uses: actions/github-script@v7
@@ -83,12 +84,11 @@ jobs:
                 .filter(commit => commit.author !== null)
                 .map(commit => commit.author.login)
 
-              // Fallback to repo owner if no reviewers found
+              // Fallback to the reviewers if no commits are found
               if (reviewers.length === 0) {
-                reviewers = [github.context.repo.owner];
-                console.log(`No reviewers found. Falling back to repository owner: ${github.context.repo.owner}`);
+                reviewers = ${{ matrix.fallbackReviewers }}
+                console.log(`No reviewers found for commits, falling back to ${reviewers.join(", ")}`)
               }
-              
 
               // Get the most recent commit author to be the assignee
               const assignee = reviewers[reviewers.length - 1]

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -153,8 +153,11 @@ jobs:
               })
 
               // Add the reviewers to the pull request if there are any
+              // Remove the author from the reviewers list
+              if (uniqueReviewers.includes(pullRequest.user.login)) {
+                uniqueReviewers.splice(uniqueReviewers.indexOf(pullRequest.user.login), 1)
+              }
               if (uniqueReviewers.length > 0) {
-                console.log(`Adding reviewers to pull request ${pullRequest.number}: ${uniqueReviewers.join(", ")}`)
                 await github.rest.pulls.requestReviewers({
                   owner: "${{ matrix.owner }}",
                   repo: "${{ matrix.repo }}",

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -82,7 +82,7 @@ jobs:
               })
 
               // Create a unique set of reviewers: Reviewers for the PR should be anyone with commits in the diff 
-              const reviewers = diff.data.commits
+              let reviewers = diff.data.commits
                 .filter(commit => commit.author !== null)
                 .map(commit => commit.author.login)
 
@@ -96,7 +96,7 @@ jobs:
               const assignee = reviewers[reviewers.length - 1]
 
               // Remove any duplicate reviewers
-              const uniqueReviewers = [...new Set(reviewers)]
+              let uniqueReviewers = [...new Set(reviewers)]
 
               // If apiUser is a reviewer, remove them but tag them in the description
               let addApiUser = false

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -3,6 +3,9 @@ name: Create upmerge pull requests
 # **What it does**: Loops through protected branches and creates pull requests to upmerge them if there are any commits between them.
 # **Why we have it**: To automate the process of upmerging branches.
 
+env:
+  FALLBACK_REVIEWERS: '["brian.bolt@schrodinger.com", "brian.frost@schrodinger.com"]'
+
 on:
   # Run every 3 hours on the hour
   schedule:
@@ -19,7 +22,6 @@ jobs:
       matrix:
         repo: [ acas, acas-roo-server, racas ]
         owner: [ mcneilco ]
-        fallbackReviewers: [ "brian.bolt@schrodinger.com", "brian.frost@schrodinger.com"]
     steps:
       - name: Create pull requests to upmerge branches to main
         uses: actions/github-script@v7
@@ -86,8 +88,8 @@ jobs:
 
               // Fallback to the reviewers if no commits are found
               if (reviewers.length === 0) {
-                reviewers = ${{ matrix.fallbackReviewers }}
-                console.log(`No reviewers found for commits, falling back to ${reviewers.join(", ")}`)
+                reviewers = JSON.parse(process.env.FALLBACK_REVIEWERS);
+                console.log(`No reviewers found. Falling back to: ${reviewers}`);
               }
 
               // Get the most recent commit author to be the assignee

--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -79,7 +79,16 @@ jobs:
               })
 
               // Create a unique set of reviewers: Reviewers for the PR should be anyone with commits in the diff 
-              const reviewers = diff.data.commits.map(commit => commit.author.login)
+              const reviewers = diff.data.commits
+                .filter(commit => commit.author !== null)
+                .map(commit => commit.author.login)
+
+              // Fallback to repo owner if no reviewers found
+              if (reviewers.length === 0) {
+                reviewers = [github.context.repo.owner];
+                console.log(`No reviewers found. Falling back to repository owner: ${github.context.repo.owner}`);
+              }
+              
 
               // Get the most recent commit author to be the assignee
               const assignee = reviewers[reviewers.length - 1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Fixes issue when commits is not a valid GitHub author e.g." `7f0ac61071e83580b32ae313004a0113b7a7df82 Tanay Makharia makharia@MacBook-Pro-83.local`
 - The script will now fallback to set of default reviewers.
 - Also removes reviewers that are the author of the PR to fix an unrelated issue when running the Script on this PR branch.

## Related Issue
ACAS-780

## How Has This Been Tested?
Ran upmerge and verified the fix.