### PR TITLE
ACAS-854: Don't include users in project fetch

### DIFF
--- a/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
+++ b/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
@@ -265,7 +265,7 @@ def get_user(client, username, use_acas_only_acl_groups = True):
 
 def get_projects(client):
     logger.info("get_projects")
-    ld_projects = client.projects()      
+    ld_projects = client.projects(include_users=False)
 
     projects = list(map(ld_project_to_acas, ld_projects))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Adds include_users=False to client.projects call to decrease the amount of data fetched/returned since we don't actually use the users returned in this call.

## Related Issue
https://schrodinger.atlassian.net/browse/ACAS-854

## How Has This Been Tested?
Patched this into a server which was returning more data than the allowed buffer (1MB at that time) and causing json parsing issue when trying to parse a truncated stdout.
Verified that this decreased the amount of data returned by the call and the data returned was < 1MB and could be parsed correctly.
Verified that the Experiments Editor page loaded correctly after this change.