### PR TITLE
ACAS-1000 show delete dependency errors

### DIFF
--- a/modules/CmpdRegAdmin/src/server/routes/CmpdRegAdminRoutes.coffee
+++ b/modules/CmpdRegAdmin/src/server/routes/CmpdRegAdminRoutes.coffee
@@ -267,22 +267,24 @@ exports.deleteCmpdRegEntity = (req, resp) ->
 	request(
 		method: 'DELETE'
 		url: cmpdRegCall
+		json: false
 		timeout: 6000000
-	, (error, response, json) =>
-		if !error && response.statusCode == 200
-			console.log JSON.stringify json
+	, (error, response, body) =>
+		if !error && response?
+			deleteResponse = body
+			if typeof body == 'string'
+				try
+					deleteResponse = JSON.parse body
+				catch parseError
+					deleteResponse = message: body
+			console.log JSON.stringify deleteResponse
 			resp.statusCode = response.statusCode
 			resp.setHeader('Content-Type', 'application/json')
-			resp.json json
-		if response.statusCode == 409
-			console.log "Conflict! something is preventing CmpdRegEntity to be removed."
-			resp.statusCode = response.statusCode
-			resp.setHeader('Content-Type', 'application/json')
-			resp.json json
+			resp.json deleteResponse
 		else
 			resp.statusCode = 404
 			console.log "got ajax error trying to delete #{entityType}"
-			console.log json
+			console.log body
 			resp.end JSON.stringify {error: "something went wrong :("}
 	)
 

--- a/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowser.coffee
+++ b/modules/CodeTablesAdmin/src/client/AbstractCodeTablesAdminBrowser.coffee
@@ -296,15 +296,21 @@ class AbstractCodeTablesAdminBrowserController extends Backbone.View
 				@$(".bv_okayButton").removeClass "hide"
 				@$(".bv_deletingStatusIndicator").addClass "hide"
 				@$(".bv_errorDeletingCodeTablesAdminMessage").removeClass "hide"
-				errorMsg = response.responseText
-				if (errorMsg)
-					errorJSON = JSON.parse(errorMsg)
-					# Grabbing the first (and assumingly only) error and displaying the message in placeholder element 
-					@$('.bv_deleteCodeTablesAdminErrorMessageHolder').html errorJSON[0].message
-				else
-					noServerMessage = "The server has no error message. Please contact support for additional help."
-					@$('.bv_deleteCodeTablesAdminErrorMessageHolder').html noServerMessage
+				@$('.bv_deleteCodeTablesAdminErrorMessageHolder').html @getDeleteCodeTablesAdminErrorMessage(response)
 		)
+
+	getDeleteCodeTablesAdminErrorMessage: (response) =>
+		noServerMessage = "The server has no error message. Please contact support for additional help."
+		errorMsg = response?.responseText
+		return noServerMessage unless errorMsg
+		try
+			errorJSON = JSON.parse(errorMsg)
+			if _.isArray(errorJSON)
+				return errorJSON[0]?.message or noServerMessage
+			else
+				return errorJSON.message or errorJSON.error or errorMsg
+		catch e
+			return errorMsg
 
 	handleCancelDeleteClicked: =>
 		@$(".bv_confirmDeleteCodeTablesAdmin").modal('hide')

--- a/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
+++ b/modules/CodeTablesAdmin/src/server/routes/CodeTablesAdminRoutes.coffee
@@ -171,4 +171,6 @@ exports.deleteCodeTablesEntity = (req, resp) ->
 	codeTableServiceRoutes.deleteCodeTableInternal {id: req.params.id}, (statusCode, response) ->
 		console.log(statusCode)
 		console.log(response)
+		resp.statusCode = statusCode
+		resp.setHeader('Content-Type', 'application/json')
 		resp.json response

--- a/modules/Components/src/server/routes/CodeTableServiceRoutes.coffee
+++ b/modules/Components/src/server/routes/CodeTableServiceRoutes.coffee
@@ -149,8 +149,7 @@ exports.deleteCodeTableInternal = (codeTableEntry, callback) ->
 				console.log 'got ajax error trying to delete code table'
 				console.log error
 				console.log json
-				callback response.statusCode, response.json
+				callback response.statusCode, json
 		)
-
 
 

