### PR TITLE
ACAS-923: Preserve protocol experiment 404 responses

### DIFF
--- a/modules/ServerAPI/spec/serviceTests/ServerUtilityFunctionsMochaSpec.coffee
+++ b/modules/ServerAPI/spec/serviceTests/ServerUtilityFunctionsMochaSpec.coffee
@@ -18,6 +18,24 @@ parseResponse = (jsonStr) ->
 
 
 describe "Server Utiilty Function Tests", ->
+	describe "getFromACASServerInternalPreserveResponseStatus", ->
+		originalRequestAdapter = null
+
+		beforeEach ->
+			originalRequestAdapter = servUtilities.requestAdapter
+
+		afterEach ->
+			servUtilities.requestAdapter = originalRequestAdapter
+
+		it "should preserve not found responses from the ACAS server", (done) ->
+			servUtilities.requestAdapter = (options, callback) ->
+				callback null, {statusCode: 404}, []
+
+			servUtilities.getFromACASServerInternalPreserveResponseStatus "http://example.test/missing", (statusCode, json) ->
+				assert.equal statusCode, 404
+				assert.deepEqual json, []
+				done()
+
 	describe "File Value filtering", ->
 		describe "get fileValues from thing", ->
 			before (done) ->
@@ -77,5 +95,3 @@ describe "Server Utiilty Function Tests", ->
 			assert.equal @modEnt.lsStates[0].lsTransaction, 8354
 		it "should have a trans in the values", ->
 			assert.equal @modEnt.lsStates[0].lsValues[0].lsTransaction, 8354
-
-

--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -161,7 +161,7 @@ exports.experimentsByProtocolCodenameInternal = (code, user, testMode, callback)
 			allowedProjectCodes = _.pluck(allowedUserProjects, "code")
 			baseurl = "#{baseurl}?projects=#{encodeURIComponent(allowedProjectCodes.join(','))}"
 
-			serverUtilityFunctions.getFromACASServerInternal baseurl, (statusCode, value) ->
+			serverUtilityFunctions.getFromACASServerInternalPreserveResponseStatus baseurl, (statusCode, value) ->
 				callback(statusCode, value)
 
 exports.experimentById = (req, resp) ->

--- a/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
+++ b/modules/ServerAPI/src/server/routes/ServerUtilityFunctions.coffee
@@ -288,6 +288,22 @@ exports.getFromACASServerInternal = (baseurl, callback) ->
 			callback 500, {error: true, message:error}
 	)
 
+exports.getFromACASServerInternalPreserveResponseStatus = (baseurl, callback) ->
+	request = exports.requestAdapter
+	request(
+		method: 'GET'
+		url: baseurl
+		json: true
+	, (error, response, json) =>
+		if !error && response?
+			callback response.statusCode, json
+		else
+			console.log 'got ajax error'
+			console.log error
+			console.log json
+			callback 500, {error: true, message:error}
+	)
+
 exports.getRestrictedEntityFromACASServer = (baseurl, username, projectStateType, projectStateKind, resp) ->
 	exports.getRestrictedEntityFromACASServerInternal baseurl, username,  projectStateType, projectStateKind, (statusCode, json) ->
 		resp.statusCode = statusCode


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The route for fetching experiments by protocol code was returning 500 error when protocol didn't exist. I papered over this with acasclient code to convert 500 errors into `None` results, which then obfuscated real 500 errors like those caused by Java OOM errors.

The `getFromACASServerInternal` function (used very widely in this codebase) converts any non-200 responses into 500s, so instead of changing that ubiquitous behavior, I've added a narrow alternative that preserves status codes on responses.

This PR is part 2 of 3:
- https://github.com/mcneilco/acas-roo-server/pull/518 fixes Roo error throwing to yield a 404
- This PR updates node to bypass "throw 500 on any non-200 response" rule built into node layer
- https://github.com/mcneilco/acasclient/pull/189 acasclient test & removal of workaround that was converting 500s to None


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
- On local docker compose with Roo & ACAS changes, hit http://localhost:3000/api/experiments/protocolCodename/FAKECODE and confirmed it returns 404 status and body `[]` 