### PR TITLE
ACAS-988: Migrate acas base to node:20.20.2-slim; simplify launcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,45 @@
-FROM quay.io/centos/centos:stream9
+# acas base image.
+#
+# This is a *base* image: downstream images (acas_custom_schrodinger) and the
+# dev docker-compose run `gulp build` / `gulp dev` on top of it, so the Node
+# build toolchain (gulp, coffeescript, git) must remain installed here. The
+# security-baseline win is the runtime base itself: the former full-distro,
+# rolling-tag quay.io/centos/centos:stream9 is replaced by the minimal,
+# version-pinned node:20.20.2-slim.
+FROM node:20.20.2-slim
 
-# Update
-RUN \
-  dnf update -y && \
-  dnf upgrade -y && \
-# tar for pulling down node
-# git required for some npm packages
-# postgresql for utility scripts
-  dnf install -y tar git && \
-  dnf install -y fontconfig urw-fonts iputils postgresql && \
-  dnf clean all
+# Runtime + build deps (Debian-slim equivalents of the old centos set):
+#  - git: required by some npm packages and downstream gulp builds
+#  - curl: bin/acas.sh polls the roo persistence service before starting
+#  - python3 + pip: the LiveDesign integration scripts the app shells out to
+#  - fontconfig + fonts-urw-base35: parity with the old fontconfig/urw-fonts
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git tar curl ca-certificates \
+      python3 python3-pip \
+      fontconfig fonts-urw-base35 \
+  && ln -sf /usr/bin/python3 /usr/bin/python \
+  && rm -rf /var/lib/apt/lists/*
 
-#Install python dependencies
-RUN   dnf install -y python311 python3.11-pip initscripts
-RUN   alternatives --install /usr/bin/python python /usr/bin/python3.11 1
-RUN   alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 1
-RUN		pip install argparse requests psycopg2-binary
-COPY    --chown=runner:runner requirements.txt $ACAS_BASE/requirements.txt
-RUN    pip install -r $ACAS_BASE/requirements.txt
+# Base python deps used by the runtime LiveDesign scripts.
+RUN pip install --no-cache-dir --break-system-packages requests psycopg2-binary
 
-# node
-ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 20.x
-RUN curl -fsSL https://rpm.nodesource.com/setup_$NODE_VERSION | bash - && \
-  dnf install -y nodejs
+# node:slim ships a `node` user/group at UID/GID 1000; drop it so runner can take 1000.
+RUN userdel -r node 2>/dev/null || true; groupdel node 2>/dev/null || true; \
+    useradd -u 1000 -ms /bin/bash runner
 
-# ACAS
-RUN	    useradd -u 1000 -ms /bin/bash runner
-ENV     APP_NAME ACAS
-ENV     BUILD_PATH /home/runner/build
-ENV     ACAS_BASE /home/runner/acas
-ENV     ACAS_CUSTOM /home/runner/acas_custom
-ENV     ACAS_SHARED /home/runner/acas_shared
-ENV     APACHE Redhat
-RUN     npm install -g gulp@4.0.2 forever@3.0.4 coffeescript@2.5.1
+ENV     APP_NAME=ACAS \
+        BUILD_PATH=/home/runner/build \
+        ACAS_BASE=/home/runner/acas \
+        ACAS_CUSTOM=/home/runner/acas_custom \
+        ACAS_SHARED=/home/runner/acas_shared
+
+# forever is intentionally not installed: in a container the runtime
+# (Docker/Kubernetes) is the process manager. bin/acas.sh runs node in the
+# foreground as PID 1.
+RUN     npm install -g gulp@4.0.2 coffeescript@2.5.1
 COPY    --chown=runner:runner package.json $ACAS_BASE/package.json
+COPY    --chown=runner:runner requirements.txt $ACAS_BASE/requirements.txt
+RUN     pip install --no-cache-dir --break-system-packages -r $ACAS_BASE/requirements.txt
 USER    runner
 WORKDIR $ACAS_BASE
 
@@ -66,4 +71,4 @@ RUN     gulp execute:prepare_config_files
 USER	runner
 
 EXPOSE 3000
-CMD     ["/bin/sh","bin/acas.sh", "run"]
+CMD     ["bin/acas.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
-# acas base image.
-#
-# This is a *base* image: downstream images (acas_custom_schrodinger) and the
-# dev docker-compose run `gulp build` / `gulp dev` on top of it, so the Node
-# build toolchain (gulp, coffeescript, git) must remain installed here. The
-# security-baseline win is the runtime base itself: the former full-distro,
-# rolling-tag quay.io/centos/centos:stream9 is replaced by the minimal,
-# version-pinned node:20.20.2-slim.
 FROM node:20.20.2-slim
 
-# Runtime + build deps (Debian-slim equivalents of the old centos set):
+# Runtime and build dependencies:
 #  - git: required by some npm packages and downstream gulp builds
 #  - curl: bin/acas.sh polls the roo persistence service before starting
 #  - python3 + pip: the LiveDesign integration scripts the app shells out to
-#  - fontconfig + fonts-urw-base35: parity with the old fontconfig/urw-fonts
+#  - fontconfig + fonts-urw-base35: fonts for server-side image/PDF rendering
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git tar curl ca-certificates \
       python3 python3-pip \
@@ -25,9 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # so allow pip to write there without passing --break-system-packages each call.
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-# Base python deps used by the runtime LiveDesign scripts. (truststore -- a
-# runtime dep of the ldclient that acas installs with --no-deps -- is pinned in
-# requirements.txt below, which is the single source for it.)
+# Python deps for the runtime LiveDesign scripts.
 RUN pip install --no-cache-dir --break-system-packages \
       requests psycopg2-binary
 
@@ -41,9 +31,6 @@ ENV     APP_NAME=ACAS \
         ACAS_CUSTOM=/home/runner/acas_custom \
         ACAS_SHARED=/home/runner/acas_shared
 
-# forever is intentionally not installed: in a container the runtime
-# (Docker/Kubernetes) is the process manager. bin/acas.sh runs node in the
-# foreground as PID 1.
 RUN     npm install -g gulp@4.0.2 coffeescript@2.5.1
 COPY    --chown=runner:runner package.json $ACAS_BASE/package.json
 COPY    --chown=runner:runner requirements.txt $ACAS_BASE/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && ln -sf /usr/bin/python3 /usr/bin/python \
   && rm -rf /var/lib/apt/lists/*
 
-# Base python deps used by the runtime LiveDesign scripts.
-RUN pip install --no-cache-dir --break-system-packages requests psycopg2-binary
+# Debian marks its Python as externally managed (PEP 668). acas installs the
+# LiveDesign ldclient into the user site at runtime (ServerAPI Bootstrap.coffee),
+# so allow pip to write there without passing --break-system-packages each call.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+# Base python deps used by the runtime LiveDesign scripts. (truststore -- a
+# runtime dep of the ldclient that acas installs with --no-deps -- is pinned in
+# requirements.txt below, which is the single source for it.)
+RUN pip install --no-cache-dir --break-system-packages \
+      requests psycopg2-binary
 
 # node:slim ships a `node` user/group at UID/GID 1000; drop it so runner can take 1000.
 RUN userdel -r node 2>/dev/null || true; groupdel node 2>/dev/null || true; \

--- a/bin/acas.sh
+++ b/bin/acas.sh
@@ -1,504 +1,63 @@
 #!/bin/bash
-### BEGIN INIT INFO
-# Provides:		acas
-# Required-Start:	$local_fs
-# Required-Stop:	$local_fs
-# Default-Start:	2 3 4 5
-# Default-Stop:		0 1 6
-# Short-Description: start and stop the acas app.js, server.js and apache instance
-# Description: start and stop the acas app.js, server.js and apache instance
-### END INIT INFO
-# chkconfig: 2345 64 02
-# description: start and stop the acas app.js, server.js and apache instance
-# processname: acas
+#
+# Launcher for the ACAS Node app.
+#
+# This was historically a large SysV-init script that managed the node app via
+# `forever`, plus Apache/rapache and R. In a container the runtime (Docker /
+# Kubernetes) is the process manager, so this is now a thin launcher that just
+# prepares config and runs the app in the foreground (PID 1). Supported forms:
+#
+#   bin/acas.sh run [acas]          prepare config, then `node app.js`
+#   bin/acas.sh run [acas] start    same as above
+#   bin/acas.sh run [acas] dev      prepare config, then `gulp dev` (watch)
+#
 
-################################################################################
-################################################################################
-##                                                                            ##
-#                       PATHs section                                          #
-##                                                                            ##
-################################################################################
-################################################################################
-
-ARCH=$(uname -m | sed 's/x86_//;s/i[3-6]86/32/')
-
-if [ -f /etc/redhat-release ]; then
-    OS=`cat /etc/redhat-release | awk {'print $1}'`
-    VER=`cut -d ' ' -f 3 /etc/redhat-release`
-    . /etc/init.d/functions
-    apacheCMD='/usr/sbin/httpd'
-elif [ -f /etc/lsb-release ]; then
-    . /etc/lsb-release
-    OS=$DISTRIB_ID
-    VER=$DISTRIB_RELEASE
-    . /lib/lsb/init-functions
-    action() {
-      local STRING rc
-
-      STRING=$1
-      echo -n "$STRING "
-      shift
-      "$@" && success $"$STRING" || failure $"$STRING"
-      rc=$?
-      echo
-      return $rc
-    }
-    success() {
-      [ "$BOOTUP" != "verbose" -a -z "$LSB" ] && echo_success
-      return 0
-    }
-    failure() {
-      rc=$?
-      [ "$BOOTUP" != "verbose" -a -z "$LSB" ] && echo_failure
-      return $rc
-    }
-    echo_success() {
-      [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
-      echo -n "[  "
-      [ "$BOOTUP" = "color" ] && $SETCOLOR_SUCCESS
-      echo -n $"OK"
-      [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
-      echo -n "  ]"
-      echo -ne "\r"
-      return 0
-    }
-
-    echo_failure() {
-      [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
-      echo -n "["
-      [ "$BOOTUP" = "color" ] && $SETCOLOR_FAILURE
-      echo -n $"FAILED"
-      [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
-      echo -n "]"
-      echo -ne "\r"
-      return 1
-    }
-    apacheCMD='/usr/sbin/apache2'
-elif [ -f /etc/debian_version ]; then
-    OS=Debian  # XXX or Ubuntu??
-    VER=$(cat /etc/debian_version)
-    . /lib/lsb/init-functions
-else
-    OS=$(uname -s)
-    VER=$(uname -r)
-fi
-
-export PATH=/usr/local/bin:${PATH:=}
-export MANPATH=/usr/local/man:${MANPATH:=}
-export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH:=}
-
-# Get default locale
-# Ubuntu
-[ -f /etc/default/locale ] && . /etc/default/locale
-
-# Centos
-[ -f /etc/sysconfig/i18n ] && . /etc/sysconfig/i18n
-export LANG
-
-################################################################################
-################################################################################
-##                                                                            ##
-#                       FOREVER section                                        #
-##                                                                            ##
-################################################################################
-################################################################################
-
-
-running() {
-    runningCommand="export FOREVER_ROOT=$ACAS_HOME/bin && forever list 2>/dev/null | grep $ACAS_HOME/app.js 2>&1 >/dev/null"
-    if [ $(whoami) != "$ACAS_USER" ]; then
-        runningCommand="su -p - $ACAS_USER $suAdd -c \"($runningCommand)\""
-    fi
-    eval $runningCommand
-    return $?
-}
-
-start_server() {
-    startCommand="export FOREVER_ROOT=$ACAS_HOME/bin && forever start --killSignal=SIGTERM --workingDir --append -l $logname -o $logout -e $logerr $ACAS_HOME/app.js 2>&1 >/dev/null"
-    if [ $(whoami) != "$ACAS_USER" ]; then
-        startCommand="su -p - $ACAS_USER $suAdd -c \"(cd `dirname $ACAS_HOME/app.js` && $startCommand)\""
-    fi
-    eval $startCommand
-    return $?
-}
-
-run_server() {
-    if [ -z "$@" ]; then
-      runCommand="npm run start"
-    else
-      runCommand="npm run $@"
-    fi
-    echo "runCommand: $runCommand"
-    if [ $(whoami) != "$ACAS_USER" ]; then
-        startCommand="su -p - $ACAS_USER $suAdd -c \"(cd `dirname $ACAS_HOME/app.js` && $startCommand)\""
-    fi
-    eval "($runCommand)" &
-    return $?
-}
-
-stop_server() {
-    stopCommand="export FOREVER_ROOT=$ACAS_HOME/bin && forever stop $ACAS_HOME/app.js 2>&1 >/dev/null"
-    if [ $(whoami) != "$ACAS_USER" ]; then
-        stopCommand="su -p - $ACAS_USER $suAdd -c \"($stopCommand)\""
-    fi
-    eval $stopCommand
-
-    return $?
-}
-
-apache_running() {
-    pidofproc -p $ACAS_HOME/bin/apache.pid "DAEMON" 2>&1 >/dev/null
-    return $?
-    #[ `pgrep $pid` ] && echo 'running' || echo 'running'
-}
-
-start_apache() {
-    remove_apache_pid
-    startCommand=" $apacheCMD -f $ACAS_HOME/conf/compiled/apache.conf -k start 2>&1 >/dev/null"
-    if [ $(whoami) != "$RAPACHE_START_ACAS_USER" ]; then
-        startCommand="su -p - $RAPACHE_START_ACAS_USER $suAdd -c \"($startCommand)\""
-    fi
-    eval $startCommand
-    return $?
-}
-
-run_apache() {
-    cp $ACAS_HOME/conf/compiled/apache.conf /tmp/apache.conf
-    startCommand=" $apacheCMD -f /tmp/apache.conf -k start -DFOREGROUND"
-    if [ $(whoami) != "$RAPACHE_START_ACAS_USER" ]; then
-        startCommand="su -p - $RAPACHE_START_ACAS_USER $suAdd -c \"($startCommand)\""
-    fi
-    eval "($startCommand) $1"
-    return $?
-}
-
-stop_apache() {
-    stopCommand="$apacheCMD -f $ACAS_HOME/conf/compiled/apache.conf -k stop 2>&1 >/dev/null"
-    if [ $(whoami) != "$RAPACHE_START_ACAS_USER" ]; then
-        stopCommand="su -p - $RAPACHE_START_ACAS_USER $suAdd -c \"($stopCommand)\""
-    fi
-    eval $stopCommand
-    return $?
-}
-
-apache_reload() {
-    reloadCommand="$apacheCMD -f $ACAS_HOME/conf/compiled/apache.conf -k graceful 2>&1 >/dev/null"
-    if [ $(whoami) != "$RAPACHE_START_ACAS_USER" ]; then
-        reloadCommand="su -p - $RAPACHE_START_ACAS_USER $suAdd -c \"($reloadCommand)\""
-    fi
-    eval $reloadCommand
-    return $?
-}
-
-################################################################################
-################################################################################
-##                                                                            ##
-#                       GENERIC section                                        #
-##                                                                            ##
-################################################################################
-################################################################################
-
-DIETIME=1              # Time to wait for the server to die, in seconds
-# If this value is set too low you might not
-# let some servers to die gracefully and
-# 'restart' will not work
-
-STARTTIME=0.1             # Time to wait for the server to start, in seconds
-# If this value is set each time the server is
-# started (on start or restart) the script will
-# stall to try to determine if it is running
-# If it is not set and the server takes time
-# to setup a pid file the log message might
-# be a false positive (says it did not start
-# when it actually did)
-
-# Console logging.
-log() {
-    local STRING mode
-
-    STRING=$1
-    arg2=$2
-    mode="${arg2:=success}"
-
-    echo -n "$STRING "
-    if [ "${RHGB_STARTED:-}" != "" -a -w /etc/rhgb/temp/rhgb-console ]; then
-        echo -n "$STRING " > /etc/rhgb/temp/rhgb-console
-    fi
-    if [ "$mode" = "success" ]; then
-        success $"$STRING"
-    else
-        failure $"$STRING"
-    fi
-    echo
-    if [ "${RHGB_STARTED:-}" != "" -a -w /etc/rhgb/temp/rhgb-console ]; then
-        if [ "$mode" = "success" ]; then
-            echo_success > /etc/rhgb/temp/rhgb-console
-        else
-            echo_failure > /etc/rhgb/temp/rhgb-console
-            [ -x /usr/bin/rhgb-client ] && /usr/bin/rhgb-client --details=yes
-        fi
-        echo > /etc/rhgb/temp/rhgb-console
-    fi
-}
-
-# Starts the server.
-do_start() {
-    dirname=`basename $ACAS_HOME`
-    LOCKFILE=$ACAS_HOME/bin/app.js.LOCKFILE
-    logname=$server_log_path/acas_app${server_log_suffix}.log
-    logout=$server_log_path/acas_app${server_log_suffix}_stdout.log
-    logerr=$server_log_path/acas_app${server_log_suffix}_stderr.log
-    # Check if it's running first
-    if running ;  then
-        log "app.js already running"
-    else
-        action "Starting app.js" start_server
-        RETVAL=$?
-        if [ $RETVAL -eq 0 ]; then
-            # NOTE: Some servers might die some time after they start,
-            # this code will detect this issue if STARTTIME is set
-            # to a reasonable value
-            [ -n "$STARTTIME" ] && sleep $STARTTIME # Wait some time
-            if  running ;  then
-                # It's ok, the server started and is running
-                log "app.js started"
-                touch $LOCKFILE
-                RETVAL=0
-            else
-                # It is not running after we did start
-                log "app.js died on startup" "failure"
-                RETVAL=1
-            fi
-        fi
-
-    fi
-    if [ $doApache = true ]; then
-        if apache_running ;  then
-            log "apache already running"
-        else
-            action "Starting apache" start_apache
-            RETVAL=$?
-            if [ $RETVAL -eq 0 ]; then
-                log "apache started"
-            else
-                log "apache startup failure" "failure"
-                RETVAL=1
-            fi
-        fi
-    fi
-    return $RETVAL
-}
-
-remove_apache_pid() {
-  if [ -f "$ACAS_HOME/bin/apache.pid" ]; then
-      rm "$ACAS_HOME/bin/apache.pid"
-  fi
-}
-# Runs the server.
-do_run() {
-    if [ $name == "rservices" ] || [ $name == "all" ]; then
-        remove_apache_pid
-        counter=0
-        wait=5
-        until [ -f $ACAS_HOME/conf/compiled/apache.conf  ] || [ $counter == $wait ]; do
-            printf "."
-            sleep 1
-            counter=$((counter+1))
-        done
-        if [ $name == "all" ]; then
-            action "Running apache in background" run_apache &
-        else
-            action "Running apache" run_apache &
-        fi
-    fi
-
-    if [ $name == "acas" ] || [ $name == "all" ]; then
-        dirname=`basename $ACAS_HOME`
-        LOCKFILE=$ACAS_HOME/bin/app.js.LOCKFILE
-        action "Running app.js" run_server "${@:2}"
-        acaspid=$?
-    fi
-    trap 'kill -TERM jobs -p' TERM
-    wait
-    return $RETVAL
-}
-
-# Stops the server.
-do_stop() {
-    dirname=`basename $ACAS_HOME`
-    LOCKFILE=$ACAS_HOME/bin/app.js.LOCKFILE
-    if running ; then
-        # Only stop the server if we see it running
-        action "Stopping app.js" stop_server
-        RETVAL=$?
-        [ $RETVAL -eq 0 ] && rm -f $LOCKFILE
-    else
-        # If it's not running don't do anything
-        log "app.js not running"
-        RETVAL=0
-    fi
-    if [ $doApache = true ]; then
-        if apache_running ;  then
-            action "Stopping apache" stop_apache
-            RETVAL=$?
-        else
-            # If it's not running don't do anything
-            log "apache not running"
-            RETVAL=0
-        fi
-    fi
-    return $RETVAL
-}
-
-get_status() {
-    dirname=`basename $ACAS_HOME`
-    if running ;  then
-        log "app.js running"
-    else
-        log "app.js not running"
-    fi
-    if apache_running ;  then
-        log "apache running"
-    else
-        log "apache not running"
-    fi
-}
-
-usage() {
-    echo "Usage: ${0} {start|stop|status|restart|reload|run (options-rservices,acas,all:default-all)}"
-}
-
-################################################################################
-################################################################################
-##                                                                            ##
-#                           APPLICATION section                                #
-##             Edit the variables below for your installation                 ##
-#####################################################r###########################
-################################################################################
-# SETUP ACAS_HOME path
-scriptPath=$(readlink -f ${BASH_SOURCE[0]})
+scriptPath=$(readlink -f "${BASH_SOURCE[0]}")
 ACAS_HOME=$(cd "$(dirname "$scriptPath")"/..; pwd)
+cd "$ACAS_HOME" || exit 1
+export PATH=/usr/local/bin:${PATH}
 echo "ACAS_HOME=$ACAS_HOME"
-cd $ACAS_HOME
 
-# get customer specific environment
-[ -f $ACAS_HOME/bin/setenv.sh ] && . $ACAS_HOME/bin/setenv.sh  || echo "$ACAS_HOME/bin/setenv.sh not found"
+# Customer-specific environment overrides, if present.
+[ -f "$ACAS_HOME/bin/setenv.sh" ] && . "$ACAS_HOME/bin/setenv.sh"
 
-# Run Prepare config files as the compiled directory should be empty
+# Regenerate the compiled config from the environment.
 if [ "$PREPARE_CONFIG_FILES" = "true" ]; then
-    node $ACAS_HOME/src/javascripts/BuildUtilities/PrepareConfigFiles.js
+    node "$ACAS_HOME/src/javascripts/BuildUtilities/PrepareConfigFiles.js"
 fi
 
-#Get ACAS config variables
+# Load the compiled config into the shell (needed for the persistence URL below).
 counter=0
-wait=5
-until [ -f $ACAS_HOME/conf/compiled/conf.properties  ] || [ $counter == $wait ]; do
+until [ -f "$ACAS_HOME/conf/compiled/conf.properties" ] || [ $counter -ge 5 ]; do
     printf "."
     sleep 1
-    counter=$((counter+1))
+    counter=$((counter + 1))
 done
-source /dev/stdin <<< "$(cat $ACAS_HOME/conf/compiled/conf.properties | awk -f $ACAS_HOME/bin/readproperties.awk)"
+if [ -f "$ACAS_HOME/conf/compiled/conf.properties" ]; then
+    source /dev/stdin <<< "$(awk -f "$ACAS_HOME/bin/readproperties.awk" "$ACAS_HOME/conf/compiled/conf.properties")"
+fi
 
-# Once the script is available and the persistence service is up, run PrepareModuleConfJSON.js
+# Once the persistence service (roo) is up, (re)generate module config. Runs in
+# the background so it doesn't block the app from starting.
 if [ "$PREPARE_MODULE_CONF_JSON" = "true" ]; then
     (
-        # Run this until it succeeds
         persistence_service_url=$client_service_persistence_fullpath/protocoltypes
-        wait_between_retries=1
-        while true; do
-            # Wait until the persistence_service_url returns a non failure status code
-            if ! curl --output /dev/null --silent --head --fail $persistence_service_url; then
-                echo "PrepareModuleConfJSON.js: Persistence service url $persistence_service_url unavailable, waiting $wait_between_retries seconds before retrying"
-            else
-                echo "PrepareModuleConfJSON.js: Running PrepareModuleConfJSON.js"
-                node $ACAS_HOME/src/javascripts/BuildUtilities/PrepareModuleConfJSON.js
-                if [ $? -eq 0 ]; then
-                    echo "PrepareModuleConfJSON.js: Success"
-                    break
-                else
-                    echo "PrepareModuleConfJSON.js: Failed"
-                fi
-            fi
-            sleep $wait_between_retries
+        until curl --output /dev/null --silent --head --fail "$persistence_service_url"; do
+            echo "PrepareModuleConfJSON.js: $persistence_service_url unavailable, retrying in 1s"
+            sleep 1
         done
+        echo "PrepareModuleConfJSON.js: Running"
+        if node "$ACAS_HOME/src/javascripts/BuildUtilities/PrepareModuleConfJSON.js"; then
+            echo "PrepareModuleConfJSON.js: Success"
+        else
+            echo "PrepareModuleConfJSON.js: Failed"
+        fi
     ) &
 fi
 
-# Export these variables so that the apache config can pick them up
-export ACAS_USER=${server_run_user}
-if [ "$ACAS_USER" == "" ] || [ "$ACAS_USER" == "null" ]; then
-    #echo "Setting ACAS_USER to $(whoami)"
-    export ACAS_USER=$(whoami)
-fi
-echo "ACAS_USER=$ACAS_USER"
-echo "CLIENT_PORT=${client_port}"
-
-echo "RAPACHE_PORT=${client_service_rapache_port}"
-if [ ${client_service_rapache_port} -lt 1024 ] && [ $(whoami) != "root" ]; then
-    echo "skipping rapache as client.service.rapache.port is set to run on privilaged port '${client_service_rapache_port}' you must be root to stop, start or reload apache on this port"
-    doApache=false
+# Run the app. `dev` => gulp watch/rebuild; anything else => plain node.
+if [ "${@: -1}" = "dev" ]; then
+    exec npm run dev
 else
-    doApache=true
-    if [ ${client_service_rapache_port} -lt 1024 ]; then
-        RAPACHE_START_ACAS_USER="root"
-    else
-        RAPACHE_START_ACAS_USER=$ACAS_USER
-    fi
+    exec node app.js
 fi
-
-case "$1" in
-    run)
-        name=$2
-        name=${name:-all}
-        if [[ "$name" =~ ^(acas|rservices|all)$ ]]; then
-            do_run $name "${@:3}"
-        else
-            usage
-        fi
-    ;;
-    start)
-        do_start
-        RETVAL=$?
-    ;;
-    stop)
-        do_stop
-        RETVAL=$?
-    ;;
-    restart)
-        do_stop
-        RETVAL=$?
-        if [ $RETVAL -eq 0 ]; then
-            # Wait some sensible amount, some server need this
-            [ -n "$DIETIME" ] && sleep $DIETIME
-            do_start
-            RETVAL=$?
-        fi
-    ;;
-    status)
-        get_status
-        RETVAL=0
-    ;;
-    reload)
-        if [ $doApache = true ];  then
-            if apache_running; then
-                action "reloading apache" apache_reload
-                RETVAL=$?
-                if [ $RETVAL -eq 0 ]; then
-                    log "apache reloaded"
-                else
-                    log "apache reload failure" "failure"
-                    RETVAL=1
-                fi
-            else
-                log "apache is not running" "failure"
-                REVAL=0
-            fi
-            RETVAL=$RETVAL
-        fi
-    ;;
-    *)
-        usage
-        RETVAL=1
-    ;;
-esac
-exit $RETVAL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 requests>=2.0.0, <3.0.0
 Deprecated==1.2.10
+# Required by the LiveDesign ldclient, which ACAS installs at runtime with
+# --no-deps (modules/ServerAPI/src/server/Bootstrap.coffee), so its truststore
+# dependency must be pre-installed here. Without it the ldclient cannot establish
+# a TLS connection to LiveDesign. See ACAS-991.
+truststore>=0.9.0


### PR DESCRIPTION
## Problem
The acas runtime base `quay.io/centos/centos:stream9` is a full distro on a rolling tag — violating the [container image security baselines](https://schrodinger.atlassian.net/wiki/spaces/LDE/pages/1940160531) (minimal, version-pinned runtime).

## Change
- **Base → `node:20.20.2-slim`** (minimal, version-pinned). `acas-oss` is a *base* image that downstream (`acas_custom_schrodinger`) and the dev docker-compose run `gulp build`/`gulp dev` on top of, so the build toolchain (gulp, coffeescript, git) is retained; `python3`/`pip` remain for the LiveDesign integration scripts the app shells out to at runtime. Only the unused `forever` process manager is dropped.
- **`bin/acas.sh` slimmed 523 → 63 lines.** It was a legacy SysV-init script managing node via `forever`, plus Apache/rapache and R, and assumed CentOS (`/etc/init.d/functions`). In a container the runtime is the process manager, so it is now a thin launcher: prepare config → wait for roo + run `PrepareModuleConfJSON` → `exec` the app as PID 1 (`gulp dev` for `dev`, else `node app.js`). This also removes the CentOS-specific init-functions dependency so it runs on the slim base.

## Testing
Built and run via docker-compose: acas serves the UI on :3000 (401 login) and the API on :3001; module config generation and dev watch both work.

acasclient tests pass
loading data in bbchem version tests + open in livedesign and curve images inline in LD.

> Note: a downstream follow-up is needed in `acas_custom_schrodinger/Dockerfile` (its `yum install` line is a CentOS-ism that breaks now that this base is Debian).

Part of ACAS-988.

## Runtime Python deps for ldclient (truststore / PEP 668)

acas installs the LiveDesign `ldclient` at runtime with `--no-deps` (`ServerAPI` `Bootstrap.coffee`), so ldclient's dependencies must already be present in the image. Moving the base to Debian surfaced two issues:

- **`truststore`** — `ldclient` 2026.3 made `truststore` a required dependency: SSL verification now uses the native OS trust store instead of extracting certs to temp files (see schrodinger/livedesign-client#623). No acas base ever shipped `truststore`, so the `--no-deps` startup install fails with `ModuleNotFoundError: No module named 'truststore'`. This is an **ldclient version bump, not a Debian-specific issue** — the old CentOS base hits it too against ldclient ≥ 2026.3. Fixed by pre-baking `truststore>=0.9.0` into the base.
- **PEP 668 (externally-managed environment)** — Debian marks its system Python as externally managed, so the runtime `pip install --user` of ldclient is refused. Fixed with `ENV PIP_BREAK_SYSTEM_PACKAGES=1` so runtime installs succeed without editing the acas pip commands.
