### PR TITLE
ACAS-786: Add restandardization check to SaltBrowser

### DIFF
--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -167,7 +167,28 @@ class SaltBrowserController extends Backbone.View
 			el: @$('.bv_fieldNotifications')
 			showPreview: false
 		@$('.bv_fieldNotifications').hide()
+		@checkAllowCmpdRegistration()
 
+	checkAllowCmpdRegistration: ->
+		$.ajax
+			type: 'GET'
+			url: "/cmpdReg/allowCmpdRegistration"
+			success: (allowRegResp) =>
+				if !allowRegResp.allowCmpdRegistration
+					@$('.bv_createNewSaltBtn').prop 'disabled', true
+					@$('.bv_downloadSaltBtn').prop 'disabled', true
+					@$('.bv_disableCmpdRegistrationMessage').show()
+					@$('.bv_disableCmpdRegistrationMessage').html allowRegResp.message.replace("Compounds", "Salts")
+					@allowCmpdRegistration = false
+				else
+					@allowCmpdRegistration = true
+			error: (err) =>
+				@$('.bv_createNewSaltBtn').prop 'disabled', true
+				@$('.bv_downloadSaltBtn').prop 'disabled', true
+				@$('.bv_disableCmpdRegistrationMessage').show()
+				@$('.bv_disableCmpdRegistrationMessage').html JSON.parse(err.responseText).message.replace("Compounds", "Salts")
+				@allowCmpdRegistration = false
+	
 	setupSaltSummaryTable: (salts) =>
 		@destroySaltSummaryTable()
 
@@ -195,6 +216,8 @@ class SaltBrowserController extends Backbone.View
 		$('.bv_saltController').html @saltController.render().el
 		$(".bv_saltController").removeClass("hide")
 		$(".bv_saltControllerContainer").removeClass("hide")
+		if !@allowCmpdRegistration
+			@$('.bv_saltControllerContainer .bv_editSalt').prop 'disabled', true
 
 		# Request JSON Used to Render Image of Salt
 		requestJSON = {

--- a/modules/ServerAPI/src/client/SaltBrowser.html
+++ b/modules/ServerAPI/src/client/SaltBrowser.html
@@ -107,6 +107,7 @@
                 <div class="bv_saltController hide"></div>
             </div>
         </div>
+        <div class="alert bv_disableCmpdRegistrationMessage span6 offset3 hide"></div>
     </div>
 
     <!-- CREATE SALT SECTION -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the "allow cmpd registration" check that already exists on CReg single and bulk pages into the Salt Browser, since it also relies on chemistry services. Create, Edit, and Download buttons are disabled if compound registration is currently unavailable due to a need for a restandardization or due to unavailable chemistry services.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
Tested by switching local roo to bbchem mode and pointing at a remove bbchem instance, which triggered some errors / failures from the allowCmpdRegistration route.
The table is still visible but the buttons at the top are disabled
<img width="1634" alt="Screenshot 2025-03-04 at 3 33 20 PM" src="https://github.com/user-attachments/assets/b2878b6b-f162-4d3f-bfe0-a91aaaf5fbc6" />

Viewing and deleting is still available but editing is blocked
<img width="1626" alt="Screenshot 2025-03-04 at 3 33 25 PM" src="https://github.com/user-attachments/assets/8fff2825-ab72-4b5b-b3b6-d407b9785260" />
