### PR TITLE
ACAS-814: Fix typo and styling on Salt browser/editor

### DIFF
--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -125,7 +125,6 @@ class SaltBrowserController extends Backbone.View
 		"click .bv_cancelCreate": "handleCancelCreateClicked"
 		"click .bv_okayCreateButton":"handleOkayCreateClicked"
 		"click .bv_backConfirmCreate":"handleBackConfirmCreateClicked"
-		"click .bv_cancelConfirmCreate":"handleCancelConfirmCreateClicked"
 		"click .bv_saveSaltButton":"handleSaveSaltButtonClicked"
 		# Edit Salt Button Events
 		"click .bv_editSalt": "handleEditSaltClicked"
@@ -351,11 +350,6 @@ class SaltBrowserController extends Backbone.View
 		@$('.bv_confirmCreateSalt').hide()
 		@$('.bv_createSalt').show()
 		@$('.bv_createNotifications').hide()
-
-	handleCancelConfirmCreateClicked: => 
-		@$('.bv_confirmCreateSalt').hide()
-		@$('.bv_saltBrowserCoreContainer').show()
-		@$('bv_saltBrowserCore').show()
 
 	# Non Dry Run Method to Register Salt Reviewed by User
 	handleSaveSaltButtonClicked: =>

--- a/modules/ServerAPI/src/client/SaltBrowser.html
+++ b/modules/ServerAPI/src/client/SaltBrowser.html
@@ -118,7 +118,7 @@
             <!-- Input Salt Section-->
             <div class="bv_chemicalStructureForm">
             </div>
-            <p><i>Use the sketcher to sepcify the molecular structure of the salt. Pay close attention to charges as they will be used in calculating Lot Molecular Weight. Use the + and - buttons to add positive or negative charges</i></p>
+            <p><i>Use the sketcher to specify the molecular structure of the salt. Pay close attention to charges as they will be used in calculating Lot Molecular Weight. Use the + and - buttons to add positive or negative charges</i></p>
             <br>
             <br>
             <label for="abbrevName">Abbreviation: </label><br>
@@ -130,11 +130,11 @@
         </div>
         <div class="footer">
 		    <span class="bv_createButtons">
-		      <a href="#" class="btn btn-primary bv_cancelCreate">Back</a>
-		      <a href="#" class="btn btn-danger bv_confirmCreateSaltButton">Next</a>
+		      <a href="#" class="btn bv_cancelCreate">Back</a>
+		      <a href="#" class="btn bv_confirmCreateSaltButton">Next</a>
 			  </span>
 		    <span class="bv_okayCreateButton hide">
-			    <a href="#" class="btn btn-primary bv_okayCreate">Okay</a>
+			    <a href="#" class="btn bv_okayCreate">Okay</a>
 		    </span>
         </div>
     </div>
@@ -159,9 +159,8 @@
         </div>
         <div class="footer">
 		    <span class="bv_createConfirmButtons">
-		      <a href="#" class="btn btn-primary bv_backConfirmCreate">Back</a>
-              <a href="#" class="btn btn-danger bv_cancelConfirmCreate">Cancel</a>
-		      <a href="#" class="btn btn-danger bv_saveSaltButton">Save</a>
+		      <a href="#" class="btn bv_backConfirmCreate">Back</a>
+		      <a href="#" class="btn btn-success bv_saveSaltButton">Save</a>
 			  </span>
         </div>
     </div>
@@ -195,7 +194,7 @@
         <div class="body">
             <div class="bv_editChemicalStructureForm">
             </div>
-            <p><i>Use the sketcher to sepcify the molecular structure of the salt. Pay close attention to charges as they will be used in calculating Lot Molecular Weight. Use the + and - buttons to add positive or negative charges</i></p>
+            <p><i>Use the sketcher to specify the molecular structure of the salt. Pay close attention to charges as they will be used in calculating Lot Molecular Weight. Use the + and - buttons to add positive or negative charges</i></p>
             <br>
             <label for="abbrevName">Abbreviation: </label>
             <input type="text" id="abbrevNameEdit" name="abbrevNameEdit" class="bv_abbrevNameEdit"><br>
@@ -206,8 +205,8 @@
         </div>
         <div class="footer">
             <span class="bv_createButtons">
-                <a href="#" class="btn btn-primary bv_cancelEdit">Back</a>
-                <a href="#" class="btn btn-danger bv_confirmEditSaltButton">Next</a>
+                <a href="#" class="btn bv_cancelEdit">Back</a>
+                <a href="#" class="btn bv_confirmEditSaltButton">Next</a>
                 </span>
         </div>
     </div>
@@ -251,12 +250,9 @@
                 </td>
             </tr>
         </div>
-        <div class="footer">
-		    <span class="bv_editConfirmButtons">
-		      <a href="#" class="btn btn-primary bv_backConfirmEdit">Back</a>
-              <a href="#" class="btn btn-danger bv_cancelConfirmEdit">Cancel</a>
-		      <a href="#" class="btn btn-danger bv_editSaltButton">Update</a>
-			  </span>
+        <div class="footer span12">
+		      <a href="#" class="btn bv_backConfirmEdit">Back</a>
+		      <a href="#" class="btn btn-success bv_editSaltButton">Update</a>
         </div>
     </div>
     <div class="hide bv_editSaltStatus">
@@ -273,7 +269,7 @@
         </div>
         <div class="footer">
 		    <span class="bv_editConfirmButtons">
-              <a href="#" class="btn btn-danger bv_okayEditButton hide">Okay</a>
+              <a href="#" class="btn bv_okayEditButton hide">Okay</a>
 			  </span>
         </div>
     </div>
@@ -299,7 +295,7 @@
                 </tr>
             </div>
 		    <span class="bv_deleteButtons">
-		      <a href="#" class="btn btn-primary bv_cancelDelete">Cancel</a>
+		      <a href="#" class="btn bv_cancelDelete">Cancel</a>
 		      <a href="#" class="btn btn-danger bv_confirmDeleteSaltButton">Delete Salt</a>
 			  </span>
         </div>
@@ -321,7 +317,7 @@
         </div>
         <div class="modal-footer">
 		    <span class="bv_okayDeleteButton">
-			    <a href="#" class="btn btn-primary bv_okayDelete">Okay</a>
+			    <a href="#" class="btn bv_okayDelete">Okay</a>
 		    </span>
         </div>
     </div>


### PR DESCRIPTION
## Description
Reported issue was a typo in user instructions. I also noticed use of color on buttons was inconsistent with the rest of the app, and there was a layout issue with the confirmation buttons on the Edit salt confirmation dialog.

- Fixed `sepcify` -> `specify` typo
- Removed `btn-primary` and `btn-danger` classes from most buttons in the workflow so `btn-danger` is only used on Delete dialogs. Switched Save / Update dialogs to `btn-success` (green)
- Removed the Cancel button from dialogs that had Back / Cancel / Save. The Back button already works to go backward and the wizard is only 2 steps deep, so I found the Cancel button to be unnecessary

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
Manual testing. See video (sorry for low resolution):

https://github.com/user-attachments/assets/1f0f44e4-bb28-455e-ac9f-84d0bfbe4cf4

