### PR TITLE
ACAS-815: Increase chemical sketcher height

### DIFF
--- a/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
+++ b/modules/CmpdReg/src/client/css/NewCmpdReg_nocompile.css
@@ -198,13 +198,13 @@ div {
     height: 20px;
 }
 .MetaLotView div.floatingPanel.newSaltView .marvinWrapper {
-    height: 506px !important;
+    height: 526px !important;
 }
 .marvinWrapper iframe {
-    height: 500px !important;
+    height: 520px !important;
 }
 .marvinContainer iframe {
-    height: 500px !important;
+    height: 520px !important;
 }
 .MetaLotView div.floatingPanel.NewLotSuccessView {
     cursor: hand;
@@ -611,7 +611,7 @@ div {
 .RegistrationSearchView .corpNameInput{
     position: absolute;
     left: 20px;
-    top: 560px;
+    top: 580px;
     margin-left: 140px;
 }
 .RegistrationSearchView a.nextButton, .EditParentSearchView a.nextButton {
@@ -620,7 +620,7 @@ div {
     width: 90px;
     position: absolute;
     left: 680px;
-    top: 560px;
+    top: 580px;
 }
 .RegistrationSearchView a.cancelButton, .EditParentSearchView a.cancelEditButton {
     background: no-repeat url('../images/cancel.png');
@@ -628,7 +628,7 @@ div {
     width: 90px;
     position: absolute;
     left: 580px;
-    top: 560px;
+    top: 580px;
 }
 /****** REGISTRATION STEP 2 ******/
 .RegSearchResultsView .radioWrapper label, .EditParentSearchResultsView .radioWrapper label {
@@ -999,7 +999,7 @@ div {
     margin-right: 14px;
 }
 .LotForm_SaltFormView iframe {
-    height: 500px;
+    height: 520px;
 }
 
 .EnterIsoHeader {

--- a/modules/Components/src/client/ACASFormChemicalStructureView.html
+++ b/modules/Components/src/client/ACASFormChemicalStructureView.html
@@ -7,13 +7,13 @@
 
 
 <script type="text/template" id="MaestroChemicalStructureControllerView" xmlns="http://www.w3.org/1999/html">
-    <iframe class="bv_sketcherIFrame"  style="width:600px; height:500px;">sketcher should load here</iframe>
+    <iframe class="bv_sketcherIFrame"  style="width:600px; height:520px;">sketcher should load here</iframe>
 </script>
 
 <script type="text/template" id="KetcherChemicalStructureControllerView" xmlns="http://www.w3.org/1999/html">
-    <iframe class="bv_sketcherIFrame"  style="width:600px; height:500px;">sketcher should load here</iframe>
+    <iframe class="bv_sketcherIFrame"  style="width:600px; height:520px;">sketcher should load here</iframe>
 </script>
 
 <script type="text/template" id="MarvinJSChemicalStructureControllerView" xmlns="http://www.w3.org/1999/html">
-    <iframe class="bv_sketcherIFrame"  style="width:600px; height:500px;" data-toolbars="search">sketcher should load here</iframe>
+    <iframe class="bv_sketcherIFrame"  style="width:600px; height:520px;" data-toolbars="search">sketcher should load here</iframe>
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The maestro sketcher min height increased from 500 to 520 pixels.  ACAS is styling is very right so I increased the size of all sketchers to the same height and a few surrounding items to match.

## Related Issue
ACAS-815

## How Has This Been Tested?
Lots of clicking around on various components. 
Below are screenshots of those components before and after the change for Maestro Sketcher and OSS Ketcher sketcher.  I did not test the MarvinJS sketcher.

#### Before screenshots:

##### Maestro
Search
<img width="737" alt="Screenshot 2024-11-26 at 4 03 50 PM" src="https://github.com/user-attachments/assets/8678cede-ccdd-4c07-b44d-5eb6e235ed17">

Reg step 1
<img width="765" alt="Screenshot 2024-11-26 at 4 04 11 PM" src="https://github.com/user-attachments/assets/b8c88b4b-68c5-4857-a9c0-02d2d9e61813">

Reg step 2 (no sketcher but some of the same elements)
<img width="753" alt="Screenshot 2024-11-26 at 4 04 16 PM" src="https://github.com/user-attachments/assets/d8869d68-d432-45be-be85-dc931f296538">

Edit parent step 1
<img width="792" alt="Screenshot 2024-11-26 at 4 04 26 PM" src="https://github.com/user-attachments/assets/cff302f6-b7d1-4f90-9c72-ae2b245f9cdf">

Edit parent step 2  (no sketcher but some of the same elements)
<img width="806" alt="Screenshot 2024-11-26 at 4 04 30 PM" src="https://github.com/user-attachments/assets/38f53147-df42-4d7d-938c-8a965a92fdbc">

New salt (cmpdreg)
<img width="663" alt="Screenshot 2024-11-26 at 4 31 42 PM" src="https://github.com/user-attachments/assets/6b85ede7-8689-4c26-a8cd-be7bd00d6f79">

New salt (acas salt module)
<img width="1377" alt="Screenshot 2024-11-26 at 4 04 45 PM" src="https://github.com/user-attachments/assets/1a359bd5-c255-4e2b-975d-e786b719a846">

#### After screenshots:
Search
<img width="693" alt="Screenshot 2024-11-26 at 4 05 52 PM" src="https://github.com/user-attachments/assets/28e4b1cd-c7b8-4c01-8eee-9f3a94b9a343">

Reg step 1
<img width="753" alt="Screenshot 2024-11-26 at 4 05 14 PM" src="https://github.com/user-attachments/assets/41dc5b3f-da94-4624-b1f0-59a6af318558">

Reg step 2 (no sketcher but some of the same elements)
<img width="753" alt="Screenshot 2024-11-26 at 4 05 14 PM" src="https://github.com/user-attachments/assets/d51f1ab5-6739-4653-aa97-9efb6f0857ae">

Edit parent step 1
<img width="760" alt="Screenshot 2024-11-26 at 4 05 21 PM" src="https://github.com/user-attachments/assets/9c2b1846-82e1-45c9-844d-3ec1ad915d84">

Edit parent step 2  (no sketcher but some of the same elements)
<img width="671" alt="Screenshot 2024-11-26 at 4 05 25 PM" src="https://github.com/user-attachments/assets/5caea56e-6315-4487-acf7-ad0819e56628">

New salt (cmpdreg)
<img width="655" alt="Screenshot 2024-11-26 at 4 31 55 PM" src="https://github.com/user-attachments/assets/2347ad45-5083-4746-8b5b-ac69edbb17d5">

New salt (acas salt module)
<img width="1348" alt="Screenshot 2024-11-26 at 4 07 57 PM" src="https://github.com/user-attachments/assets/d62ed798-a983-4091-b0e9-4ee19d1608e6">

##### OSS Ketcher (mostly boring as they weren't off the screen like maestro in the before but are just slightly taller)

Search
<img width="668" alt="Screenshot 2024-11-26 at 4 50 10 PM" src="https://github.com/user-attachments/assets/ce8a7beb-4a8b-4e49-935b-2624b3ad5131">


Reg step 1
<img width="667" alt="Screenshot 2024-11-26 at 4 50 21 PM" src="https://github.com/user-attachments/assets/fcda3b5e-e34f-4842-81cd-a946eb1a18f3">


Reg step 2 (no sketcher but some of the same elements)
<img width="648" alt="Screenshot 2024-11-26 at 4 50 36 PM" src="https://github.com/user-attachments/assets/8c00e8ed-c9b7-46a8-a397-ac6c4cc83340">


Edit parent step 1
<img width="676" alt="Screenshot 2024-11-26 at 4 50 44 PM" src="https://github.com/user-attachments/assets/1ddf1b94-afbe-4af0-b301-1a2a8b0460f3">

Edit parent step 2  (no sketcher but some of the same elements)
<img width="667" alt="Screenshot 2024-11-26 at 4 50 48 PM" src="https://github.com/user-attachments/assets/a5fa1873-c1d7-4a7a-86ba-f6f8a07ad070">

New salt (cmpdreg)
<img width="652" alt="Screenshot 2024-11-26 at 4 51 10 PM" src="https://github.com/user-attachments/assets/8e6074d1-c40d-412b-8189-c28a98324a2e">

New salt (acas salt module)
<img width="1363" alt="Screenshot 2024-11-26 at 4 51 35 PM" src="https://github.com/user-attachments/assets/450fbe67-aebf-4055-8124-24719ebd39ea">


#### After screenshots:
Search
<img width="737" alt="Screenshot 2024-11-26 at 4 52 13 PM" src="https://github.com/user-attachments/assets/30b63cef-30e6-49d3-b091-9f6549cef72e">


Reg step 1
<img width="697" alt="Screenshot 2024-11-26 at 4 52 25 PM" src="https://github.com/user-attachments/assets/54fdd09e-bf4f-4265-ab65-f2eef9c6dc97">


Reg step 2 (no sketcher but some of the same elements)
<img width="761" alt="Screenshot 2024-11-26 at 4 52 27 PM" src="https://github.com/user-attachments/assets/ccf08c8a-b172-48d2-aea0-6f69e48c8821">



Edit parent step 1
<img width="678" alt="Screenshot 2024-11-26 at 4 52 33 PM" src="https://github.com/user-attachments/assets/c2efa900-2147-42f4-b236-ba9f363a5ed4">


Edit parent step 2  (no sketcher but some of the same elements)
<img width="684" alt="Screenshot 2024-11-26 at 4 52 36 PM" src="https://github.com/user-attachments/assets/c4bebe4a-38e0-4d1d-b696-1be6c622c7db">


New salt (cmpdreg)
<img width="658" alt="Screenshot 2024-11-26 at 4 52 48 PM" src="https://github.com/user-attachments/assets/71068c94-f53a-4b66-8ce7-b53f23cb10cc">


New salt (acas salt module)
<img width="1339" alt="Screenshot 2024-11-26 at 4 53 00 PM" src="https://github.com/user-attachments/assets/223217c6-304d-417b-81e1-4517d15bec75">

