### PR TITLE
ACAS-802: Air gapped ACAS cannot install LDClient dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN   dnf install -y python311 python3.11-pip initscripts
 RUN   alternatives --install /usr/bin/python python /usr/bin/python3.11 1
 RUN   alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 1
 RUN		pip install argparse requests psycopg2-binary
+COPY    --chown=runner:runner requirements.txt $ACAS_BASE/requirements.txt
+RUN    pip install -r $ACAS_BASE/requirements.txt
 
 # node
 ENV NPM_CONFIG_LOGLEVEL warn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.0.0, <3.0.0
+Deprecated==1.2.10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Adds ldclient python requirements to ACAS base image

## Related Issue
ACAS-802

## How Has This Been Tested?
Verified image builds and that I could install ldclient without installing dependencies:

```
Defaulting to user installation because normal site-packages is not writeable
Collecting https://redacted.com/livedesign/ldclient.tar.gz
  Downloading https://redcated.com/livedesign/ldclient.tar.gz (133 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.9/133.9 kB 718.2 kB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Requirement already satisfied: requests<3.0.0,>=2.0.0 in /usr/local/lib/python3.11/site-packages (from ldclient==2024.4.2.dev0) (2.32.3)
Requirement already satisfied: Deprecated==1.2.10 in /usr/local/lib/python3.11/site-packages (from ldclient==2024.4.2.dev0) (1.2.10)
Requirement already satisfied: wrapt<2,>=1.10 in /usr/local/lib64/python3.11/site-packages (from Deprecated==1.2.10->ldclient==2024.4.2.dev0) (1.16.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib64/python3.11/site-packages (from requests<3.0.0,>=2.0.0->ldclient==2024.4.2.dev0) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/site-packages (from requests<3.0.0,>=2.0.0->ldclient==2024.4.2.dev0) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/site-packages (from requests<3.0.0,>=2.0.0->ldclient==2024.4.2.dev0) (2.2.3)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/site-packages (from requests<3.0.0,>=2.0.0->ldclient==2024.4.2.dev0) (2024.8.30)
Installing collected packages: ldclient
  Attempting uninstall: ldclient
    Found existing installation: ldclient 2024.3.3.dev0
    Uninstalling ldclient-2024.3.3.dev0:
      Successfully uninstalled ldclient-2024.3.3.dev0
  DEPRECATION: ldclient is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559
  Running setup.py install for ldclient ... done
Successfully installed ldclient-2024.4.2.dev0
```
