### PR TITLE
ACAS-994: Experiment retention policy (frontend field + folders-for-codes)

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -503,6 +503,11 @@ server.experiment.retention.cron=0 0 5 * * *
 server.experiment.retention.cronZone=UTC
 # Rows deleted per committed batch (bounds transaction size for very large experiments).
 server.experiment.retention.batchSize=100000
+# Optional system-wide retention days applied to experiments whose protocol has no per-protocol
+# "deleted experiment retention days" value (a per-protocol value still overrides this). Blank =
+# no global policy (only protocols with their own value are ever purged). Use with care: a value
+# here makes every soft-deleted/overwritten experiment older than this eligible, across all protocols.
+server.experiment.retention.globalDays=
 
 client.protocol.showAssayTreeRule=false
 client.protocol.showCurveDisplayParams=true

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -491,6 +491,21 @@ client.entity.deletingRoles=
 #client.entity.viewDeletedRoles=projectAdmin,ROLE_ACAS-ADMINS
 client.entity.viewDeletedRoles=
 
+# Experiment retention purge (runs inside roo). Permanently deletes experiments that have been
+# soft-deleted/overwritten longer than their protocol's "deleted experiment retention days" value,
+# in per-batch-committed chunks. Disabled by default; only one pod runs each scheduled time.
+# Enable the scheduled purge.
+server.experiment.retention.enabled=false
+# When to run (6-field Spring cron). Default 02:00 daily. cronZone blank = server time zone.
+server.experiment.retention.cron=0 0 2 * * *
+server.experiment.retention.cronZone=
+# Rows deleted per committed batch (bounds transaction size for very large experiments).
+server.experiment.retention.batchSize=100000
+# Root of the experiment data-files volume as mounted in roo (used to delete experiment folders).
+server.experiment.retention.dataFilesRoot=${server.service.persistence.filePath}
+# Base URL of the acas internal API roo calls to resolve experiment folder paths.
+server.experiment.retention.acasBaseUrl=${server.nodeapi.path}
+
 client.protocol.showAssayTreeRule=false
 client.protocol.showCurveDisplayParams=true
 client.protocol.notebook.require=false

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -494,17 +494,14 @@ client.entity.viewDeletedRoles=
 # Experiment retention purge (runs inside roo). Permanently deletes experiments that have been
 # soft-deleted/overwritten longer than their protocol's "deleted experiment retention days" value,
 # in per-batch-committed chunks. Disabled by default; only one pod runs each scheduled time.
+# (Folder deletion reuses server.service.persistence.filePath and server.nodeapi.path below.)
 # Enable the scheduled purge.
 server.experiment.retention.enabled=false
-# When to run (6-field Spring cron). Default 02:00 daily. cronZone blank = server time zone.
+# When to run (6-field Spring cron). Default 02:00 daily, interpreted in cronZone (UTC).
 server.experiment.retention.cron=0 0 2 * * *
-server.experiment.retention.cronZone=
+server.experiment.retention.cronZone=UTC
 # Rows deleted per committed batch (bounds transaction size for very large experiments).
 server.experiment.retention.batchSize=100000
-# Root of the experiment data-files volume as mounted in roo (used to delete experiment folders).
-server.experiment.retention.dataFilesRoot=${server.service.persistence.filePath}
-# Base URL of the acas internal API roo calls to resolve experiment folder paths.
-server.experiment.retention.acasBaseUrl=${server.nodeapi.path}
 
 client.protocol.showAssayTreeRule=false
 client.protocol.showCurveDisplayParams=true

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -493,10 +493,11 @@ client.entity.viewDeletedRoles=
 
 # Experiment retention purge (runs inside roo). Permanently deletes experiments that have been
 # soft-deleted/overwritten longer than their protocol's "deleted experiment retention days" value,
-# in per-batch-committed chunks. Disabled by default; only one pod runs each scheduled time.
+# in per-batch-committed chunks. Only one pod runs each scheduled time.
 # (Folder deletion reuses server.service.persistence.filePath and server.nodeapi.path below.)
