### PR TITLE
ACAS-782: Use pip rather than pip3.6

### DIFF
--- a/modules/ServerAPI/src/server/Bootstrap.coffee
+++ b/modules/ServerAPI/src/server/Bootstrap.coffee
@@ -6,7 +6,7 @@ exports.main = (callback) ->
     config = require "#{ACAS_HOME}/conf/compiled/conf.js"
     if config.all.server.liveDesign.installClientOnStart? && config.all.server.liveDesign.installClientOnStart
         exec = require('child_process').exec
-        command = "pip3.6 install --upgrade --force-reinstall --user #{config.all.client.service.result.viewer.liveDesign.baseUrl}/ldclient.tar.gz"
+        command = "pip install --upgrade --force-reinstall --user #{config.all.client.service.result.viewer.liveDesign.baseUrl}/ldclient.tar.gz"
         console.log "About to call python using command: "+command
         child = exec command,  (error, stdout, stderr) ->
             console.log stdout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - `pip3.6` was replaced with `pip` which uses the installed python 3.11 pip
 - Fixes this error which was introduced in https://github.com/mcneilco/acas/pull/1164 
```
[acas] [ACAS] 2024-06-24T19:35:05.663Z info: 'Bootstrap being called'
[acas] [ACAS] 2024-06-24T19:35:05.664Z info: 'About to call python using command: pip3.6 install --upgrade --force-reinstall --user http://livedesign-internal-bbolt-darwin/livedesign/ldclient.tar.gz'
[acas] [ACAS] 2024-06-24T19:35:05.674Z info: ''
[acas] [ACAS] 2024-06-24T19:35:05.674Z warn: 'Error installing ld client. This can happen if Live Design was down during ACAS start or otherwise ACAS could not communicate with Live Design.  This is just a warning as LD client might already be installed and be the correction version.'
[acas] [ACAS] 2024-06-24T19:35:05.675Z error: '/bin/sh: line 1: pip3.6: command not found\n'
```



## Related Issue
ACAS-782

## How Has This Been Tested?
 - On a cluster configured to install LDClient. I verified it was installed successfully and api calls to LD via activating the Experiment Editor module worked successfully:

Bootstrap success:
```
[acas] [ACAS] 2024-06-24T19:38:47.255Z info: 'Bootstrap being called'
[acas] [ACAS] 2024-06-24T19:38:47.256Z info: 'About to call python using command: pip install --upgrade --force-reinstall --user http://livedesign-internal-bbolt-darwin/livedesign/ldclient.tar.gz'
[acas] [ACAS] 2024-06-24T19:38:50.006Z info: 'Collecting http://livedesign-internal-bbolt-darwin/livedesign/ldclient.tar.gz\n' +
[acas]   '  Downloading http://livedesign-internal-bbolt-darwin/livedesign/ldclient.tar.gz (131 kB)\n' +
[acas]   '     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 131.6/131.6 kB 91.2 MB/s eta 0:00:00\n' +
[acas]   '  Preparing metadata (setup.py): started\n' +
[acas]   "  Preparing metadata (setup.py): finished with status 'done'\n" +
[acas]   'Collecting requests<3.0.0,>=2.0.0\n' +
[acas]   '  Downloading requests-2.32.3-py3-none-any.whl (64 kB)\n' +
[acas]   '     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.9/64.9 kB 500.6 kB/s eta 0:00:00\n' +
[acas]   'Collecting Deprecated==1.2.10\n' +
[acas]   '  Downloading Deprecated-1.2.10-py2.py3-none-any.whl (8.7 kB)\n' +
[acas]   'Collecting wrapt<2,>=1.10\n' +
[acas]   '  Downloading wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (80 kB)\n' +
[acas]   '     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 80.7/80.7 kB 1.6 MB/s eta 0:00:00\n' +
[acas]   'Collecting charset-normalizer<4,>=2\n' +
[acas]   '  Downloading charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (140 kB)\n' +
[acas]   '     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.3/140.3 kB 6.1 MB/s eta 0:00:00\n' +
[acas]   'Collecting idna<4,>=2.5\n' +
[acas]   '  Downloading idna-3.7-py3-none-any.whl (66 kB)\n' +
[acas]   '     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 66.8/66.8 kB 9.2 MB/s eta 0:00:00\n' +
[acas]   'Collecting urllib3<3,>=1.21.1\n' +
[acas]   '  Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)\n' +
[acas]   '     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.4/121.4 kB 10.9 MB/s eta 0:00:00\n' +
[acas]   'Collecting certifi>=2017.4.17\n' +
[acas]   '  Downloading certifi-2024.6.2-py3-none-any.whl (164 kB)\n' +
[acas]   '     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 164.4/164.4 kB 12.1 MB/s eta 0:00:00\n' +
[acas]   'Installing collected packages: wrapt, urllib3, idna, charset-normalizer, certifi, requests, Deprecated, ldclient\n' +
[acas]   '  Running setup.py install for ldclient: started\n' +
[acas]   "  Running setup.py install for ldclient: finished with status 'done'\n" +
[acas]   'Successfully installed Deprecated-1.2.10 certifi-2024.6.2 charset-normalizer-3.3.2 idna-3.7 ldclient-2024.3.3.dev0 requests-2.32.3 urllib3-2.2.2 wrapt-1.16.0\n'
[acas] [ACAS] 2024-06-24T19:38:50.006Z info: 'Bootstrap called successfully'
```

API call
```
[acas]   '2024-06-24 20:20:08,470 - ldclient.api.requester - DEBUG - About to request [http://livedesign-internal-bbolt-darwin/livedesign/api/projects\n'](http://livedesign-internal-bbolt-darwin/livedesign/api/projects/n'%3C/span%3E) +
[acas]   '2024-06-24 20:20:08,470 - ldclient.api.requester - DEBUG - Using params {}\n' +
[acas]   '2024-06-24 20:20:08,470 - ldclient.api.requester - DEBUG - Using data None\n' +
[acas]   "2024-06-24 20:20:08,470 - ldclient.api.requester - DEBUG - Using headers {'Accept': 'application/json', 'Content-Type': 'application/json'}\n" +
[acas]   '2024-06-24 20:20:08,515 - urllib3.connectionpool - DEBUG - [http://livedesign-internal-bbolt-darwin:80](http://livedesign-internal-bbolt-darwin/) "GET /livedesign/api/projects?_type=json HTTP/11" 200 None\n' +
[
```