### PR TITLE
ACAS-999 support SAML metadata URL

### DIFF
--- a/app_template.coffee
+++ b/app_template.coffee
@@ -27,6 +27,7 @@ startApp = ->
 	util = require 'util'
 	LocalStrategy = require('passport-local').Strategy
 	SamlStrategy = require('@node-saml/passport-saml').Strategy;
+	samlMetadata = require './src/javascripts/ServerAPI/SamlMetadata.js'
 	global.deployMode = config.all.client.deployMode
 
 	console.log "log level set to '#{console.level}'"
@@ -66,15 +67,8 @@ startApp = ->
 
 	if config.all.server.security.saml.use == true
 		if csUtilities.ssoLoginStrategy?
-			passport.use new SamlStrategy({
-				passReqToCallback: true
-				callbackUrl: "#{config.all.client.fullpath}/login/callback"
-				entryPoint: config.all.server.security.saml.entryPoint
-				issuer: config.all.server.security.saml.issuer
-				idpCert: config.all.server.security.saml.cert
-				audience: config.all.server.security.saml.audience
-				disableRequestedAuthnContext: config.all.server.security.saml.disableRequestedAuthnContext
-			}, csUtilities.ssoLoginStrategy)
+			samlOptions = await samlMetadata.getSamlStrategyOptions config.all
+			passport.use new SamlStrategy(samlOptions, csUtilities.ssoLoginStrategy)
 		else
 			console.error("NOT USING SSO configs! config.all.server.security.saml.use is set true but CustomerSpecificServerFunction 'ssoLoginStrategy' is not defined.")
 
@@ -213,3 +207,6 @@ startApp = ->
 			console.log "system test completed"
 
 startApp()
+	.catch (error) ->
+		console.error "Failed to start ACAS Node server: #{error.stack or error}"
+		process.exit 1

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -359,6 +359,9 @@ client.security.authstrategy=${server.security.authstrategy}
 # Examples configs using okta but can use any SAML login IDP
 
 server.security.saml.use=false
+# When set, metadataUrl is used as the source of truth for entryPoint, issuer, and cert.
+# Leave metadataUrl empty to use the explicit entryPoint, issuer, and cert settings below.
+server.security.saml.metadataUrl=
 server.security.saml.entryPoint=https://<organization>.okta.com/app/<appName>/<issuerID>/sso/saml
 server.security.saml.issuer=http://www.okta.com/<issuerID>
 server.security.saml.audience=false

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -359,14 +359,21 @@ client.security.authstrategy=${server.security.authstrategy}
 # Examples configs using okta but can use any SAML login IDP
 
 server.security.saml.use=false
-# When set, metadataUrl is used as the source of truth for entryPoint, issuer, and cert.
-# Leave metadataUrl empty to use the explicit entryPoint, issuer, and cert settings below.
+
+# When set, metadataUrl is used to derive the IdP entryPoint, issuer, and cert.
+# Leave metadataUrl empty to use the explicit IdP settings below.
 server.security.saml.metadataUrl=
+
+# Passport-SAML settings. entryPoint, issuer, and cert are used when metadataUrl is empty.
+# audience and disableRequestedAuthnContext still apply when metadataUrl is set.
 server.security.saml.entryPoint=https://<organization>.okta.com/app/<appName>/<issuerID>/sso/saml
 server.security.saml.issuer=http://www.okta.com/<issuerID>
 server.security.saml.audience=false
 # Embedded cert needs \\n in string to escape properly
 server.security.saml.cert=-----BEGIN CERTIFICATE-----\\nABC\\nXYZ\\n-----END CERTIFICATE-----
