### PR TITLE
ACAS-669: Fix text overflow of long sdf property name

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.html
@@ -210,7 +210,7 @@
 <script type="text/template" id="AssignedPropertyView" xmlns="http://www.w3.org/1999/html">
 
     <div class="form-inline" style="margin-bottom:10px;margin-left:0px;">
-        <span class="bv_sdfProperty span2" style="margin-top:5px;margin-left:0px;text-align:right;">Corporate ID</span>
+        <span class="bv_sdfProperty span2" style="margin-top:5px;margin-left:0px;text-align:right;overflow-wrap:break-word;">Corporate ID</span>
         <span class="control-group bv_group_dbProperty">
             <select class="bv_dbProperty span3"></select>
         </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The UI looks buggy when an SDF property with a long name is uploaded. This PR fixes the CSS to overflow even if it has to break a word.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
Manually in local UI:
<img width="923" alt="Screenshot 2025-03-04 at 11 35 57 AM" src="https://github.com/user-attachments/assets/c0c9b00e-540d-49cb-bde6-68d1de192340" />
