### PR TITLE
ACAS-855: Configs for allow multiple workers to work on dry run standardization

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -619,7 +619,7 @@ server.curveRender.plotPointsOnOverlay=false
 # Restrict experiment search by project
 server.service.projects.restrictExperiments=true
 
-server.flyway.location=com.labsynch.labseer.db.migration.postgres,db/migration/postgres,db/migration/indigo/postgres
+server.flyway.location=com.labsynch.labseer.db.migration.postgres,db/migration/postgres,db/migration/bbchem/postgres
 
 server.chemistry.package=rdkit
 server.acas.batchSize=250
@@ -752,8 +752,8 @@ client.cmpdreg.serverSettings.disableTubeCreationIfNoBarcode=false
 client.cmpdreg.serverSettings.checkACASDependenciesByContainerCode=false
 client.cmpdreg.serverSettings.jchemVersion=16.4.25.0
 client.cmpdreg.serverSettings.databaseType=postgres
-client.cmpdreg.serverSettings.standardizeStructure=false
-client.cmpdreg.serverSettings.useExternalStandardizerConfig=false
+client.cmpdreg.serverSettings.standardizeStructure=true
+client.cmpdreg.serverSettings.useExternalStandardizerConfig=true
 client.cmpdreg.serverSettings.standardizerConfigFilePath=/home/runner/build/conf/standardizerConfig.xml
 client.cmpdreg.serverSettings.orderSelectLists=true
 client.cmpdreg.serverSettings.registerNoStructureCompoundsAsUniqueParents=false
@@ -763,8 +763,8 @@ client.cmpdreg.marvin.marvinImplicitH=heteroterm
 client.cmpdreg.marvin.sketchBondLength=20
 client.cmpdreg.marvin.delayShowStep2Next=750
 client.cmpdreg.marvin.exportFormat=mol:V3
-client.cmpdreg.serverSettings.liveDesign.preprocessorSettings=
-client.cmpdreg.serverSettings.liveDesign.url=http://localhost:8010/ld-chem
+client.cmpdreg.serverSettings.liveDesign.preprocessorSettings={"output_format":"MOL","process_options":{"hash_scheme":"ALL_LAYERS","ignore_errors":false,"output_formats":["registration_hash","smiles","sdf","no_stereo_hash"],"process_attachment_point_structures":true,"process_star_atom_structure":true},"standardizer_actions":{"CHIRAL_FLAG_0_MEANING":"UNGROUPED_ARE_ABSOLUTE","CHOOSE_CANONICAL_TAUTOMER":true,"CLEAR_INVALID_WEDGE_BONDS":true,"EXPLICIT_HYDROGENS":"REMOVE_ALL","GENERATE_COORDINATES":"FULL_ALIGNED","HEAVY_HYDROGEN_DT":false,"KEEP_ONLY_LARGEST_STRUCTURE":true,"NEUTRALIZE":true,"REMOVE_PROPERTIES":false,"RESOLVE_AMBIGUOUS_TAUTOMERS":false,"STRIP_AND_GROUPS_ON_SINGLE_ATOM":true,"TRANSFORMATIONS":[]},"timeout":590}
+client.cmpdreg.serverSettings.liveDesign.url=https://qa-demo-25-2-beta.dev.bb.schrodinger.com/ld-chem
 
 client.cmpdreg.serverSettings.maxStandardizationDisplay=20000
 server.acas.externalStructureProcessingBatchSize=100

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -767,8 +767,17 @@ client.cmpdreg.serverSettings.liveDesign.preprocessorSettings=
 client.cmpdreg.serverSettings.liveDesign.url=http://localhost:8010/ld-chem
 
 client.cmpdreg.serverSettings.maxStandardizationDisplay=20000
+
+# Configures how many compounds are sent to the external structure processing service per request.
 server.acas.externalStructureProcessingBatchSize=100
+
+# Configures how many compounds are processed at a time when standardizing structures.
+# Structures are processed with 10 parallel processes
+# So with the default settings, 1000 compounds are split into groups of 10 and 100 are requested to the external service at a time.
 server.acas.standardizationBatchSize=1000
+
+# Configures how often a check is done to see if standardizaiton dry run is running.
+# If standardizaiton dry run is running then a worker will pick up and contribute to dry run after a default of 60 seconds.
 client.cmpdreg.serverSettings.checkForDryRunStandardizationDelay=60000
 
 # Sets cookie maxAge to 1440 minutes = 24 hours

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -619,7 +619,7 @@ server.curveRender.plotPointsOnOverlay=false
 # Restrict experiment search by project
 server.service.projects.restrictExperiments=true
 
