### PR TITLE
ACAS-1010: upgrade Debian runtime packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20.20.2-slim
 #  - curl: bin/acas.sh polls the roo persistence service before starting
 #  - python3 + pip: the LiveDesign integration scripts the app shells out to
 #  - fontconfig + fonts-urw-base35: fonts for server-side image/PDF rendering
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
       git tar curl ca-certificates \
       python3 python3-pip \
       fontconfig fonts-urw-base35 \


### PR DESCRIPTION
## Summary

Refresh Debian runtime packages during the ACAS image build.

The image uses `node:20.20.2-slim` (Debian). It previously updated package indexes and installed requested packages, but did not upgrade packages already present in the base image.

## Change

- Run `apt-get upgrade -y` after `apt-get update` and before installing ACAS runtime dependencies.
- Keep the change scoped to ACAS; the separate R-services Dockerfile is RHEL-based and continues to use `yum`.

## Checks

- [x] Confirmed the Dockerfile runs `apt-get upgrade -y` before package installation.
- [x] Fresh Docker build layer selected `libgnutls30 3.7.9-2+deb12u7`, the fixed version named in ACAS-1010.
- [x] The layer also updated libc, dpkg, curl, and Python runtime packages.


Resolves [ACAS-1010](https://schrodinger.atlassian.net/browse/ACAS-1010).