-# Enable the scheduled purge.
-server.experiment.retention.enabled=false
+# Enable the scheduled purge. Note: only protocols that have a "deleted experiment retention days"
+# value purge anything; protocols without it are never touched. Set false to disable entirely.
+server.experiment.retention.enabled=true
 # When to run (6-field Spring cron). Default 05:00 daily, interpreted in cronZone (UTC).
 server.experiment.retention.cron=0 0 5 * * *
 server.experiment.retention.cronZone=UTC

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -497,8 +497,8 @@ client.entity.viewDeletedRoles=
 # (Folder deletion reuses server.service.persistence.filePath and server.nodeapi.path below.)
 # Enable the scheduled purge.
 server.experiment.retention.enabled=false
-# When to run (6-field Spring cron). Default 02:00 daily, interpreted in cronZone (UTC).
-server.experiment.retention.cron=0 0 2 * * *
+# When to run (6-field Spring cron). Default 05:00 daily, interpreted in cronZone (UTC).
+server.experiment.retention.cron=0 0 5 * * *
 server.experiment.retention.cronZone=UTC
 # Rows deleted per committed batch (bounds transaction size for very large experiments).
 server.experiment.retention.batchSize=100000

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -479,7 +479,7 @@ client.protocol.strictEndpointMatchingDefault=false
 client.protocol.endpointManager.enabled=true
 
 # Protocols and experiments which should be hidden (to non-admin users) in the protocol/expt browser when the status is in the config below
-client.entity.hideStatuses=[]
+client.entity.hideStatuses=["deleted"]
 
 # client.entity.editingRoles/deletingRoles determine which users can edit/delete protocols/expts. Leave config empty if all users can edit/delete
 # use 'entityScientist' if want to restrict privileges to user saved in the scientist value
@@ -488,7 +488,8 @@ client.entity.hideStatuses=[]
 # client.entity.deletingRoles=entityScientist,projectAdmin,admin
 client.entity.editingRoles=
 client.entity.deletingRoles=
-client.entity.viewDeletedRoles=projectAdmin,ROLE_ACAS-ADMINS
+#client.entity.viewDeletedRoles=projectAdmin,ROLE_ACAS-ADMINS
+client.entity.viewDeletedRoles=
 
 client.protocol.showAssayTreeRule=false
 client.protocol.showCurveDisplayParams=true

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -479,7 +479,7 @@ client.protocol.strictEndpointMatchingDefault=false
 client.protocol.endpointManager.enabled=true
 
 # Protocols and experiments which should be hidden (to non-admin users) in the protocol/expt browser when the status is in the config below
-client.entity.hideStatuses=["deleted"]
+client.entity.hideStatuses=[]
 
 # client.entity.editingRoles/deletingRoles determine which users can edit/delete protocols/expts. Leave config empty if all users can edit/delete
 # use 'entityScientist' if want to restrict privileges to user saved in the scientist value
@@ -488,8 +488,7 @@ client.entity.hideStatuses=["deleted"]
 # client.entity.deletingRoles=entityScientist,projectAdmin,admin
 client.entity.editingRoles=
 client.entity.deletingRoles=
-#client.entity.viewDeletedRoles=projectAdmin,ROLE_ACAS-ADMINS
-client.entity.viewDeletedRoles=
+client.entity.viewDeletedRoles=projectAdmin,ROLE_ACAS-ADMINS
 
 client.protocol.showAssayTreeRule=false
 client.protocol.showCurveDisplayParams=true

--- a/modules/ServerAPI/conf/ExperimentConfJSON.coffee
+++ b/modules/ServerAPI/conf/ExperimentConfJSON.coffee
@@ -182,6 +182,12 @@
 			,
 				typeName: "codeValue"
 				kindName: "agonist batch code"
+			,
+				typeName: "dateValue"
+				kindName: "database deleted date"
+			,
+				typeName: "dateValue"
+				kindName: "files deleted date"
 			]
 
 		labeltypes:

--- a/modules/ServerAPI/conf/ExperimentConfJSON.coffee
+++ b/modules/ServerAPI/conf/ExperimentConfJSON.coffee
@@ -182,12 +182,6 @@
 			,
 				typeName: "codeValue"
 				kindName: "agonist batch code"
-			,
-				typeName: "dateValue"
-				kindName: "database deleted date"
-			,
-				typeName: "dateValue"
-				kindName: "files deleted date"
 			]
 
 		labeltypes:

