### PR TITLE
ACAS-783: Fix package import error and message printing

### DIFF
--- a/modules/ServerAPI/src/server/python/createLiveDesignLiveReportForACAS/create_lr_for_acas.py
+++ b/modules/ServerAPI/src/server/python/createLiveDesignLiveReportForACAS/create_lr_for_acas.py
@@ -22,22 +22,20 @@ http_client.HTTPConnection.debuglevel = 0
 import ldclient
 from ldclient.client import LDClient, LiveReport
 
-try:
-    import requests
-    from requests.packages.urllib3.exceptions import (InsecurePlatformWarning,
-                                                      InsecureRequestWarning,
-                                                      SNIMissingWarning)
-    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-    requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
-    requests.packages.urllib3.disable_warnings(SNIMissingWarning)
-except ImportError:
-    #ignore error, allow warnings
-    print('ignoring ImportError')
-
 ### Generic helper functions
 def eprint(*args, **kwargs):
     """Print to stderr"""
     print(*args, file=sys.stderr, **kwargs)
+
+try:
+    import requests
+    from requests.packages.urllib3.exceptions import (InsecurePlatformWarning,
+                                                      InsecureRequestWarning)
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
+except ImportError as e:
+    #ignore error, allow warnings
+    eprint(f"Ignoring ImportError: {e}")
 
 def str2bool(v):
     if isinstance(v, bool):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Fixes this error when opening an experiment in LiveDesign:
```
[acas] [ACAS] 2024-06-24T21:05:46.778Z error: 'Caught exception: RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: NaN\n' +
[acas]   '    at ServerResponse.writeHead (node:_http_server:352:11)\n' +
[acas]   '    at ServerResponse.writeHead (/home/runner/build/node_modules/on-headers/index.js:44:26)\n' +
[acas]   '    at ServerResponse.writeHead (/home/runner/build/node_modules/on-headers/index.js:44:26)\n' +
[acas]   '    at ServerResponse._implicitHeader (node:_http_server:338:8)\n' +
[acas]   '    at write_ (node:_http_outgoing:945:9)\n' +
[acas]   '    at ServerResponse.end (node:_http_outgoing:1056:5)\n' +
[acas]   '    at writeend (/home/runner/build/node_modules/express-session/index.js:270:22)\n' +
[acas]   '    at Immediate.onsave (/home/runner/build/node_modules/express-session/index.js:348:11)\n' +
[acas]   '    at process.processImmediate (node:internal/timers:480:21)'
```
*The bug*
Python3.11 upgrade caused an import error `Ignoring ImportError: cannot import name 'SNIMissingWarning' from 'urllib3.exceptions' (/home/runner/.local/lib/python3.11/site-packages/urllib3/exceptions.py)` which triggered a print() statement at the beginning of the script which went to stdout rather than stderr.  Which eventually lead to the nodejs code to try and interpret the error output line as the return status code and led to a NaN error above.
 
*The fixes*
 - Print import errors to stderr
 - Fix the import error by removing SNIMissingWarning which is not longer available and isn't necessary anyway.


## Related Issue
ACAS-783

## How Has This Been Tested?
Ran open in LiveDesign after applying the fixes and verified the LiveReport was opened successfully.