### PR TITLE
add allowed operator config to generic data parser

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -510,7 +510,7 @@ server.sel.validateDoseResponseCurves=true
 # the config below is recommended for new installations
 # server.sel.supportedOperators=>,<,>=,<=,=
 # the config below matches the original hard-coded behavior
-server.sel.supportedOperators=>,<,=
+server.sel.supportedOperators=>,<
 
 # Default protocol/experiment description when loaded through experiment loader
 # server.sel.protocolDescription=${client.protocol.label} created by generic data parser

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -506,6 +506,12 @@ server.sel.protocolStatus=created
 server.sel.assayStage=unassigned
 server.sel.validateDoseResponseCurves=true
 
+# Supported operator types, to add additional operator types you may need to update modules/GenericDataParser/conf/genericDataParserConfJSON.coffee
+# the config below is recommended for new installations
+# server.sel.supportedOperators=>,<,>=,<=,=
+# the config below matches the original hard-coded behavior
+server.sel.supportedOperators=>,<,=
+
 # Default protocol/experiment description when loaded through experiment loader
 # server.sel.protocolDescription=${client.protocol.label} created by generic data parser
 # server.sel.experimentDescription=${client.experiment.label} created by generic data parser

--- a/modules/GenericDataParser/src/server/generic_data_parser.R
+++ b/modules/GenericDataParser/src/server/generic_data_parser.R
@@ -1683,8 +1683,12 @@ organizeCalculatedResults <- function(calculatedResults, inputFormat, formatPara
   
   longResults$"UnparsedValue" <- trim(as.character(longResults$"UnparsedValue"))
   
+  # Get supportedOperators from config
+  supportedOperators <- strsplit(racas::applicationSettings$server.sel.supportedOperators,",")[[1]]
+  matchExpression <- paste0(supportedOperators, collapse = "|")
+
   # Parse numeric data from the unparsed values
-  matches <- is.na(suppressWarnings(as.numeric(gsub("^(>|<)(.*)", "\\2", gsub(",","",longResults$"UnparsedValue")))))
+  matches <- is.na(suppressWarnings(as.numeric(gsub(paste0("^(",matchExpression,")(.*)"), "\\2", gsub(",","",longResults$"UnparsedValue")))))
   longResults$"numericValue" <- longResults$"UnparsedValue"
   longResults$"numericValue"[matches] <- ""
   
@@ -1697,7 +1701,6 @@ organizeCalculatedResults <- function(calculatedResults, inputFormat, formatPara
   longResults$"stringValue"[longResults$Class == "Clob"] <- ""
   
   # Parse Operators from the unparsed value
-  matchExpression <- ">|<"
   longResults$"valueOperator" <- longResults$"numericValue"
   matches <- gregexpr(matchExpression,longResults$"numericValue")
   regmatches(longResults$"valueOperator",matches, invert = TRUE) <- ""


### PR DESCRIPTION


## Description
Added a configuration to set which value operators are accepted by Generic Data Parser

## Related Issue
https://github.com/mcneilco/acas/issues/565

## How Has This Been Tested?
Tested against release 2024.2 and released to prod for Nimbus