--- a/modules/ServerAPI/conf/ProtocolConfJSON.coffee
+++ b/modules/ServerAPI/conf/ProtocolConfJSON.coffee
@@ -145,6 +145,9 @@
 			,
 				typeName: "codeValue"
 				kindName: "strict endpoint matching"
+			, 				
+				typeName: "numericValue"
+				kindName: "deleted experiment retention days"
 			]
 
 		labeltypes:

--- a/modules/ServerAPI/src/client/Protocol.coffee
+++ b/modules/ServerAPI/src/client/Protocol.coffee
@@ -103,7 +103,10 @@ class Protocol extends BaseEntity
 			maxY.set numericValue: 120.0
 
 		maxY
-			
+
+	getDeletedExperimentRetentionDays: ->
+		@.get('lsStates').getOrCreateValueByTypeAndKind "metadata", "protocol metadata", "numericValue", "deleted experiment retention days"
+
 	getStrictEndpointMatching: ->
 		strictEndpointMatching = @.get('lsStates').getOrCreateValueByTypeAndKind "metadata", "protocol metadata", "codeValue", "strict endpoint matching"		
 		if strictEndpointMatching.get('codeValue') is undefined or strictEndpointMatching.get('codeValue') is ""
@@ -204,6 +207,7 @@ class ProtocolBaseController extends BaseEntityController
 			"click .bv_creationDateIcon": "handleCreationDateIconClicked"
 			"keyup .bv_maxY": "handleCurveDisplayMaxChanged"
 			"keyup .bv_minY": "handleCurveDisplayMinChanged"
+			"keyup .bv_deletedExperimentRetentionDays": "handleDeletedExperimentRetentionDaysChanged"
 			"click .bv_closeDeleteProtocolModal": "handleCloseProtocolModal"
 			"click .bv_confirmDeleteProtocolButton": "handleConfirmDeleteProtocolClicked"
 			"click .bv_cancelDelete": "handleCancelDeleteClicked"
@@ -346,6 +350,14 @@ class ProtocolBaseController extends BaseEntityController
 			@$('.bv_minY').val(@model.getCurveDisplayMin().get('numericValue'))
 		else
 			@$('.bv_group_curveDisplayWrapper').hide()
+		retentionDays = @model.getDeletedExperimentRetentionDays().get('numericValue')
+		@$('.bv_deletedExperimentRetentionDays').val(if retentionDays? then retentionDays else "")
+		isRetentionAdmin = false
+		if window.conf.roles?.acas?.adminRole?
+			adminRoles = window.conf.roles.acas.adminRole.split(",")
+			isRetentionAdmin = UtilityFunctions::testUserHasRole(window.AppLaunchParams?.loginUser, adminRoles)
+		unless isRetentionAdmin
+			@$('.bv_deletedExperimentRetentionDays').attr('disabled', 'disabled')
 		showRequiredEntityType = false
 		if window.conf.protocol?.requiredEntityType?.save?
 			showRequiredEntityType = window.conf.protocol.requiredEntityType.save
@@ -546,6 +558,12 @@ class ProtocolBaseController extends BaseEntityController
 		unless value is ""
 			value = parseFloat value
 		@handleValueChanged "CurveDisplayMin", value
+
+	handleDeletedExperimentRetentionDaysChanged: =>
+		value = UtilityFunctions::getTrimmedInput @$('.bv_deletedExperimentRetentionDays')
+		unless value is ""
+			value = parseInt value, 10
+		@handleValueChanged "DeletedExperimentRetentionDays", value
 
 	handleStrictEndpointMatchingChanged: =>
 		value = $('.bv_strictEndpointMatchingInputCheckbox').is(":checked")

--- a/modules/ServerAPI/src/client/Protocol.html
+++ b/modules/ServerAPI/src/client/Protocol.html
@@ -71,6 +71,13 @@
                     <input class="bv_notebookPage" style="width:336px;" type="text" placeholder="" />
                 </div>
             </div>
