### PR TITLE
ACAS-1011: Sync SSO roles from LiveDesign

### DIFF
--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -375,6 +375,14 @@ server.security.saml.disableRequestedAuthnContext=true
 
 # ACAS-specific SSO profile mapping and role sync settings.
 server.security.saml.profileAttributeToSystemRoles=[{"ssoName":"ACASUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"ssoName":"ACASAdmin","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"ssoName":"CmpdRegUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"ssoName":"CmpdRegAdmin","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"ssoName":"CmpdRegReadOnlyUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"ssoName":"ACASCrossProjectLoaderUser","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]
+# Select the authorization source for SAML users. Keep idp for the legacy
+# profileAttributeToSystemRoles behavior. Set livedesign to obtain mapped roles
+# from GET <liveDesign.baseUrl>/livedesign/api/roles/user/{username} using the
+# configured LiveDesign service account.
+server.security.saml.roles.source=idp
+# LiveDesign API enum values are case-sensitive. In livedesign mode, these are
+# the only ACAS/CmpdReg system roles synchronized; other System roles are kept.
+server.security.saml.liveDesignRoleToSystemRoles=[{"liveDesignRole":"ACAS_USER","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"ACAS_ADMINISTRATOR","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"liveDesignRole":"CREG_USER","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CREG_ADMINISTRATOR","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"liveDesignRole":"CREG_READ_ONLY","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"ACAS_CROSS_PROJECT_LOADER","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]
 server.security.saml.userNameAttribute=nameID
 server.security.saml.firstNameAttribute=firstName
 server.security.saml.lastNameAttribute=lastName

--- a/conf/config.properties.example
+++ b/conf/config.properties.example
@@ -376,13 +376,15 @@ server.security.saml.disableRequestedAuthnContext=true
 # ACAS-specific SSO profile mapping and role sync settings.
 server.security.saml.profileAttributeToSystemRoles=[{"ssoName":"ACASUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"ssoName":"ACASAdmin","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"ssoName":"CmpdRegUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"ssoName":"CmpdRegAdmin","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"ssoName":"CmpdRegReadOnlyUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"ssoName":"ACASCrossProjectLoaderUser","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]
 # Select the authorization source for SAML users. Keep idp for the legacy
-# profileAttributeToSystemRoles behavior. Set livedesign to obtain mapped roles
-# from GET <liveDesign.baseUrl>/livedesign/api/roles/user/{username} using the
-# configured LiveDesign service account.
+# profileAttributeToSystemRoles behavior. Set livedesign to obtain mapped,
+# effective roles through ACAS's Python ldclient bridge using the configured
+# LiveDesign service account.
 server.security.saml.roles.source=idp
-# LiveDesign API enum values are case-sensitive. In livedesign mode, these are
+# LiveDesign ldclient role values are case-sensitive. In livedesign mode, these are
 # the only ACAS/CmpdReg system roles synchronized; other System roles are kept.
-server.security.saml.liveDesignRoleToSystemRoles=[{"liveDesignRole":"ACAS_USER","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"ACAS_ADMINISTRATOR","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"liveDesignRole":"CREG_USER","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CREG_ADMINISTRATOR","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"liveDesignRole":"CREG_READ_ONLY","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"ACAS_CROSS_PROJECT_LOADER","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]
+# Administrator mappings deliberately include their required user role; duplicate
+# mappings are de-duplicated when LiveDesign supplies both roles explicitly.
+server.security.saml.liveDesignRoleToSystemRoles=[{"liveDesignRole":"AcasUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"AcasAdministrator","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"liveDesignRole":"AcasAdministrator","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"CregUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CregAdministrator","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"liveDesignRole":"CregAdministrator","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CregReadOnly","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"AcasCrossProjectLoader","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]
 server.security.saml.userNameAttribute=nameID
 server.security.saml.firstNameAttribute=firstName
 server.security.saml.lastNameAttribute=lastName

--- a/modules/ServerAPI/spec/serviceTests/CustomerSpecificServerFunctionsSpec.coffee
+++ b/modules/ServerAPI/spec/serviceTests/CustomerSpecificServerFunctionsSpec.coffee
@@ -1,4 +1,5 @@
 assert = require 'assert'
+EventEmitter = require('events').EventEmitter
 acasHome = '../../../..'
 serverUtilityFunctions = require "#{acasHome}/routes/ServerUtilityFunctions.js"
 request = serverUtilityFunctions.requestAdapter
@@ -16,6 +17,23 @@ parseResponse = (jsonStr) ->
 
 
 describe "Base ACAS Customer Specific Function Tests", ->
+	describe "LiveDesign SSO role lookup", ->
+		it "retrieves ldclient role values from the Python user bridge", async ->
+			spawnProcess = (command, args) ->
+				assert.equal command, 'python'
+				assert.ok args.includes('--method')
+				assert.ok args.includes('get_user')
+				process = new EventEmitter
+				process.stdout = new EventEmitter
+				process.stderr = new EventEmitter
+				global.process.nextTick ->
+					process.stdout.emit 'data', '{"liveDesignRoles":["AcasUser","AcasAdministrator"]}'
+					process.emit 'close', 0
+				process
+
+			roles = await csUtilities.getLiveDesignRoles('ld-user@example.com', spawnProcess)
+			assert.deepEqual roles, ['AcasUser', 'AcasAdministrator']
+
 	describe "User information testing", ->
 		if process.env.NODE_ENV == "integration"
 			describe "User creation", ->

--- a/modules/ServerAPI/spec/serviceTests/LiveDesignRoleMappingSpec.coffee
+++ b/modules/ServerAPI/spec/serviceTests/LiveDesignRoleMappingSpec.coffee
@@ -13,14 +13,14 @@ describe 'LiveDesign SSO role mapping configuration', ->
 
 	it 'documents an opt-in mapping for all ACAS roles LiveDesign can manage', ->
 		configExample = fs.readFileSync configExamplePath, 'utf8'
-		expectedMapping = '[{"liveDesignRole":"ACAS_USER","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"ACAS_ADMINISTRATOR","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"liveDesignRole":"CREG_USER","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CREG_ADMINISTRATOR","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"liveDesignRole":"CREG_READ_ONLY","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"ACAS_CROSS_PROJECT_LOADER","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]'
+		expectedMapping = '[{"liveDesignRole":"AcasUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"AcasAdministrator","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"liveDesignRole":"AcasAdministrator","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"CregUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CregAdministrator","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"liveDesignRole":"CregAdministrator","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CregReadOnly","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"AcasCrossProjectLoader","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]'
 
 		assert.ok configExample.includes("server.security.saml.liveDesignRoleToSystemRoles=#{expectedMapping}")
 
 	it 'maps configured LiveDesign roles without adding unmapped roles', ->
-		mapping = JSON.parse '[{"liveDesignRole":"ACAS_USER","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"CREG_READ_ONLY","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"ACAS_CROSS_PROJECT_LOADER","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]'
+		mapping = JSON.parse '[{"liveDesignRole":"AcasUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"CregReadOnly","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"AcasCrossProjectLoader","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]'
 
-		assert.deepEqual liveDesignRoleMapping.formatSystemRolesFromLiveDesignRoles(['ACAS_USER', 'CREG_READ_ONLY', 'UnknownRole'], mapping), [
+		assert.deepEqual liveDesignRoleMapping.formatSystemRolesFromLiveDesignRoles(['AcasUser', 'CregReadOnly', 'UnknownRole'], mapping), [
 			lsType: 'System'
 			lsKind: 'ACAS'
 			roleName: 'ROLE_ACAS-USERS'
@@ -30,5 +30,23 @@ describe 'LiveDesign SSO role mapping configuration', ->
 			roleName: 'ROLE_CMPDREG-READONLY'
 		]
 
-	it 'builds the LiveDesign role API URL for a base installation URL', ->
-		assert.equal liveDesignRoleMapping.getLiveDesignRoleApiUrl('https://ld.example', 'sam+user'), 'https://ld.example/livedesign/api/roles/user/sam%2Buser'
+	it 'maps administrator roles to their required user roles without duplicates', ->
+		mapping = JSON.parse '[{"liveDesignRole":"AcasUser","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"AcasAdministrator","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"liveDesignRole":"AcasAdministrator","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"CregUser","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CregAdministrator","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"liveDesignRole":"CregAdministrator","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"}]'
+
+		assert.deepEqual liveDesignRoleMapping.formatSystemRolesFromLiveDesignRoles(['AcasUser', 'AcasAdministrator', 'CregAdministrator'], mapping), [
+			lsType: 'System'
+			lsKind: 'ACAS'
+			roleName: 'ROLE_ACAS-USERS'
+		,
+			lsType: 'System'
+			lsKind: 'ACAS'
+			roleName: 'ROLE_ACAS-ADMINS'
+		,
+			lsType: 'System'
+			lsKind: 'CmpdReg'
+			roleName: 'ROLE_CMPDREG-ADMINS'
+		,
+			lsType: 'System'
+			lsKind: 'CmpdReg'
+			roleName: 'ROLE_CMPDREG-USERS'
+		]

--- a/modules/ServerAPI/spec/serviceTests/LiveDesignRoleMappingSpec.coffee
+++ b/modules/ServerAPI/spec/serviceTests/LiveDesignRoleMappingSpec.coffee
@@ -1,0 +1,34 @@
+assert = require 'assert'
+fs = require 'fs'
+path = require 'path'
+
+acasHome = path.resolve __dirname, '../../../..'
+configExamplePath = path.join acasHome, 'conf/config.properties.example'
+liveDesignRoleMapping = require "#{acasHome}/src/javascripts/ServerAPI/LiveDesignRoleMapping.js"
+
+describe 'LiveDesign SSO role mapping configuration', ->
+	it 'keeps IdP roles as the default source', ->
+		configExample = fs.readFileSync configExamplePath, 'utf8'
+		assert.ok configExample.includes('server.security.saml.roles.source=idp')
+
+	it 'documents an opt-in mapping for all ACAS roles LiveDesign can manage', ->
+		configExample = fs.readFileSync configExamplePath, 'utf8'
+		expectedMapping = '[{"liveDesignRole":"ACAS_USER","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"ACAS_ADMINISTRATOR","lsKind":"ACAS","roleName":"ROLE_ACAS-ADMINS"},{"liveDesignRole":"CREG_USER","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-USERS"},{"liveDesignRole":"CREG_ADMINISTRATOR","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-ADMINS"},{"liveDesignRole":"CREG_READ_ONLY","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"ACAS_CROSS_PROJECT_LOADER","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]'
+
+		assert.ok configExample.includes("server.security.saml.liveDesignRoleToSystemRoles=#{expectedMapping}")
+
+	it 'maps configured LiveDesign roles without adding unmapped roles', ->
+		mapping = JSON.parse '[{"liveDesignRole":"ACAS_USER","lsKind":"ACAS","roleName":"ROLE_ACAS-USERS"},{"liveDesignRole":"CREG_READ_ONLY","lsKind":"CmpdReg","roleName":"ROLE_CMPDREG-READONLY"},{"liveDesignRole":"ACAS_CROSS_PROJECT_LOADER","lsKind":"ACAS","roleName":"ROLE_ACAS-CROSS-PROJECT-LOADER"}]'
+
+		assert.deepEqual liveDesignRoleMapping.formatSystemRolesFromLiveDesignRoles(['ACAS_USER', 'CREG_READ_ONLY', 'UnknownRole'], mapping), [
+			lsType: 'System'
+			lsKind: 'ACAS'
+			roleName: 'ROLE_ACAS-USERS'
+		,
+			lsType: 'System'
+			lsKind: 'CmpdReg'
+			roleName: 'ROLE_CMPDREG-READONLY'
+		]
+
+	it 'builds the LiveDesign role API URL for a base installation URL', ->
+		assert.equal liveDesignRoleMapping.getLiveDesignRoleApiUrl('https://ld.example', 'sam+user'), 'https://ld.example/livedesign/api/roles/user/sam%2Buser'

--- a/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
+++ b/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
@@ -10,6 +10,7 @@ request = serverUtilityFunctions.requestAdapter
 fs = require 'fs'
 _ = require 'underscore'
 util = require 'util'
+liveDesignRoleMapping = require './LiveDesignRoleMapping.js'
 
 exports.logUsage = (action, data, username) ->
 # no ACAS logging service yet
@@ -154,6 +155,50 @@ formatSystemRolesFromSSOProfile = (profile) =>
 			})
 	return roles
 
+syncLiveDesignSystemRoles = (savedAuthor, liveDesignRoles, authorRoutes, setupRoutes) ->
+	liveDesignSystemRoles = liveDesignRoleMapping.formatSystemRolesFromLiveDesignRoles(
+		liveDesignRoles,
+		config.all.server.security.saml.liveDesignRoleToSystemRoles)
+	managedRoleKeys = liveDesignRoleMapping.getManagedSystemRoleKeys(
+		config.all.server.security.saml.liveDesignRoleToSystemRoles)
+
+	if liveDesignSystemRoles.length > 0
+		[err, saveResult] = await serverUtilityFunctions.promisifyRequestResponseStatus(
+			setupRoutes.setupTypeOrKindInternal, ["lsroles", liveDesignSystemRoles])
+		throw err if err?
+
+	savedManagedSystemRoles = authorRoutes.getRolesByLsType(savedAuthor.authorRoles, "System").filter (role) ->
+		managedRoleKeys.has("#{role.lsKind}/#{role.roleName}")
+
+	diffSystemRolesWithSaved = util.promisify(authorRoutes.diffSystemRolesWithSaved)
+	[err, diffResult] = await serverUtilityFunctions.promiseCatch(
+		diffSystemRolesWithSaved(savedAuthor.userName, liveDesignSystemRoles, savedManagedSystemRoles, ["lsType", "lsKind", "roleName"]))
+	throw err if err?
+
+	if diffResult.rolesToAdd.length > 0 or diffResult.rolesToDelete.length > 0
+		syncRoles = util.promisify(authorRoutes.syncRoles)
+		[err, updatedAuthor] = await serverUtilityFunctions.promiseCatch(
+			syncRoles(savedAuthor, diffResult.rolesToAdd, diffResult.rolesToDelete))
+		throw err if err?
+
+exports.getLiveDesignRoles = (username, requestAdapter = request) ->
+	liveDesignConfig = config.all.client.service.result.viewer.liveDesign
+	url = liveDesignRoleMapping.getLiveDesignRoleApiUrl(liveDesignConfig.baseUrl, username)
+
+	new Promise (resolve, reject) ->
+		requestAdapter.get
+			url: url
+			auth:
+				user: liveDesignConfig.username
+				pass: liveDesignConfig.password
+				sendImmediately: true
+			json: true
+		, (error, response, body) ->
+			return reject(error) if error?
+			return reject(new Error("LiveDesign role request failed with status #{response?.statusCode}")) unless response?.statusCode is 200
+			return reject(new Error("LiveDesign role response is missing roles")) unless Array.isArray(body?.roles)
+			resolve(body.roles)
+
 exports.ssoLoginStrategy = (req, profile, callback) ->
 	exports.logUsage "login attempt", JSON.stringify(ip: req.ip, referer: req.headers['referer'], agent: req.headers['user-agent']), JSON.stringify(profile)
 	authorRoutes = require '../../../routes/AuthorRoutes.js'
@@ -231,7 +276,15 @@ exports.ssoLoginStrategy = (req, profile, callback) ->
 			console.error("Got error saving new author #{err} during sso login strategy Author json: #{JSON.stringify(author)}")
 			return callback null, false, message: "Got error trying to save author"
 
-	if config.all.server.security.saml.roles.sync
+	roleSource = config.all.server.security.saml.roles.source ? 'idp'
+	if roleSource is 'livedesign'
+		try
+			liveDesignRoles = await exports.getLiveDesignRoles(userName)
+			await syncLiveDesignSystemRoles(savedAuthor, liveDesignRoles, authorRoutes, setupRoutes)
+		catch error
+			console.error("Got error synchronizing LiveDesign roles during SSO login: #{error}")
+			return callback null, false, message: "Unable to retrieve roles from LiveDesign"
+	else if roleSource is 'idp' and config.all.server.security.saml.roles.sync
 		console.log "Checking for roles to sync"
 
 		# Format sso groups into ACAS system roles [{roleName: , lsType: 'System', lsKind: 'ACAS'/'CmpdReg'}]

--- a/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
+++ b/modules/ServerAPI/src/server/CustomerSpecificServerFunctions.coffee
@@ -10,6 +10,7 @@ request = serverUtilityFunctions.requestAdapter
 fs = require 'fs'
 _ = require 'underscore'
 util = require 'util'
+childProcess = require 'child_process'
 liveDesignRoleMapping = require './LiveDesignRoleMapping.js'
 
 exports.logUsage = (action, data, username) ->
@@ -156,9 +157,11 @@ formatSystemRolesFromSSOProfile = (profile) =>
 	return roles
 
 syncLiveDesignSystemRoles = (savedAuthor, liveDesignRoles, authorRoutes, setupRoutes) ->
+	console.log("Found #{liveDesignRoles.length} LiveDesign roles for author #{savedAuthor.userName}: #{JSON.stringify(liveDesignRoles)}")
 	liveDesignSystemRoles = liveDesignRoleMapping.formatSystemRolesFromLiveDesignRoles(
 		liveDesignRoles,
 		config.all.server.security.saml.liveDesignRoleToSystemRoles)
+	console.log("Mapped #{liveDesignSystemRoles.length} LiveDesign roles to ACAS system roles for author #{savedAuthor.userName}: #{JSON.stringify(liveDesignSystemRoles)}")
 	managedRoleKeys = liveDesignRoleMapping.getManagedSystemRoleKeys(
 		config.all.server.security.saml.liveDesignRoleToSystemRoles)
 
@@ -181,23 +184,34 @@ syncLiveDesignSystemRoles = (savedAuthor, liveDesignRoles, authorRoutes, setupRo
 			syncRoles(savedAuthor, diffResult.rolesToAdd, diffResult.rolesToDelete))
 		throw err if err?
 
-exports.getLiveDesignRoles = (username, requestAdapter = request) ->
+exports.getLiveDesignRoles = (username, spawnProcess = childProcess.spawn) ->
 	liveDesignConfig = config.all.client.service.result.viewer.liveDesign
-	url = liveDesignRoleMapping.getLiveDesignRoleApiUrl(liveDesignConfig.baseUrl, username)
+	args = [
+		'./src/python/ServerAPI/acas_ldclient/acasldclient.py'
+		'--ldserver', liveDesignConfig.baseUrl
+		'--user', liveDesignConfig.username
+		'--password', liveDesignConfig.password
+		'--method', 'get_user'
+		'--args', username
+	]
 
 	new Promise (resolve, reject) ->
-		requestAdapter.get
-			url: url
-			auth:
-				user: liveDesignConfig.username
-				pass: liveDesignConfig.password
-				sendImmediately: true
-			json: true
-		, (error, response, body) ->
-			return reject(error) if error?
-			return reject(new Error("LiveDesign role request failed with status #{response?.statusCode}")) unless response?.statusCode is 200
-			return reject(new Error("LiveDesign role response is missing roles")) unless Array.isArray(body?.roles)
-			resolve(body.roles)
+		subprocess = spawnProcess 'python', args
+		stdout = ''
+		stderr = ''
+		subprocess.stdout.setEncoding? 'utf8'
+		subprocess.stderr.setEncoding? 'utf8'
+		subprocess.stdout.on 'data', (data) -> stdout += data.toString()
+		subprocess.stderr.on 'data', (data) -> stderr += data.toString()
+		subprocess.on 'error', (error) -> reject(error)
+		subprocess.on 'close', (exitCode) ->
+			return reject(new Error("LiveDesign role lookup script failed with exit code #{exitCode}: #{stderr}")) unless exitCode is 0
+			try
+				liveDesignUser = JSON.parse stdout
+			catch parseError
+				return reject(new Error("LiveDesign role lookup script returned invalid JSON: #{parseError.message}"))
+			return reject(new Error("LiveDesign role lookup script returned roles in an invalid format")) unless Array.isArray(liveDesignUser?.liveDesignRoles)
+			resolve(liveDesignUser.liveDesignRoles)
 
 exports.ssoLoginStrategy = (req, profile, callback) ->
 	exports.logUsage "login attempt", JSON.stringify(ip: req.ip, referer: req.headers['referer'], agent: req.headers['user-agent']), JSON.stringify(profile)

--- a/modules/ServerAPI/src/server/LiveDesignRoleMapping.coffee
+++ b/modules/ServerAPI/src/server/LiveDesignRoleMapping.coffee
@@ -1,0 +1,35 @@
+###
+  Maps LiveDesign API role names to ACAS system roles.
+
+  This module is intentionally not used by the legacy SAML login path.  A future
+  LiveDesign-authorized SSO mode can call it after retrieving roles from
+  LiveDesign without changing the existing IdP-role behavior.
+###
+
+parseMapping = (mapping) ->
+	if typeof mapping is 'string'
+		JSON.parse mapping
+	else if Array.isArray mapping
+		mapping
+	else
+		[]
+
+exports.getManagedSystemRoleKeys = (mapping) ->
+	new Set parseMapping(mapping).map (roleMapping) ->
+		"#{roleMapping.lsKind}/#{roleMapping.roleName}"
+
+exports.formatSystemRolesFromLiveDesignRoles = (liveDesignRoles, mapping) ->
+	roles = new Set(liveDesignRoles ? [])
+
+	parseMapping(mapping)
+		.filter (roleMapping) -> roles.has(roleMapping.liveDesignRole)
+		.map (roleMapping) ->
+			lsType: 'System'
+			lsKind: roleMapping.lsKind
+			roleName: roleMapping.roleName
+
+exports.getLiveDesignRoleApiUrl = (baseUrl, username) ->
+	normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+	unless normalizedBaseUrl.endsWith('/livedesign/api')
+		normalizedBaseUrl += if normalizedBaseUrl.endsWith('/livedesign') then '/api' else '/livedesign/api'
+	"#{normalizedBaseUrl}/roles/user/#{encodeURIComponent(username)}"

--- a/modules/ServerAPI/src/server/LiveDesignRoleMapping.coffee
+++ b/modules/ServerAPI/src/server/LiveDesignRoleMapping.coffee
@@ -20,6 +20,7 @@ exports.getManagedSystemRoleKeys = (mapping) ->
 
 exports.formatSystemRolesFromLiveDesignRoles = (liveDesignRoles, mapping) ->
 	roles = new Set(liveDesignRoles ? [])
+	roleKeys = new Set
 
 	parseMapping(mapping)
 		.filter (roleMapping) -> roles.has(roleMapping.liveDesignRole)
@@ -27,9 +28,8 @@ exports.formatSystemRolesFromLiveDesignRoles = (liveDesignRoles, mapping) ->
 			lsType: 'System'
 			lsKind: roleMapping.lsKind
 			roleName: roleMapping.roleName
-
-exports.getLiveDesignRoleApiUrl = (baseUrl, username) ->
-	normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
-	unless normalizedBaseUrl.endsWith('/livedesign/api')
-		normalizedBaseUrl += if normalizedBaseUrl.endsWith('/livedesign') then '/api' else '/livedesign/api'
-	"#{normalizedBaseUrl}/roles/user/#{encodeURIComponent(username)}"
+		.filter (role) ->
+			roleKey = "#{role.lsType}/#{role.lsKind}/#{role.roleName}"
+			return false if roleKeys.has(roleKey)
+			roleKeys.add(roleKey)
+			true

--- a/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
+++ b/modules/ServerAPI/src/server/python/acas_ldclient/acasldclient.py
@@ -193,6 +193,15 @@ def get_users(client, ls_type = None, ls_kind = None, role_name = None, use_acas
             acas_users = []
     return acas_users
 
+def get_user_roles(client, username):
+    """Return effective LiveDesign role values for one user via ldclient."""
+    roles = client.get_roles_for_users_by_username([username])
+    return [
+        role.role.value if hasattr(role.role, 'value') else str(role.role)
+        for role in roles
+        if role.username == username
+    ]
+
 def ld_user_to_acas_user(ld_user, roles):
     acas_user = {
         'id': ld_user["id"],
@@ -261,6 +270,7 @@ def get_user(client, username, use_acas_only_acl_groups = True):
         })
         logger.info(description)
     acas_user = ld_user_to_acas_user(user, roles)
+    acas_user['liveDesignRoles'] = get_user_roles(client, username)
     return acas_user
 
 def get_projects(client):


### PR DESCRIPTION
## Summary

Adds an opt-in livedesign SAML role source. ACAS fetches mapped roles from LiveDesign at SSO login, synchronizes only the LiveDesign-managed ACAS/CmpdReg roles, and preserves the existing IdP flow by default.

The goal of this is to support LiveDesign admin interface owning the roles ACAS/CmpdReg users have.

## Configuration

- server.security.saml.roles.source=idp preserves existing SAML profile role synchronization.
- server.security.saml.roles.source=livedesign queries LiveDesign using the configured service account and uses the roles returned as the source to update the author roles instead of the IDP mapping.

## Validation

- Ran the new mocha tests

## Manual LiveDesign-role-sync verification completed:

 - With the user assigned only to LiveDesign AcasAdministrator, ACAS synchronized both ROLE_ACAS-ADMINS and the required ROLE_ACAS-USERS.
 - Changing the user to only AcasUser removed ROLE_ACAS-ADMINS and retained only ROLE_ACAS-USERS.
- With the user assigned only to CregAdministrator, ACAS synchronized both ROLE_CMPDREG-ADMINS and the required ROLE_CMPDREG-USERS.
 - CregUser was also verified to synchronize only its intended user role.
 - This confirms that administrator roles automatically imply their corresponding user roles when server.security.saml.roles.source=livedesign is configured. IdP-sourced role synchronization remains unchanged.

