### PR TITLE
ACAS-1001 Fix auto dry-run report download

### DIFF
--- a/modules/Standardization/spec/serviceTests/StandardizationRoutesSpec.coffee
+++ b/modules/Standardization/spec/serviceTests/StandardizationRoutesSpec.coffee
@@ -1,0 +1,112 @@
+assert = require 'assert'
+EventEmitter = require('events').EventEmitter
+fs = require 'fs'
+Module = require 'module'
+path = require 'path'
+
+acasHome = '../../../..'
+
+describe "Standardization Routes", ->
+	originalLoad = null
+	routePath = null
+	fakeUpstream = null
+	requestedOptions = null
+
+	loadRoutesWithFakeRequest = ->
+		routePath = path.resolve __dirname, "#{acasHome}/routes/StandardizationRoutes.js"
+		unless fs.existsSync(routePath)
+			routePath = path.resolve process.cwd(), 'modules/Standardization/src/server/routes/StandardizationRoutes.coffee'
+
+		delete require.cache[require.resolve(routePath)] if require.cache[require.resolve(routePath)]?
+
+		originalLoad = Module._load
+		Module._load = (request, parent, isMain) ->
+			if parent?.filename is routePath and request is './ServerUtilityFunctions.js'
+				return {
+					requestAdapter: (options) ->
+						requestedOptions = options
+						fakeUpstream = new FakeUpstream()
+						fakeUpstream
+				}
+			if parent?.filename is routePath and request is '../conf/compiled/conf.js'
+				return {
+					all:
+						client:
+							service:
+								cmpdReg:
+									persistence:
+										fullpath: 'http://persistence.example'
+				}
+			if request is 'underscore'
+				return {}
+			originalLoad.apply @, arguments
+
+		require routePath
+
+	afterEach ->
+		Module._load = originalLoad if originalLoad?
+		delete require.cache[require.resolve(routePath)] if routePath? and require.cache[require.resolve(routePath)]?
+		originalLoad = null
+		routePath = null
+		fakeUpstream = null
+		requestedOptions = null
+
+	class FakeUpstream extends EventEmitter
+		constructor: ->
+			super()
+			@ended = false
+			@pipedDestination = null
+
+		pipe: (destination) ->
+			@pipedDestination = destination
+			@
+
+		end: ->
+			@ended = true
+			@emit 'response',
+				statusCode: 200
+				headers:
+					'content-type': 'chemical/x-mdl-sdfile'
+					'content-length': '8'
+			@emit 'data', Buffer.from('SDF DATA')
+			@emit 'end'
+
+	class FakeResponse
+		constructor: ->
+			@headersSent = false
+			@statusCode = null
+			@headers = null
+			@chunks = []
+			@ended = false
+
+		writeHead: (statusCode, headers) ->
+			@headersSent = true
+			@statusCode = statusCode
+			@headers = headers
+
+		write: (chunk) ->
+			@chunks.push chunk
+
+		end: (body) ->
+			@ended = true
+			@chunks.push Buffer.from(body) if body?
+
+	describe "standardizationAutoDryRunReportFile", ->
+		it "starts the upstream report stream and forwards the SDF response", ->
+			routes = loadRoutesWithFakeRequest()
+			req =
+				query:
+					historyId: '108'
+				setTimeout: ->
+			resp = new FakeResponse()
+
+			routes.standardizationAutoDryRunReportFile req, resp
+
+			assert fakeUpstream.ended, "upstream report stream should be started"
+			assert.equal requestedOptions.method, 'GET'
+			assert.equal requestedOptions.url, 'http://persistence.example/standardization/dryRunAutoReportFile?historyId=108'
+			assert.equal resp.statusCode, 200
+			assert.equal resp.headers['Content-Type'], 'chemical/x-mdl-sdfile'
+			assert.equal resp.headers['Content-Disposition'], 'attachment; filename=standardization-dry-run-report-history-108.sdf'
+			assert.equal Buffer.concat(resp.chunks).toString(), 'SDF DATA'
+			assert resp.ended, "response should be ended when upstream stream ends"

--- a/modules/Standardization/src/server/routes/StandardizationRoutes.coffee
+++ b/modules/Standardization/src/server/routes/StandardizationRoutes.coffee
@@ -264,11 +264,19 @@ exports.standardizationAutoDryRunReportFile = (req, resp) ->
 		resp.writeHead(response.statusCode or 500, headers)
 
 	upstream.on 'error', (error) ->
-		return if resp.headersSent
+		if resp.headersSent
+			resp.end()
+			return
 		resp.statusCode = 500
 		resp.end error?.message or 'Request failed'
 
-	upstream.pipe resp
+	upstream.on 'data', (chunk) ->
+		resp.write chunk
+
+	upstream.on 'end', ->
+		resp.end()
+
+	upstream.end()
 exports.getDryRunStats = (req, resp) ->
 	req.setTimeout 86400000
 	url = config.all.client.service.cmpdReg.persistence.fullpath + '/standardization/dryRunStats'


### PR DESCRIPTION
## Summary

Fix the Standardization History `Dry Run Report` download route so callback-free GET streaming requests actually start and forward the SDF response back to the browser.

## Root Cause

`standardizationAutoDryRunReportFile` created a streaming request to the persistence endpoint and piped it to the Express response, but the callback-free GET stream was never ended. In this request adapter path, that meant the upstream request could remain idle, leaving the browser waiting on the download navigation.

## Changes

- Start the upstream GET stream explicitly with `upstream.end()`.
- Forward upstream `data` chunks and close the Express response on upstream `end`.
- Preserve existing header forwarding behavior for content type, disposition, and length.
- Add a regression spec proving the route starts the upstream stream and forwards the SDF response.

## Validation

- Ran focused Standardization route regression with a lightweight CoffeeScript/Mocha shim: `PASS starts the upstream report stream and forwards the SDF response`.
- Compiled `modules/Standardization/src/server/routes/StandardizationRoutes.coffee` with `coffee -c`.
- Compiled `modules/Standardization/spec/serviceTests/StandardizationRoutesSpec.coffee` with `coffee -c`.
- Hot-patched `qa-demo-26-3` using the existing `acas-custom-config-map` route mount, restarted `deployment/acas`, verified rollout completed, and confirmed the mounted route file contains `upstream.end()`.
- Manually confirmed via the UI that the download works with the patched file.