+            <div class="control-group bv_group_deletedExperimentRetentionDays">
+                <label class="control-label bv_deletedExperimentRetentionDaysLabel">Deleted experiment retention (days)</label>
+                <div class="controls">
+                    <input class="bv_deletedExperimentRetentionDays" style="width:336px;" type="number" min="0" step="1" placeholder="Blank = keep indefinitely" />
+                    <i class="icon-info-sign" style="margin-left:4px;" title="Soft-deleted experiments under this protocol are purged this many days after deletion. Blank = never purge."></i>
+                </div>
+            </div>
             <div class="control-group bv_group_tags" style="margin-bottom:10px;">
                 <label class="control-label">Key Words</label>
                 <div class="controls">

--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -13,6 +13,10 @@ exports.setupAPIRoutes = (app) ->
 	app.post '/api/experiments', exports.postExperiment
 	app.put '/api/experiments/:id', exports.putExperiment
 	app.get '/api/experiments/resultViewerURL/:code', exports.resultViewerURLByExperimentCodename
+	app.delete '/api/experiments/expired/database/', exports.deleteExpiredExperimentsDatabase
+	app.delete '/api/experiments/expired/folders/', exports.deleteExpiredExperimentsFolders
+	app.delete '/api/experiments/expired/complete/', exports.deleteExpiredExperimentsComplete
+	app.delete '/api/experiments/expired', exports.deleteExpiredExperiments
 	app.delete '/api/experiments/:id', exports.deleteExperiment
 	app.get '/api/getItxExptExptsByFirstExpt/:firstExptId', exports.getItxExptExptsByFirstExpt
 	app.get '/api/getItxExptExptsBySecondExpt/:secondExptId', exports.getItxExptExptsBySecondExpt
@@ -42,6 +46,10 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/api/experiments', loginRoutes.ensureAuthenticated, exports.postExperiment
 	app.put '/api/experiments/:id', loginRoutes.ensureAuthenticated, exports.putExperiment
 	app.get '/api/experiments/genericSearch/:searchTerm', loginRoutes.ensureAuthenticated, exports.genericExperimentSearch
+	app.delete '/api/experiments/expired/database', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperimentsDatabase
+	app.delete '/api/experiments/expired/folders', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperimentsFolders
+	app.delete '/api/experiments/expired/complete', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperimentsComplete
+	app.delete '/api/experiments/expired', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperiments
 	app.delete '/api/experiments/:id', loginRoutes.ensureAuthenticated, exports.deleteExperiment
 	app.get '/api/experiments/resultViewerURL/:code', loginRoutes.ensureAuthenticated, exports.resultViewerURLByExperimentCodename
 	app.get '/api/experiments/values/:id', loginRoutes.ensureAuthenticated, exports.experimentValueById
@@ -62,6 +70,9 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.get '/api/getExperimentalMetadata', loginRoutes.ensureAuthenticated, exports.getExperimentalMetadata
 
 serverUtilityFunctions = require './ServerUtilityFunctions.js'
+fs = require 'fs'
+path = require 'path'
+
 csUtilities = require '../src/javascripts/ServerAPI/CustomerSpecificServerFunctions.js'
 _ = require 'underscore'
 config = require '../conf/compiled/conf.js'
@@ -1232,3 +1243,190 @@ exports.getPaginatedExperiments = (req, resp) ->
 					resp.statusCode = response?.statusCode || 500
 					resp.json error: true, message: error || json
 			)
