### PR TITLE
Nim 1808 curve overlay coloring v2

### DIFF
--- a/modules/CurveAnalysis/src/server/renderCurve.R
+++ b/modules/CurveAnalysis/src/server/renderCurve.R
@@ -43,7 +43,11 @@ renderCurve <- function(getParams, postData) {
   setContentType("image/png")
   setHeader("Content-Disposition", paste0("filename=\"",strtrim(getParams$curveIds,200),".png\""))
   t <- tempfile()
-  racas::plotCurve(curveData = data$points, params = data$parameters, drawCurve = TRUE, logDose = parsedParams$logDose, logResponse = parsedParams$logResponse, outFile = t, ymin=parsedParams$yMin, ymax=parsedParams$yMax, xmin=parsedParams$xMin, xmax=parsedParams$xMax, height=parsedParams$height, width=parsedParams$width, showGrid = parsedParams$showGrid, showAxes = parsedParams$showAxes, labelAxes = parsedParams$labelAxes, showLegend=parsedParams$legend, mostRecentCurveColor = parsedParams$mostRecentCurveColor, axes = parsedParams$axes, plotColors = parsedParams$plotColors, curveLwd=parsedParams$curveLwd, plotPoints=parsedParams$plotPoints, xlabel = parsedParams$xLab, ylabel = parsedParams$yLab)
+
+  #preserve requested curve coloring order
+  orderedParams <- data$parameters[order(match(data$parameters$curveId, parsedParams$curveId),na.last = TRUE), ]
+
+  plotCurve(curveData = data$points, params = orderedParams, drawCurve = TRUE, logDose = parsedParams$logDose, logResponse = parsedParams$logResponse, outFile = t, ymin=parsedParams$yMin, ymax=parsedParams$yMax, xmin=parsedParams$xMin, xmax=parsedParams$xMax, height=parsedParams$height, width=parsedParams$width, showGrid = parsedParams$showGrid, showAxes = parsedParams$showAxes, labelAxes = parsedParams$labelAxes, showLegend=parsedParams$legend, mostRecentCurveColor = parsedParams$mostRecentCurveColor, axes = parsedParams$axes, plotColors = parsedParams$plotColors, curveLwd=parsedParams$curveLwd, plotPoints=parsedParams$plotPoints, xlabel = parsedParams$xLab, ylabel = parsedParams$yLab)
   sendBin(readBin(t,'raw',n=file.info(t)$size))
   unlink(t)
   DONE


### PR DESCRIPTION
Description
If http request &mostRecentCurveColor is supplied as "none" or "false" then the global config option is disabled.

Sort descending by curve recordedDate is removed. However, if mostRecentCurveColor is enabled, then only that curve is moved to the top of the plot.

Because of these changes, if the request includes &plotColors aligned in order with &curveIds, that color assignment is respected

Related Issue
Tracked in a user issue tracking system

This change works with changes to racas rendering.R

How Has This Been Tested?
Stage and prod testing, then stage again when this further issue was found