### PR TITLE
ACAS-984 Fix standardization dry-run export download parsing

### DIFF
--- a/modules/Standardization/src/server/routes/StandardizationRoutes.coffee
+++ b/modules/Standardization/src/server/routes/StandardizationRoutes.coffee
@@ -178,9 +178,11 @@ exports.standardizationDryRunSearchExport = (req, resp) ->
 
 	request(
 		method: 'POST'
-		body: req.body
+		body: JSON.stringify(req.body)
 		url: url
-		json: true
+		headers:
+			'Content-Type': 'application/json'
+		json: false
 		timeout: 86400000
 	, (error, response, json) =>
 		console.log "standardizationDryRunFiles response" + JSON.stringify(response)
@@ -197,8 +199,8 @@ exports.standardizationDryRunSearchExport = (req, resp) ->
 			console.log 'Error with standardization dry run files'
 			console.log error
 			console.log json
-			resp.statusCode = response.statusCode
-			resp.end error
+			resp.statusCode = response?.statusCode or 500
+			resp.end if error? then JSON.stringify(error) else (json or 'Unable to export dry run files')
 	)
 
 exports.standardizationDryRunFiles = (req, resp) ->
@@ -211,7 +213,7 @@ exports.standardizationDryRunFiles = (req, resp) ->
 		method: 'POST'
 		body: filePath
 		url: url
-		json: true
+		json: false
 		timeout: 86400000
 	, (error, response, json) =>
 		console.log "standardizationDryRunFiles response" + JSON.stringify(response)
@@ -228,8 +230,8 @@ exports.standardizationDryRunFiles = (req, resp) ->
 			console.log 'Error with standardization dry run files'
 			console.log error
 			console.log json
-			resp.statusCode = response.statusCode
-			resp.end error
+			resp.statusCode = response?.statusCode or 500
+			resp.end if error? then JSON.stringify(error) else (json or 'Unable to fetch dry run files')
 	)
 
 


### PR DESCRIPTION
## Summary
Standardization dry-run result downloads could fail because the route expected a JSON response from the persistence endpoint even when that endpoint returned a plain text file path. That produced a JSON parse error and then a null response crash when reading `statusCode`.

This change updates the route calls to handle non-JSON response bodies for dry-run export/file retrieval and hardens error handling when no response object is available.

## Why this fixes it
- `standardizationDryRunSearchExport` now sends JSON request payload explicitly but does **not** force JSON parsing on the response.
- `standardizationDryRunFiles` now also treats the response as non-JSON.
- Both error paths now guard `response?.statusCode` and provide a safe fallback error body instead of throwing.

## Testing
- Reproduced the issue by running dry-run standardization and attempting to download results (observed JSON parse failure).
- Applied this patch on the server via ConfigMap override and deployment mount/restart.
- Re-tested dry-run standardization download; download now works.

<details>
<summary>Patch commands used during verification</summary>

```bash
kubectl patch configmap acas-custom-config-map \
  -n livedesign \
  --type merge \
  --patch "$(jq -Rs '{data:{\"StandardizationRoutes.coffee\": .}}' modules/Standardization/src/server/routes/StandardizationRoutes.coffee)"
```

```bash
kubectl patch deployment acas -n livedesign --type=json --patch='[
  {
    "op": "add",
    "path": "/spec/template/spec/volumes/-",
    "value": {
      "name": "standardization-routes",
      "configMap": {
        "name": "acas-custom-config-map",
        "defaultMode": 511
      }
    }
  },
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/volumeMounts/-",
    "value": {
      "name": "standardization-routes",
      "mountPath": "/home/runner/acas_custom/modules/Standardization/src/server/routes/StandardizationRoutes.coffee",
      "subPath": "StandardizationRoutes.coffee"
    }
  }
]'
```

```bash
kubectl rollout restart deployment/acas -n livedesign
kubectl rollout status deployment/acas -n livedesign
```

</details>

Then removed the patch manually later