+
+# Hard delete proxy to just call the ACAS server
+exports.deleteExpiredExperimentsDatabase = (req, resp) ->
+	config = require '../conf/compiled/conf.js'
+	baseurl = config.all.client.service.persistence.fullpath+"experiments/retention/hard-delete"
+	console.log baseurl
+	request = require 'request'
+	console.log "calling retention hard delete service at #{baseurl}"
+	request(
+		method: 'POST'
+		url: baseurl
+		json: true
+	, (error, response, json) =>
+		console.log response.statusCode
+		console.log json
+		if !error and !json.error
+			resp.json json
+		else
+			console.log 'got ajax error trying to call retention hard delete service'
+			resp.statusCode = 500
+			resp.json json.errorMessages
+	)
+
+
+# Function to update experiment value via persistence API
+updateExperimentValue = (codeName, stateType, stateKind, valueType, valueKind, value, callback) ->
+	config = require '../conf/compiled/conf.js'
+	request = require 'request'
+	baseurl = config.all.client.service.persistence.fullpath + "values/experiment/#{codeName}/bystate/#{stateType}/#{stateKind}/byvalue/#{valueType}/#{valueKind}/"
+	console.log "Updating experiment value at #{baseurl} with value #{value}"
+	request(
+		method: 'PUT'
+		url: baseurl
+		body: value
+		json: true
+	, (error, response, json) =>
+		if !error && response.statusCode == 200
+			console.log "Successfully updated experiment #{codeName} value"
+			callback null, json
+		else
+			console.log "Failed to update experiment #{codeName} value: #{error}"
+			callback error || { statusCode: response.statusCode, body: json }
+	)
+
+# Complete deletion proxy to call the ACAS server retention/complete-deletion endpoint
+exports.deleteExpiredExperimentsComplete = (req, resp) ->
+	config = require '../conf/compiled/conf.js'
+	baseurl = config.all.client.service.persistence.fullpath+"experiments/retention/complete-deletion"
+	console.log baseurl
+	request = require 'request'
+	console.log "calling complete deletion service at #{baseurl}"
+	request(
+		method: 'POST'
+		url: baseurl
+		json: true
+	, (error, response, json) =>
+		console.log response.statusCode
+		console.log json
+		if !error and !json.error
+			resp.json json
+		else
+			console.log 'got ajax error trying to call complete deletion service'
+			resp.statusCode = 500
+			resp.json json.errorMessages
+	)
+
+# Calls /awaiting-files-deletion and deletes experiment folders for each code
+exports.deleteExpiredExperimentsFolders = (req, resp) ->
+	config = require '../conf/compiled/conf.js'
+	request = require 'request'
+	# Adjust this URL if the endpoint is external or needs full path
+	baseurl = config.all.client.service.persistence.fullpath + '/experiments/retention/awaiting-files-deletion'
+	request(
+		method: 'GET'
+		url: baseurl
+		json: true
+	, (error, response, codes) =>
+		if error or response.statusCode != 200
+			resp.statusCode = 500
+			return resp.json { error: true, message: 'Failed to fetch experiment codes', detail: error }
+		if not Array.isArray(codes)
+			resp.statusCode = 500
+			return resp.json { error: true, message: 'Response is not an array', detail: codes }
+
+		deleted = []
+		failed = []
+		completed = 0
+		total = codes.length
+
+		processComplete = ->
+			resp.json { deleted, failed }
+
+		# Handle empty array case
+		if total == 0
+			return processComplete()
+
+		# Process each experiment code
+		processExperiment = (code) ->
+			try
+				prefix = serverUtilityFunctions.getPrefixFromEntityCode(code)
+				relPath = serverUtilityFunctions.getRelativeFolderPathForPrefix(prefix)
+				data_files_root = config.all.server.datafiles.relative_path
+			  
+				if not relPath?
+					failed.push { code, error: 'No relative path for prefix' }
+					completed++
+					if completed == total then processComplete()
+					return
+				
+				folderPath = path.join(data_files_root, relPath, code)
+				console.log "Processing experiment #{code} with folder #{folderPath}"
+				
+				folderDeleted = false
+				folderError = null
+				
+				if fs.existsSync(folderPath)
+					try
+						fs.rmSync(folderPath, { recursive: true, force: true })
+						console.log "Folder deleted for experiment #{code}"
+						folderDeleted = true
+					catch deleteErr
+						folderError = "Failed to delete folder: #{deleteErr.message}"
+						console.log "Failed to delete folder for #{code}: #{deleteErr.message}"
+				else
+					console.log "Folder does not exist for experiment #{code}"
+				
+				# Update experiment value regardless of folder deletion result
+				currentTimestamp = new Date().getTime().toString()
+				updateExperimentValue code, "metadata", "experiment metadata", "dateValue", "files deleted date", currentTimestamp, (err, result) ->
+					if err
+						console.log "Failed to update experiment value for #{code}: #{JSON.stringify(err)}"
+						if folderError
+							failed.push { code, error: "#{folderError} AND failed to update experiment value: #{JSON.stringify(err)}" }
+						else
+							failed.push { code, error: "Failed to update experiment value: #{JSON.stringify(err)}" }
+					else
+						console.log "Successfully updated experiment value for #{code}"
+						if folderError
+							failed.push { code, error: folderError }
+						else
+							deleted.push code
+					
+					completed++
+					if completed == total then processComplete()
+			catch err
+				failed.push { code, error: err.message }
+				completed++
+				if completed == total then processComplete()
+
+		for code in codes
+			processExperiment(code)
+	)
+
+# Combined function that deletes both expired experiments and their folders
+exports.deleteExpiredExperiments = (req, resp) ->
+	console.log "Starting complete expired experiments cleanup (database + folders + retention)"
+	
+	# First hard delete experiments from database
+	exports.deleteExpiredExperimentsDatabase req, {
+		json: (dbResult) ->
+			console.log "Database deletion completed:", dbResult
+			
+			# Then delete folders and update experiment values
+			exports.deleteExpiredExperimentsFolders req, {
+				json: (folderResult) ->
+					console.log "Folder deletion completed:", folderResult
+					
+					# Finally call complete deletion to fully delete experiments
+					exports.deleteExpiredExperimentsComplete req, {
+						json: (completeDeletionResult) ->
+							console.log "Complete deletion completed:", completeDeletionResult
+							
+							# Combine all results
+							combinedResult = {
+								databaseDeletion: dbResult,
+								folderDeletion: folderResult,
+								completeDeletion: completeDeletionResult
+							}
+							
+							resp.json combinedResult
+						statusCode: 200
+					}
+				statusCode: 200
+			}
+		statusCode: 200
+	}
+

