### PR TITLE
ACAS-824

### DIFF
--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -291,6 +291,7 @@ class ThingSummaryTableController extends Backbone.View
 				prsc.on "gotClick", @selectedRowChanged
 				@$("tbody").append prsc.render().el
 				
+			# Create a variable to hold the variables needed for filtering inside the initComplete function scope
 			filterHandles = {
 				table: @$("table"),
 				configs: @configs,
@@ -300,10 +301,8 @@ class ThingSummaryTableController extends Backbone.View
 				oLanguage:
 					sSearch: "Filter results: " #rename summary table's search bar
 				initComplete: ->
-					filterHandles = filterHandles
 					@api().columns().every ->
 						column = this
-
 						# Default is to add a filter to each column
 						# So only skip filtering if filter is false
 						config = filterHandles.configs[column.index()]

--- a/modules/Components/src/client/ACASThingBrowser.coffee
+++ b/modules/Components/src/client/ACASThingBrowser.coffee
@@ -303,20 +303,22 @@ class ThingSummaryTableController extends Backbone.View
 					filterHandles = filterHandles
 					@api().columns().every ->
 						column = this
-						# Create select element
-						select = document.createElement('select')
 
 						# Default is to add a filter to each column
 						# So only skip filtering if filter is false
 						config = filterHandles.configs[column.index()]
 						if !config.filter? || config.filter
-							$(select).appendTo(filterHandles.table.find("thead tr:eq(1) th").eq(column.index()).empty() )
+							# Create select element in the filter row
+							select = document.createElement('select')
+							$(select).appendTo(filterHandles.table.find("tr.bv_colFilters th").eq(column.index()).empty())
 
+							# Add default option
 							select.add new Option('')
-							column.header().replaceChildren select
+
 							# Apply listener for user change in value
 							select.addEventListener 'change', ->
 								column.search(select.value, exact: true).draw()
+
 							# Add list of options
 							column.data().unique().sort().each (d, j) ->
 								select.add new Option(d)

--- a/modules/Components/src/client/ACASThingBrowserView.html
+++ b/modules/Components/src/client/ACASThingBrowserView.html
@@ -33,9 +33,9 @@
 <script type="text/template" id="ThingSummaryTableView" xmlns="http://www.w3.org/1999/html">
     <table class="table table-bordered table-striped table-hover" style="margin: 0px; padding: 0px; border: 0px; width: 100%; ">
         <thead style="">
-            <tr class="bv_colFilters">
-            </tr>
             <tr class = "bv_firstRow"> 
+            </tr>
+            <tr class="bv_colFilters">
             </tr>
         </thead>
         <tbody style="">

--- a/modules/Standardization/src/client/Standardization.html
+++ b/modules/Standardization/src/client/Standardization.html
@@ -482,11 +482,11 @@
     </form>
     <table class="table table-bordered table-striped table-hover bv_standardizationDryRunReportSummaryTable" style="margin: 0px; width: 100%; font-size:70%;">
         <thead style="">
-            <tr class="bv_colFilters">
-                <th style="width: 10%;">Corporate ID</th>
-                <th style="width: 20%;">Original Structure</th>
-                <th style="width: 20%;" >Previous Standardized Structure</th>
-                <th style="width: 20%;">New Standardized Structure</th>
+            <tr>
+                <th>Corporate ID</th>
+                <th>Original Structure</th>
+                <th>Previous Standardized Structure</th>
+                <th>New Standardized Structure</th>
                 <th>Standardization Status</th>
                 <th>Standardization Comment</th>
                 <th>Registration Status</th>
@@ -500,11 +500,11 @@
                 <th>Old Mol. Weight</th>
                 <th>As Drawn Display Change</th>
             </tr>
-            <tr>
-                <th>Corporate ID</th>
-                <th>Original Structure</th>
-                <th>Previous Standardized Structure</th>
-                <th>New Standardized Structure</th>
+            <tr class="bv_colFilters">
+                <th style="width: 10%;">Corporate ID</th>
+                <th style="width: 20%;">Original Structure</th>
+                <th style="width: 20%;" >Previous Standardized Structure</th>
+                <th style="width: 20%;">New Standardized Structure</th>
                 <th>Standardization Status</th>
                 <th>Standardization Comment</th>
                 <th>Registration Status</th>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Fixes ACASLSThingBrowser and Standardization table filtering after Datatable upgrade.
 - Fixes Standardization table column visibility UI 

## Related Issue
ACAS-824

## How Has This Been Tested?
Thing browser

https://github.com/user-attachments/assets/13b03d70-df3d-4a5f-ae57-ffc65074d89e




Standardization - This one is hard to test because Indigo standardization table only works with one compound registered for some reason.  Surprised it worked at all since we never tested the non-implemented indigo standardization.

https://github.com/user-attachments/assets/1a06a20a-4ff0-4a21-ab07-7eecdf162c4d

