### PR TITLE
ACAS-982: Remove bin folder cross mounting

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -112,6 +112,10 @@ jobs:
           pip install ./acasclient
       - name: Run tests
         run: python -m unittest discover -s ./acasclient -p "test_*.py" -v
+
+      - name: Print docker-compose logs on failure
+        if: ${{ failure() }}
+        run: docker compose -f "docker-compose.yml" logs --no-color
       - name: Build multi-arch and push
         # Only push tags, release branches, or master
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/') }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     volumes:
      - filestore:/home/runner/build/privateUploads
      - logs:/home/runner/logs
-     - /home/runner/build/bin
      - /home/runner/build/src/r
      - /home/runner/build/conf
     # Add chemaxon marvinjs here


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Improvements
 - Outputs logs when tests fail
 - Removes unnecessary acas container bin mount override to other containers on docker compose stacks
    - Since enabling kubernetes, we have long since added the tools necessary in rservices to parse its config file on startup using scripts in inst/bin. However, we never updated the docker-compose.yaml file to skip cross mounting the acas node containers bin on the rservices container.  The files in acas have since diverged slightly.  Racas inst/bin/acas.sh executes the coffeescript version of PrepareConfigFiles, while the acas version runs the compiled javascript version. Thus, on recent versions of docker compose stacks, rservices, dependending on startuptime will miss compiling its configs with:

```
rservices-1  |   throw err;
rservices-1  |   ^
rservices-1  | 
rservices-1  | Error: Cannot find module '/home/runner/build/src/javascripts/BuildUtilities/PrepareConfigFiles.js'
```

This only recently became an issue as we introduced a new config (on master no release branches yet) which is loaded right at the start of the script, depending on startup time, you may hit this error.

```
rservices-1  | 1: runFunction()
rservices-1  | c("2: runMain(pathToGenericDataFormatExcelFile, reportFilePath = reportFilePath, ", "2:     dryRun = dryRun, developmentMode = developmentMode, configList = configList, ", "2:     testMode = testMode, recordedBy = recordedBy, imagesFile = imagesFile, ", "2:     moduleName = moduleName, errorEnv = errorEnv)")
rservices-1  | c("3: organizeCalculatedResults(calculatedResults, inputFormat, formatParameters, ", "3:     mainCode, lockCorpBatchId = formatParameters$lockCorpBatchId, ", "3:     rawOnlyFormat = rawOnlyFormat, errorEnv = errorEnv, precise = precise, ", "3:     calculateGroupingID = calculateGroupingID)")
rservices-1  | c("4: strsplit(racas::applicationSettings$server.sel.supportedOperators, ", "4:     \",\")")
rservices-1  | 2026-05-26 21:31:05.545646 ERROR:com.mcneilco.acas.genericDataParser:R frames dumped to: /tmp/file23
```

## Related Issue
ACAS-982

## How Has This Been Tested?
 - Ran on versions of acas where tests fail and verified logs were outputed
 - Ran on versions of acas where tests pass and verified the build succeeded
 - Locally ran docker compose up and verified the racas log showed configs were compiled correctly using the racas bin entrypoint script.