--- a/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
+++ b/modules/ServerAPI/src/server/routes/ExperimentServiceRoutes.coffee
@@ -13,10 +13,7 @@ exports.setupAPIRoutes = (app) ->
 	app.post '/api/experiments', exports.postExperiment
 	app.put '/api/experiments/:id', exports.putExperiment
 	app.get '/api/experiments/resultViewerURL/:code', exports.resultViewerURLByExperimentCodename
-	app.delete '/api/experiments/expired/database/', exports.deleteExpiredExperimentsDatabase
-	app.delete '/api/experiments/expired/folders/', exports.deleteExpiredExperimentsFolders
-	app.delete '/api/experiments/expired/complete/', exports.deleteExpiredExperimentsComplete
-	app.delete '/api/experiments/expired', exports.deleteExpiredExperiments
+	app.post '/api/experiments/folders-for-codes', exports.getFoldersForCodes
 	app.delete '/api/experiments/:id', exports.deleteExperiment
 	app.get '/api/getItxExptExptsByFirstExpt/:firstExptId', exports.getItxExptExptsByFirstExpt
 	app.get '/api/getItxExptExptsBySecondExpt/:secondExptId', exports.getItxExptExptsBySecondExpt
@@ -46,10 +43,7 @@ exports.setupRoutes = (app, loginRoutes) ->
 	app.post '/api/experiments', loginRoutes.ensureAuthenticated, exports.postExperiment
 	app.put '/api/experiments/:id', loginRoutes.ensureAuthenticated, exports.putExperiment
 	app.get '/api/experiments/genericSearch/:searchTerm', loginRoutes.ensureAuthenticated, exports.genericExperimentSearch
-	app.delete '/api/experiments/expired/database', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperimentsDatabase
-	app.delete '/api/experiments/expired/folders', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperimentsFolders
-	app.delete '/api/experiments/expired/complete', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperimentsComplete
-	app.delete '/api/experiments/expired', loginRoutes.ensureAuthenticated, exports.deleteExpiredExperiments
+	app.post '/api/experiments/folders-for-codes', loginRoutes.ensureAuthenticated, exports.getFoldersForCodes
 	app.delete '/api/experiments/:id', loginRoutes.ensureAuthenticated, exports.deleteExperiment
 	app.get '/api/experiments/resultViewerURL/:code', loginRoutes.ensureAuthenticated, exports.resultViewerURLByExperimentCodename
 	app.get '/api/experiments/values/:id', loginRoutes.ensureAuthenticated, exports.experimentValueById
@@ -1244,189 +1238,18 @@ exports.getPaginatedExperiments = (req, resp) ->
 					resp.json error: true, message: error || json
 			)
 
