### PR TITLE
Revert "Revert "ACAS-828 Use postgres for session management""

### DIFF
--- a/app_template.coffee
+++ b/app_template.coffee
@@ -15,7 +15,7 @@ startApp = ->
 	logger = require('morgan')
 	methodOverride = require('method-override')
 	session = require('express-session')
-	MemoryStore = require('memorystore')(session)
+	PostgresqlStore = require('connect-pg-simple')(session)
 	bodyParser = require('body-parser')
 	errorHandler = require('errorhandler')
 	cookieParser = require('cookie-parser')
@@ -78,7 +78,9 @@ startApp = ->
 			console.error("NOT USING SSO configs! config.all.server.security.saml.use is set true but CustomerSpecificServerFunction 'ssoLoginStrategy' is not defined.")
 
 	loginRoutes = require './routes/loginRoutes'
-	sessionStore = new MemoryStore();
+	sessionStore = new PostgresqlStore(
+		conString: "postgres://#{config.all.server.database.username}:#{config.all.server.database.password}@#{config.all.server.database.host}:#{config.all.server.database.port}/#{config.all.server.database.name}"
+	)
 	global.app = express()
 	app.set 'port', config.all.client.port
 	app.set 'listenHost', config.all.client.listenHost
@@ -117,12 +119,14 @@ startApp = ->
 
 	# added for login support
 	app.use cookieParser()
+	console.log "Session timeout set to #{config.all.server.sessionTimeOutMinutes} minutes"
+	sessionTimeOutMilliseconds = config.all.server.sessionTimeOutMinutes * 60 * 1000
 	app.use session
 		secret: 'acas needs login'
-		cookie: maxAge: 365 * 24 * 60 * 60 * 1000
+		cookie: maxAge: sessionTimeOutMilliseconds
 		resave: true
 		saveUninitialized: true,
-		store: sessionStore # MemoryStore is used automatically if no "store" field is set, but we need a handle on the sessionStore object for Socket.IO, so we'll manually create the store so we have a handle on the object
+		store: sessionStore
 
 	app.use flash()
 	app.use passport.initialize()

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -768,6 +768,8 @@ client.cmpdreg.serverSettings.liveDesign.url=http://localhost:8010/ld-chem
 
 client.cmpdreg.serverSettings.maxStandardizationDisplay=20000
 
+# Sets cookie maxAge to 1440 minutes = 24 hours
+server.sessionTimeOutMinutes=1440
 
 # About configs
 client.about.acas.version=0.0.0

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "less": "^3.12.2",
     "lodash": "^4.17.20",
     "marked": "4.0.10",
-    "memorystore": "1.6.4",
+    "connect-pg-simple": "10.0.0",
     "method-override": "^3.0.0",
     "mocha": "8.2.1",
     "mochawesome": "^6.2.1",


### PR DESCRIPTION
## Description
 - Switch from memory store to postgres database store for session
 - Added a new config `config.all.server.sessionTimeOutMinutes` (default 1440 = 24 hours)

## Related Issue
ACAS-823

## How Has This Been Tested?
  - Ran ACAS client tests locally
  - Basic test
     - Logged into ACAS and verified login works.
     - Restarted ACAS and verified I was still logged in when ACAS started.
     - Tried logging after a few minutes and verified it was 
     - Set the session time out 1 minute and restarted acas
     - Logged back, waited one minute and verified I was logged out automatically
 - 2 Replica test
   - Setup acas with 2 replicas in kubernetes
   - Logged into ACAS
   - Deleted the pod I was logged into and continued to work on the same window I was using previously without having to log back in.