### PR TITLE
ACAS-991: Bundle ldclient truststore dependency in ACAS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 requests>=2.0.0, <3.0.0
 Deprecated==1.2.10
+# Required by the LiveDesign ldclient, which ACAS installs at runtime with
+# --no-deps (modules/ServerAPI/src/server/Bootstrap.coffee), so its truststore
+# dependency must be pre-installed here. Without it the ldclient cannot establish
+# a TLS connection to LiveDesign. See ACAS-991.
+truststore>=0.9.0


### PR DESCRIPTION
## Problem
The smoke test **"should communicate with LiveDesign"** fails (options never load in the Select).

**Root cause — ldclient version bump, not a base-image issue.** ldclient **2026.3** made [`truststore`](https://pypi.org/project/truststore/) a **required dependency**: SSL verification now uses the native OS trust store instead of extracting certs to temp files (see **LDID8-1560: Replace manual SSL cert-loading with truststore**, schrodinger/livedesign-client#623).

No ACAS base image has ever shipped `truststore`. ACAS installs the ldclient at runtime with `pip install --no-deps ... ldclient.tar.gz` ([modules/ServerAPI/src/server/Bootstrap.coffee](https://github.com/mcneilco/acas/blob/master/modules/ServerAPI/src/server/Bootstrap.coffee)), so ldclient's own dependencies are **not** pulled in. Against ldclient ≥ 2026.3 the startup install therefore fails with:

```
ModuleNotFoundError: No module named 'truststore'
```

This is **not** Debian-specific — the old CentOS base hits it too against ldclient ≥ 2026.3. (`requests` and `Deprecated`, ldclient's other deps, already arrive via `requirements.txt`; only `truststore` was missing.)

## Fix
Pre-bake the dependency by adding `truststore>=0.9.0` to `requirements.txt`, which the Dockerfile installs at build time. One line, base-image-agnostic.

## Notes
Targeted fix split out from ACAS-988 (the base-image migration) so it can land independently on `master`. ACAS-988 references `truststore` from this same `requirements.txt` line (single source), so there is no conflict when both merge.

Fixes ACAS-991.