--- a/modules/Components/src/server/routes/CodeTableServiceRoutes.coffee
+++ b/modules/Components/src/server/routes/CodeTableServiceRoutes.coffee
@@ -95,7 +95,7 @@ exports.postCodeTableInternal = (codeTableEntry, callback) ->
 				console.log 'got ajax error trying to save new code table'
 				console.log error
 				console.log json
-				callback response.statusCode, response.json
+				callback response.statusCode, json
 		)
 
 exports.putCodeTable = (req, resp) ->
@@ -123,7 +123,7 @@ exports.putCodeTableInternal = (codeTableEntry, callback) ->
 				console.log 'got ajax error trying to update code table'
 				console.log error
 				console.log response
-				callback response.statusCode, response.json
+				callback response.statusCode, json
 		)
 
 exports.deleteCodeTable = (req, resp) ->
@@ -151,5 +151,4 @@ exports.deleteCodeTableInternal = (codeTableEntry, callback) ->
 				console.log json
 				callback response.statusCode, json
 		)
-
 

--- a/modules/Project/src/server/routes/ProjectModuleServiceRoutes.coffee
+++ b/modules/Project/src/server/routes/ProjectModuleServiceRoutes.coffee
@@ -92,7 +92,7 @@ saveRolekinds = (rolekind, callback) ->
 		else
 			console.log "error saving project role kind"
 			console.log response.statusCode
-			console.log response.json
+			console.log json
 			callback "saveFailed for project rolekind"
 	)
 

--- a/modules/ServerAPI/src/client/SaltBrowser.coffee
+++ b/modules/ServerAPI/src/client/SaltBrowser.coffee
@@ -492,10 +492,23 @@ class SaltBrowserController extends Backbone.View
 			error: (errorMsg) =>
 				@$(".bv_deleteSaltStatus").show()
 				@$(".bv_deletingStatusIndicator").hide()
-				@$(".bv_deleteErrorMessage").html errorMsg.responseText
+				@$(".bv_deleteErrorMessage").text @getDeleteSaltErrorMessage(errorMsg)
 				@$(".bv_errorDeletingSaltMessage").show()
 
 		)
+
+	getDeleteSaltErrorMessage: (response) =>
+		noServerMessage = "The server has no error message. Please contact support for additional help."
+		errorMsg = response?.responseText
+		return noServerMessage unless errorMsg
+		try
+			errorJSON = JSON.parse(errorMsg)
+			if _.isArray(errorJSON)
+				return errorJSON[0]?.message or noServerMessage
+			else
+				return errorJSON.message or errorJSON.error or errorMsg
+		catch e
+			return errorMsg
 
 	handleCancelDeleteClicked: =>
 		@$(".bv_confirmDeleteSalt").modal('hide')


### PR DESCRIPTION
## Summary
- Preserve CmpdReg admin delete error responses, including plain-text salt delete messages, instead of replacing them with a generic error.
- Propagate CodeTables delete status and parsed response bodies through the server route.
- Display parsed delete messages in the CodeTables and Salt delete modals instead of raw JSON.

## Root Cause
The CmpdReg admin delete proxy only forwarded dependency details for one response shape. Salt deletes return a plain-text dependency message, which caused JSON parsing to fail and the route to fall back to `{"error":"something went wrong :("}`. CodeTables deletes also dropped the downstream status and read the wrong response field from the request adapter.

## Validation
- Ran CoffeeScript compile checks for all five changed files with `coffee -c -p`.
- Hotfixed and manually verified on `qa-demo-26-3`: Vendors, Stereo Categories, and Salts now show dependency messages; Assay Scientist unused delete path succeeded; CmpdReg Scientist skipped because no entries existed in QA.
<img width="696" height="342" alt="Screenshot 2026-06-26 at 2 36 07 PM" src="https://github.com/user-attachments/assets/3faecbdb-d375-403b-8f0b-87ee4c3ebb03" />

<img width="611" height="265" alt="Screenshot 2026-06-26 at 2 36 15 PM" src="https://github.com/user-attachments/assets/a5cf048f-a841-42ff-9304-aefba193fc9b" />
<img width="573" height="213" alt="Screenshot 2026-06-26 at 3 09 54 PM" src="https://github.com/user-attachments/assets/2357d8cc-2ed1-4a71-a0c2-ff3eeaa08cf5" />