-# Hard delete proxy to just call the ACAS server
-exports.deleteExpiredExperimentsDatabase = (req, resp) ->
-	config = require '../conf/compiled/conf.js'
-	baseurl = config.all.client.service.persistence.fullpath+"experiments/retention/hard-delete"
-	console.log baseurl
-	request = require 'request'
-	console.log "calling retention hard delete service at #{baseurl}"
-	request(
-		method: 'POST'
-		url: baseurl
-		json: true
-	, (error, response, json) =>
-		console.log response.statusCode
-		console.log json
-		if !error and !json.error
-			resp.json json
-		else
-			console.log 'got ajax error trying to call retention hard delete service'
-			resp.statusCode = 500
-			resp.json json.errorMessages
-	)
-
-
-# Function to update experiment value via persistence API
-updateExperimentValue = (codeName, stateType, stateKind, valueType, valueKind, value, callback) ->
-	config = require '../conf/compiled/conf.js'
-	request = require 'request'
-	baseurl = config.all.client.service.persistence.fullpath + "values/experiment/#{codeName}/bystate/#{stateType}/#{stateKind}/byvalue/#{valueType}/#{valueKind}/"
-	console.log "Updating experiment value at #{baseurl} with value #{value}"
-	request(
-		method: 'PUT'
-		url: baseurl
-		body: value
-		json: true
-	, (error, response, json) =>
-		if !error && response.statusCode == 200
-			console.log "Successfully updated experiment #{codeName} value"
-			callback null, json
-		else
-			console.log "Failed to update experiment #{codeName} value: #{error}"
-			callback error || { statusCode: response.statusCode, body: json }
-	)
-
-# Complete deletion proxy to call the ACAS server retention/complete-deletion endpoint
-exports.deleteExpiredExperimentsComplete = (req, resp) ->
-	config = require '../conf/compiled/conf.js'
-	baseurl = config.all.client.service.persistence.fullpath+"experiments/retention/complete-deletion"
-	console.log baseurl
-	request = require 'request'
-	console.log "calling complete deletion service at #{baseurl}"
-	request(
-		method: 'POST'
-		url: baseurl
-		json: true
-	, (error, response, json) =>
-		console.log response.statusCode
-		console.log json
-		if !error and !json.error
-			resp.json json
-		else
-			console.log 'got ajax error trying to call complete deletion service'
-			resp.statusCode = 500
-			resp.json json.errorMessages
-	)
-
-# Calls /awaiting-files-deletion and deletes experiment folders for each code
-exports.deleteExpiredExperimentsFolders = (req, resp) ->
-	config = require '../conf/compiled/conf.js'
-	request = require 'request'
-	# Adjust this URL if the endpoint is external or needs full path
-	baseurl = config.all.client.service.persistence.fullpath + '/experiments/retention/awaiting-files-deletion'
-	request(
-		method: 'GET'
-		url: baseurl
-		json: true
-	, (error, response, codes) =>
-		if error or response.statusCode != 200
-			resp.statusCode = 500
-			return resp.json { error: true, message: 'Failed to fetch experiment codes', detail: error }
-		if not Array.isArray(codes)
-			resp.statusCode = 500
-			return resp.json { error: true, message: 'Response is not an array', detail: codes }
-
-		deleted = []
-		failed = []
-		completed = 0
-		total = codes.length
-
-		processComplete = ->
-			resp.json { deleted, failed }
-
-		# Handle empty array case
-		if total == 0
-			return processComplete()
-
-		# Process each experiment code
-		processExperiment = (code) ->
-			try
-				prefix = serverUtilityFunctions.getPrefixFromEntityCode(code)
-				relPath = serverUtilityFunctions.getRelativeFolderPathForPrefix(prefix)
-				data_files_root = config.all.server.datafiles.relative_path
-			  
-				if not relPath?
-					failed.push { code, error: 'No relative path for prefix' }
-					completed++
-					if completed == total then processComplete()
-					return
-				
-				folderPath = path.join(data_files_root, relPath, code)
-				console.log "Processing experiment #{code} with folder #{folderPath}"
-				
-				folderDeleted = false
-				folderError = null
-				
-				if fs.existsSync(folderPath)
-					try
-						fs.rmSync(folderPath, { recursive: true, force: true })
-						console.log "Folder deleted for experiment #{code}"
-						folderDeleted = true
-					catch deleteErr
-						folderError = "Failed to delete folder: #{deleteErr.message}"
-						console.log "Failed to delete folder for #{code}: #{deleteErr.message}"
-				else
-					console.log "Folder does not exist for experiment #{code}"
-				
-				# Update experiment value regardless of folder deletion result
-				currentTimestamp = new Date().getTime().toString()
-				updateExperimentValue code, "metadata", "experiment metadata", "dateValue", "files deleted date", currentTimestamp, (err, result) ->
-					if err
-						console.log "Failed to update experiment value for #{code}: #{JSON.stringify(err)}"
-						if folderError
-							failed.push { code, error: "#{folderError} AND failed to update experiment value: #{JSON.stringify(err)}" }
-						else
-							failed.push { code, error: "Failed to update experiment value: #{JSON.stringify(err)}" }
-					else
-						console.log "Successfully updated experiment value for #{code}"
-						if folderError
-							failed.push { code, error: folderError }
-						else
-							deleted.push code
-					
-					completed++
-					if completed == total then processComplete()
-			catch err
-				failed.push { code, error: err.message }
-				completed++
-				if completed == total then processComplete()
-
-		for code in codes
-			processExperiment(code)
-	)
-
-# Combined function that deletes both expired experiments and their folders
-exports.deleteExpiredExperiments = (req, resp) ->
-	console.log "Starting complete expired experiments cleanup (database + folders + retention)"
-	
-	# First hard delete experiments from database
-	exports.deleteExpiredExperimentsDatabase req, {
-		json: (dbResult) ->
-			console.log "Database deletion completed:", dbResult
-			
-			# Then delete folders and update experiment values
-			exports.deleteExpiredExperimentsFolders req, {
-				json: (folderResult) ->
-					console.log "Folder deletion completed:", folderResult
-					
-					# Finally call complete deletion to fully delete experiments
-					exports.deleteExpiredExperimentsComplete req, {
-						json: (completeDeletionResult) ->
-							console.log "Complete deletion completed:", completeDeletionResult
-							
-							# Combine all results
-							combinedResult = {
-								databaseDeletion: dbResult,
-								folderDeletion: folderResult,
-								completeDeletion: completeDeletionResult
-							}
-							
-							resp.json combinedResult
-						statusCode: 200
-					}
-				statusCode: 200
-			}
-		statusCode: 200
-	}
-
+# Read-only: resolve experiment folder paths (relative to the data-files root) for the given
+# codes. Used by roo's retention purge, which deletes the folders on its mounted volume.
+exports.getFoldersForCodes = (req, resp) ->
+	serverUtilityFunctions = require './ServerUtilityFunctions.js'
+	path = require 'path'
+	codes = req.body?.codes
+	unless Array.isArray(codes)
+		resp.statusCode = 400
+		return resp.json { error: true, message: "Request body must include a 'codes' array" }
+	result = {}
+	for code in codes
+		prefix = serverUtilityFunctions.getPrefixFromEntityCode(code)
+		relPath = if prefix? then serverUtilityFunctions.getRelativeFolderPathForPrefix(prefix) else null
+		result[code] = if relPath? then path.join(relPath, code) else null
+	resp.json result


### PR DESCRIPTION
## ACAS-994 — Experiment retention policy (frontend)

Frontend half of the experiment retention feature (backend: mcneilco/acas-roo-server#519).

### What it adds
- **Per-protocol retention field** on the protocol editor: "Deleted experiment retention (days)" (`numericValue / deleted experiment retention days`). Admins can edit it; other users see it read-only. Blank = keep indefinitely.
- **Read-only `POST /api/experiments/folders-for-codes`** route: resolves each experiment code to its folder path (relative to the data-files root) via `ControllerRedirectConf`. roo calls this during the purge and deletes the folders on its mounted volume.
- Documents the `server.experiment.retention.*` config (enabled [on by default], cron, cronZone, batchSize, globalDays [unset = no global policy]) with defaults in `conf/config.properties.example`; folder-path resolution reuses the existing `server.service.persistence.filePath` and `server.nodeapi.path`.

### Testing
Validated end-to-end against a local stack with the roo backend (#519); folder-path resolution exercised during real purges. See the *Manual end-to-end test procedure* comment on mcneilco/acas-roo-server#519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