-server.flyway.location=com.labsynch.labseer.db.migration.postgres,db/migration/postgres,db/migration/bbchem/postgres
+server.flyway.location=com.labsynch.labseer.db.migration.postgres,db/migration/postgres,db/migration/indigo/postgres
 
 server.chemistry.package=rdkit
 server.acas.batchSize=250
@@ -752,8 +752,8 @@ client.cmpdreg.serverSettings.disableTubeCreationIfNoBarcode=false
 client.cmpdreg.serverSettings.checkACASDependenciesByContainerCode=false
 client.cmpdreg.serverSettings.jchemVersion=16.4.25.0
 client.cmpdreg.serverSettings.databaseType=postgres
-client.cmpdreg.serverSettings.standardizeStructure=true
-client.cmpdreg.serverSettings.useExternalStandardizerConfig=true
+client.cmpdreg.serverSettings.standardizeStructure=false
+client.cmpdreg.serverSettings.useExternalStandardizerConfig=false
 client.cmpdreg.serverSettings.standardizerConfigFilePath=/home/runner/build/conf/standardizerConfig.xml
 client.cmpdreg.serverSettings.orderSelectLists=true
 client.cmpdreg.serverSettings.registerNoStructureCompoundsAsUniqueParents=false
@@ -763,8 +763,8 @@ client.cmpdreg.marvin.marvinImplicitH=heteroterm
 client.cmpdreg.marvin.sketchBondLength=20
 client.cmpdreg.marvin.delayShowStep2Next=750
 client.cmpdreg.marvin.exportFormat=mol:V3
-client.cmpdreg.serverSettings.liveDesign.preprocessorSettings={"output_format":"MOL","process_options":{"hash_scheme":"ALL_LAYERS","ignore_errors":false,"output_formats":["registration_hash","smiles","sdf","no_stereo_hash"],"process_attachment_point_structures":true,"process_star_atom_structure":true},"standardizer_actions":{"CHIRAL_FLAG_0_MEANING":"UNGROUPED_ARE_ABSOLUTE","CHOOSE_CANONICAL_TAUTOMER":true,"CLEAR_INVALID_WEDGE_BONDS":true,"EXPLICIT_HYDROGENS":"REMOVE_ALL","GENERATE_COORDINATES":"FULL_ALIGNED","HEAVY_HYDROGEN_DT":false,"KEEP_ONLY_LARGEST_STRUCTURE":true,"NEUTRALIZE":true,"REMOVE_PROPERTIES":false,"RESOLVE_AMBIGUOUS_TAUTOMERS":false,"STRIP_AND_GROUPS_ON_SINGLE_ATOM":true,"TRANSFORMATIONS":[]},"timeout":590}
-client.cmpdreg.serverSettings.liveDesign.url=https://qa-demo-25-2-beta.dev.bb.schrodinger.com/ld-chem
+client.cmpdreg.serverSettings.liveDesign.preprocessorSettings=
+client.cmpdreg.serverSettings.liveDesign.url=http://localhost:8010/ld-chem
 
 client.cmpdreg.serverSettings.maxStandardizationDisplay=20000
 server.acas.externalStructureProcessingBatchSize=100

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -767,6 +767,9 @@ client.cmpdreg.serverSettings.liveDesign.preprocessorSettings=
 client.cmpdreg.serverSettings.liveDesign.url=http://localhost:8010/ld-chem
 
 client.cmpdreg.serverSettings.maxStandardizationDisplay=20000
+server.acas.externalStructureProcessingBatchSize=100
+server.acas.standardizationBatchSize=1000
+client.cmpdreg.serverSettings.checkForDryRunStandardizationDelay=60000
 
 # Sets cookie maxAge to 1440 minutes = 24 hours
 server.sessionTimeOutMinutes=1440


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - These are the additional configuration to go with CmpdReg standardization as part of allowing multiple workers to work on standardization dry run. Related to https://github.com/mcneilco/acas-roo-server/pull/479 

## Related Issue
ACAS-855

## How Has This Been Tested?
Verified I could toggle anyone of these settings, restart ACAS and they affected the behavior according to their purpose.