### PR TITLE
ACAS-784: Lookup qtLoader.module

### DIFF
--- a/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
+++ b/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
@@ -2,7 +2,7 @@ $(function() {
     window.MaestroJSUtil = {
         "getSketcher": function getSketcher(el) {
             function waitForReady(resolve, reject) {
-                var maestro = $(el)?.[0]?.contentWindow?.Module;
+                var maestro = $(el)?.[0]?.contentWindow?.qtLoader?.module;
                 const sketcherImportText = maestro?.sketcher_import_text || maestro?.sketcherImportText;
                 if (!sketcherImportText) {
                     setTimeout(() => waitForReady(resolve, reject), 1000);

--- a/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
+++ b/modules/CmpdReg/src/client/schrodinger/maestrosketcher/maestrosketcherlauncher.js
@@ -1,23 +1,16 @@
 $(function() {
-
-	window.MaestroJSUtil = {
-        // See implementation of "setRepresentation" in src/components/Sketcher/index.tsx of the rc-maestro-sketcher repository as a reference
-		"getSketcher": function getSketcher (el) {
-            function waitForReady (resolve, reject) {
-                var _a;
-                maestro = $(el)[0].contentWindow.Module;
-                const sketcherImportText = (_a = this.maestro) === null || _a === void 0 ? void 0 : (_a.sketcher_import_text || _a.sketcherImportText);
-                // Wait until sketcher is initialized
+    window.MaestroJSUtil = {
+        "getSketcher": function getSketcher(el) {
+            function waitForReady(resolve, reject) {
+                var maestro = $(el)?.[0]?.contentWindow?.Module;
+                const sketcherImportText = maestro?.sketcher_import_text || maestro?.sketcherImportText;
                 if (!sketcherImportText) {
-                    self = this;
-                    setTimeout(function() {waitForReady(resolve, reject)}, 1000);
-                }
-                else {
-                    resolve(maestro)
+                    setTimeout(() => waitForReady(resolve, reject), 1000);
+                } else {
+                    resolve(maestro);
                 }
             }
-			
-			return new Promise(waitForReady);				
-		}
-	};
+            return new Promise(waitForReady);
+        }
+    };
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - In 2024-3 QTLoader was updated in MaestroSketcher and way to access it has changed.

## Related Issue
ACAS-784

## How Has This Been Tested?
 - Currently this PR has 2 commits.  I tested the first commit on a 2024-2 instance to verify that the ? operator change works was expected.  I have not tested the second commit as the change to access maestro via qtLoader.module is pending.