+server.security.saml.disableRequestedAuthnContext=true
+
+# ACAS-specific SSO profile mapping and role sync settings.
 server.security.saml.profileAttributeToSystemRoles=[{"ssoName":"ACASUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"ssoName":"ACASAdmin","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"ssoName":"CmpdRegUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"ssoName":"CmpdRegAdmin","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"ssoName":"CmpdRegReadOnlyUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"ssoName":"ACASCrossProjectLoaderUser","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]
 server.security.saml.userNameAttribute=nameID
 server.security.saml.firstNameAttribute=firstName
@@ -374,7 +381,6 @@ server.security.saml.lastNameAttribute=lastName
 server.security.saml.emailAttribute=email
 server.security.saml.logoutRedirectURL=https://<organization>.okta.com
 server.security.saml.roles.sync=false
-server.security.saml.disableRequestedAuthnContext=true
 
 #Controls whether Roo syncs the AuthorRole table with authorities granted in LDAP
 server.security.syncLdapAuthRoles=false

--- a/modules/ServerAPI/spec/serviceTests/SamlMetadataSpec.coffee
+++ b/modules/ServerAPI/spec/serviceTests/SamlMetadataSpec.coffee
@@ -1,0 +1,122 @@
+assert = require 'assert'
+acasHome = '../../../..'
+samlMetadata = require "#{acasHome}/src/javascripts/ServerAPI/SamlMetadata.js"
+
+redirectFirstMetadata = '''
+<md:EntityDescriptor entityID="http://www.okta.com/exkExample" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>
+            MIICERTONE
+          </ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIICERTTWO</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.okta.com/post"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.okta.com/redirect"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>
+'''
+
+postOnlyMetadata = '''
+<EntityDescriptor entityID="http://www.okta.com/exkPostOnly" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIIPOSTCERT</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </KeyDescriptor>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.okta.com/post-only"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>
+'''
+
+describe "SAML Metadata helper", ->
+  describe "parseMetadataXml", ->
+    it "derives issuer, redirect entry point, and signing certificates from IdP metadata", ->
+      samlMetadata.parseMetadataXml redirectFirstMetadata
+        .then (options) ->
+          assert.equal options.issuer, "http://www.okta.com/exkExample"
+          assert.equal options.entryPoint, "https://example.okta.com/redirect"
+          assert.deepEqual options.idpCert, ["MIICERTONE", "MIICERTTWO"]
+
+    it "falls back to POST when Redirect binding is absent", ->
+      samlMetadata.parseMetadataXml postOnlyMetadata
+        .then (options) ->
+          assert.equal options.issuer, "http://www.okta.com/exkPostOnly"
+          assert.equal options.entryPoint, "https://example.okta.com/post-only"
+          assert.deepEqual options.idpCert, ["MIIPOSTCERT"]
+
+    it "rejects metadata without a signing certificate", ->
+      metadataWithoutCert = '''
+      <EntityDescriptor entityID="http://www.okta.com/noCert" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+        <IDPSSODescriptor>
+          <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.okta.com/redirect"/>
+        </IDPSSODescriptor>
+      </EntityDescriptor>
+      '''
+      samlMetadata.parseMetadataXml metadataWithoutCert
+        .then ->
+          throw new Error("Expected metadata without certificates to fail")
+        .catch (error) ->
+          assert.equal /signing certificate/.test(error.message), true
+
+  describe "getSamlStrategyOptions", ->
+    baseConfig = ->
+      client:
+        fullpath: "https://acas.example.com"
+      server:
+        security:
+          saml:
+            use: true
+            metadataUrl: ""
+            entryPoint: "https://explicit.example.com/sso"
+            issuer: "explicit-issuer"
+            cert: "EXPLICITCERT"
+            audience: false
+            disableRequestedAuthnContext: true
+
+    it "uses explicit SAML values when metadataUrl is absent", ->
+      samlMetadata.getSamlStrategyOptions baseConfig()
+        .then (options) ->
+          assert.equal options.callbackUrl, "https://acas.example.com/login/callback"
+          assert.equal options.entryPoint, "https://explicit.example.com/sso"
+          assert.equal options.issuer, "explicit-issuer"
+          assert.equal options.idpCert, "EXPLICITCERT"
+          assert.equal options.audience, false
+          assert.equal options.disableRequestedAuthnContext, true
+
+    it "uses metadata-derived values when metadataUrl is present", ->
+      config = baseConfig()
+      config.server.security.saml.metadataUrl = "https://idp.example.com/metadata"
+      fakeRequest = (options, callback) ->
+        callback null, {statusCode: 200}, redirectFirstMetadata
+
+      samlMetadata.getSamlStrategyOptions config, fakeRequest
+        .then (options) ->
+          assert.equal options.entryPoint, "https://example.okta.com/redirect"
+          assert.equal options.issuer, "http://www.okta.com/exkExample"
+          assert.deepEqual options.idpCert, ["MIICERTONE", "MIICERTTWO"]
+
+    it "rejects when metadataUrl fetch returns non-2xx", ->
+      config = baseConfig()
+      config.server.security.saml.metadataUrl = "https://idp.example.com/metadata"
+      fakeRequest = (options, callback) ->
+        callback null, {statusCode: 404}, "not found"
+
+      samlMetadata.getSamlStrategyOptions config, fakeRequest
+        .then ->
+          throw new Error("Expected metadata fetch failure")
+        .catch (error) ->
+          assert.equal /status 404/.test(error.message), true

--- a/modules/ServerAPI/src/server/SamlMetadata.coffee
+++ b/modules/ServerAPI/src/server/SamlMetadata.coffee
@@ -1,0 +1,160 @@
+###
+  SAML IdP metadata helpers for configuring Passport-SAML.
+###
+ACAS_HOME = "../../.."
+serverUtilityFunctions = require "#{ACAS_HOME}/routes/ServerUtilityFunctions.js"
+xml2js = require 'xml2js'
+
+request = serverUtilityFunctions.requestAdapter
+
+exports.isPresent = (value) ->
+  return false unless value?
+  "#{value}".trim() isnt ""
+
+asArray = (value) ->
+  return [] unless value?
+  if Array.isArray(value) then value else [value]
+
+localName = (name) ->
+  parts = "#{name}".split ':'
+  parts[parts.length - 1]
+
+childKeysFor = (node, wantedName) ->
+  return [] unless node?
+  Object.keys(node).filter (key) -> localName(key) is wantedName
+
+childrenFor = (node, wantedName) ->
+  matches = []
+  for key in childKeysFor(node, wantedName)
+    matches = matches.concat asArray(node[key])
+  matches
+
+firstChild = (node, wantedName) ->
+  childrenFor(node, wantedName)[0]
+
+attr = (node, name) ->
+  node?.$?[name]
+
+findEntityDescriptors = (parsed) ->
+  descriptors = childrenFor(parsed, 'EntityDescriptor')
+  return descriptors if descriptors.length > 0
+
+  rootKey = Object.keys(parsed)[0]
+  root = parsed[rootKey]
+  if localName(rootKey) is 'EntityDescriptor'
+    return [root]
+
+  descriptors = childrenFor(root, 'EntityDescriptor')
+  return descriptors if descriptors.length > 0
+  []
+
+hasIdpDescriptor = (entityDescriptor) ->
+  firstChild(entityDescriptor, 'IDPSSODescriptor')?
+
+findIdpEntityDescriptor = (parsed) ->
+  descriptors = findEntityDescriptors(parsed)
+  idpDescriptors = descriptors.filter hasIdpDescriptor
+  idpDescriptors[0] or descriptors[0]
+
+collectCertificateText = (node, output) ->
+  return unless node?
+  if typeof node is 'string'
+    return
+  for key, value of node
+    if key is '$'
+      continue
+    if localName(key) is 'X509Certificate'
+      for certNode in asArray(value)
+        certText = if typeof certNode is 'string' then certNode else certNode?._
+        if exports.isPresent certText
+          output.push certText.replace(/\s+/g, '')
+    else if typeof value is 'object'
+      for child in asArray(value)
+        collectCertificateText child, output
+
+extractSigningCertificates = (idpDescriptor) ->
+  certs = []
+  for keyDescriptor in childrenFor(idpDescriptor, 'KeyDescriptor')
+    use = attr(keyDescriptor, 'use')
+    if !use? or use is 'signing'
+      collectCertificateText keyDescriptor, certs
+  certs
+
+extractEntryPoint = (idpDescriptor) ->
+  services = childrenFor(idpDescriptor, 'SingleSignOnService')
+  redirectService = services.find (service) ->
+    /HTTP-Redirect$/.test attr(service, 'Binding') or "#{attr(service, 'Binding')}".indexOf('HTTP-Redirect') >= 0
+  postService = services.find (service) ->
+    /HTTP-POST$/.test attr(service, 'Binding') or "#{attr(service, 'Binding')}".indexOf('HTTP-POST') >= 0
+  selected = redirectService or postService or services.find (service) -> exports.isPresent attr(service, 'Location')
+  attr selected, 'Location'
+
+exports.parseMetadataXml = (metadataXml) ->
+  new Promise (resolve, reject) ->
+    parser = new xml2js.Parser
+      explicitArray: false
+      attrkey: '$'
+      charkey: '_'
+      trim: true
+    parser.parseString metadataXml, (error, parsed) ->
+      return reject error if error?
+      entityDescriptor = findIdpEntityDescriptor parsed
+      return reject new Error("SAML metadata does not contain an EntityDescriptor") unless entityDescriptor?
+      idpDescriptor = firstChild entityDescriptor, 'IDPSSODescriptor'
+      return reject new Error("SAML metadata does not contain an IDPSSODescriptor") unless idpDescriptor?
+
+      issuer = attr entityDescriptor, 'entityID'
+      return reject new Error("SAML metadata EntityDescriptor is missing entityID") unless exports.isPresent issuer
+
+      entryPoint = extractEntryPoint idpDescriptor
+      return reject new Error("SAML metadata does not contain a usable IdP SSO endpoint") unless exports.isPresent entryPoint
+
+      certs = extractSigningCertificates idpDescriptor
+      return reject new Error("SAML metadata does not contain a signing certificate") unless certs.length > 0
+
+      resolve
+        issuer: issuer
+        entryPoint: entryPoint
+        idpCert: certs
+
+commonSamlOptions = (configAll) ->
+  samlConfig = configAll.server.security.saml
+  passReqToCallback: true
+  callbackUrl: "#{configAll.client.fullpath}/login/callback"
+  audience: samlConfig.audience
+  disableRequestedAuthnContext: samlConfig.disableRequestedAuthnContext
+
+explicitSamlOptions = (configAll) ->
+  samlConfig = configAll.server.security.saml
+  Object.assign {}, commonSamlOptions(configAll),
+    entryPoint: samlConfig.entryPoint
+    issuer: samlConfig.issuer
+    idpCert: samlConfig.cert
+
+exports.fetchMetadataXml = (metadataUrl, requestAdapter = request) ->
+  new Promise (resolve, reject) ->
+    requestAdapter
+      method: 'GET'
+      url: metadataUrl
+      headers:
+        accept: 'application/samlmetadata+xml,application/xml,text/xml,*/*'
+      timeout: 30000
+      json: false
+    , (error, response, body) ->
+      return reject new Error("Unable to fetch SAML metadata from #{metadataUrl}: #{error.message}") if error?
+      statusCode = response?.statusCode
+      unless statusCode >= 200 and statusCode < 300
+        return reject new Error("Unable to fetch SAML metadata from #{metadataUrl}: status #{statusCode}")
+      unless exports.isPresent body
+        return reject new Error("SAML metadata response from #{metadataUrl} was empty")
+      resolve body
+
+exports.getSamlStrategyOptions = (configAll, requestAdapter = request) ->
+  samlConfig = configAll.server.security.saml
+  return Promise.resolve explicitSamlOptions(configAll) unless exports.isPresent samlConfig.metadataUrl
+
+  exports.fetchMetadataXml(samlConfig.metadataUrl, requestAdapter)
+    .then (metadataXml) ->
+      exports.parseMetadataXml(metadataXml)
+    .then (metadataOptions) ->
+      Object.assign {}, commonSamlOptions(configAll), metadataOptions

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "url-loader": "4.1.1",
     "winston": "3.3.3",
     "winston-mongodb": "5.0.5",
+    "xml2js": "^0.6.2",
     "yamljs": "0.3.0",
     "csv-stringify": "6.3.0"
   },


