### PR TITLE
ACAS-834: Provide appropriate inputs for bulk loader default values

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -251,6 +251,7 @@ class AssignedPropertyController extends AbstractFormController
 		@$('.bv_defaultVal').val @model.get('defaultVal')
 		if @model.get('dbProperty') is "none"
 			@$('.bv_defaultVal').attr 'disabled', 'disabled'
+		@showDatePicker()
 
 		@
 
@@ -297,6 +298,7 @@ class AssignedPropertyController extends AbstractFormController
 		else
 			@model.set required: false
 		@model.set dbProperty: dbProp
+		@showDatePicker()
 
 		@trigger 'assignedDbPropChanged'
 
@@ -306,6 +308,15 @@ class AssignedPropertyController extends AbstractFormController
 	clear: =>
 		@model.destroy()
 		@trigger 'modelRemoved'
+	
+	showDatePicker: =>
+		if @model.get('dbProperty').includes("Lot Synthesis Date")
+			@$('.bv_defaultVal').datepicker();
+			@$('.bv_defaultVal').datepicker( "option", "dateFormat", "yy-mm-dd" );
+			@$('.bv_defaultVal').attr('placeholder', 'YYYY-MM-DD')
+		else
+			@$('.bv_defaultVal').datepicker('destroy');
+			@$('.bv_defaultVal').attr('placeholder', '')
 
 class AssignedPropertiesListController extends AbstractFormController
 	template: _.template($("#AssignedPropertiesListView").html())

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.coffee
@@ -337,12 +337,13 @@ class AssignedPropertyController extends AbstractFormController
 				code: ""
 				name: "Select"
 			selectedCode: ""
+			backendSearch: false
 	
 	setupInput: =>
 		# Alter input depending on dbProperty
 		dbProp = @model.get('dbProperty')
 		if @dbPropertyUrls[dbProp]? || dbProp.includes("Units")
-			@dbPropertyUrl = @dbPropertyUrls[@model.get('dbProperty')]
+			@dbPropertyUrl = @dbPropertyUrls[dbProp]
 			if !@dbPropertyUrl?
 				@dbPropertyUrl = @dbPropertyUrls["Units"]
 			@setupSelect()
@@ -358,7 +359,7 @@ class AssignedPropertyController extends AbstractFormController
 				@selectListController = null
 			@$('.bv_defaultVal').show()
 		# Show date picker if dbProperty is a date
-		if @model.get('dbProperty').includes("Lot Synthesis Date")
+		if dbProp.includes("Lot Synthesis Date")
 			@$('.bv_defaultVal').datepicker();
 			@$('.bv_defaultVal').datepicker( "option", "dateFormat", "yy-mm-dd" );
 			@$('.bv_defaultVal').attr('placeholder', 'YYYY-MM-DD')

--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -216,6 +216,7 @@
         </span>
         <span class="control-group bv_group_defaultVal">
             <input class="bv_defaultVal span2" style="margin-left:20px;width:270px;" type="text"/>
+            <select class="bv_defaultValSelect hide" style="width:300px;margin-left:6px;">
         </span>
         <button class="close bv_deleteProperty hide" style="margin-top:1px;">&times;</button>
     </div>

--- a/modules/Components/src/client/PickList.coffee
+++ b/modules/Components/src/client/PickList.coffee
@@ -366,8 +366,10 @@ class PickListSelect2Controller extends PickListSelectController
 			allowClear: true
 			width: @width
 
-		# Conditionally add the ajax property
-		if @collection.url?
+		# Conditionally add the ajax property to enable backend searching
+		# If a url is provided, backend search is enabled by default but
+		# can be toggled off by setting the 'backendSearch' option to false
+		if @collection.url? && (!@options.backendSearch? || @options.backendSearch is true)
 			select2Options.ajax = 
 				url: (params) =>
 					if !params.term?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The original ticket was narrowly scoped to provide a date picker when entering the lot date synthesized. I did that, and then extended it to also provide dropdowns for any fields that have constrained possible values / data dictionaries.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://schrodinger.atlassian.net/browse/ACAS-834

## How Has This Been Tested?
<!--- Describe how this has been tested -->
Tested locally:
- Changing dbProperty back and forth between normal, dropdown, and date type parameters
- Submitting the form for validation and inspecting the request to confirm all types get the defaultValue inserted
- Tested creating a template, and how the form renders when a premade template is selected and then the file is loaded.

## Screenshots / Videos
Dropdown:
<img width="930" alt="Screenshot 2025-03-04 at 11 18 27 AM" src="https://github.com/user-attachments/assets/d13d78d4-d9e3-4b93-b72c-46f54b2009bf" />

Date picker:
<img width="868" alt="Screenshot 2025-03-04 at 11 18 36 AM" src="https://github.com/user-attachments/assets/b6cb5a68-fde9-4421-ae1d-750d2ea6a8da" />


## Known Issues
- Many of the cmpdreg routes don't support searching by labelText so they don't update when a user types into the select2 search box. @brianbolt do you know if we have a feature to do frontend filtering of options rather than backend?