### PR TITLE
ACAS-669: Follow-up fix to CSS for SDF bulk loader when dealing with long property names

### DIFF
--- a/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.css
+++ b/modules/CmpdRegBulkLoader/src/client/CmpdRegBulkLoader.css
@@ -90,3 +90,7 @@
     border-color: #b94a48;
     border-style: solid;
 }
+
+.bv_propInfo .form-inline {
+    clear: both;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#1204 changed styling to allow long property names to overlap, but this introduced a new styling issue:
<img width="950" alt="Screenshot 2025-03-13 at 4 57 05 PM" src="https://github.com/user-attachments/assets/937d9fc8-c204-4885-85f0-805d9c4182c9" />

This PR contains the CSS fix for that issue

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
Locally:
<img width="910" alt="Screenshot 2025-03-13 at 10 44 35 AM" src="https://github.com/user-attachments/assets/484272a2-7981-4f18-ac30-6930b3e0538f" />