### PR DESCRIPTION
## Summary
- Add `server.security.saml.metadataUrl` as an optional SAML IdP metadata source.
- Fetch and parse IdP metadata to derive SAML `entryPoint`, `issuer`, and `idpCert` when the URL is configured.
- Preserve the existing explicit `entryPoint` / `issuer` / `cert` behavior when `metadataUrl` is empty.
- Add focused service tests for metadata parsing, explicit fallback, and fetch failure handling.

## Implementation notes
- `xml2js` was chosen as a small, common Node XML parser that works cleanly from the existing CoffeeScript server code.
- It gives structured access to SAML metadata attributes and nested certificate elements, while avoiding fragile regex/string parsing of XML.
- SAML metadata often uses XML namespaces, so the helper normalizes local tag names while extracting the fields ACAS needs.
- Tradeoff: `xml2js` is a generic XML parser, not a SAML-aware validation library. This PR only extracts the configured metadata fields; the IdP issuer versus SP issuer portability concern is called out as follow-up work.
- `startApp().catch(...)` was added because SAML strategy setup now awaits metadata fetch/parse. If metadata is unreachable or malformed, ACAS logs a clear startup error and exits non-zero.

## Notes
- Local Okta validation confirmed both the metadata URL path and the explicit settings path can authenticate when the ACAS callback host and SAML role sync are configured correctly.
- Follow-up work is being filed for the portability concern around metadata-derived IdP entity IDs versus `passport-saml` SP `issuer` semantics.

## Validation
- `docker compose exec -T acas sh -lc "./node_modules/.bin/gulp coffee:root coffee:serverAPI coffee:serviceTests copy:conf coffee:buildUtilities execute:prepare_config_files && ./node_modules/.bin/mocha --reporter spec src/spec/ServerAPI/serviceTests/SamlMetadataSpec.js --timeout 5000 --no-bail --check-leaks"`
- Result: `6 passing`
